### PR TITLE
pcpanl s3 Replication

### DIFF
--- a/Core/S3Replication/main.tf
+++ b/Core/S3Replication/main.tf
@@ -40,6 +40,12 @@ locals {
         var.role_hydrovis-viz-proc-pipeline-lambda_arn
       ]
     }
+    "pcpanl" = {
+      replication_role_arn = "arn:aws:iam::${var.prod_account_id}:role/hydrovis-prod-pcpanl-incoming-replication"
+      access_principal_arns = [
+        var.user_data-ingest-service-user_arn
+      ]
+    }
   }
 }
 

--- a/Core/S3Replication/source.tf
+++ b/Core/S3Replication/source.tf
@@ -634,3 +634,318 @@ resource "aws_s3_bucket_policy" "hydrovis-nwm-incoming" {
   )
 }
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+resource "aws_kms_key" "hydrovis-pcpanl-incoming-s3" {
+  count               = var.environment == "prod" ? 1 : 0 // This makes sure this is only built when deploying to prod
+  description         = "Symmetric CMK for KMS-KEY-ARN for pcpanl Incoming Bucket"
+  enable_key_rotation = true
+  policy = jsonencode(
+    {
+      Version = "2012-10-17"
+      Id      = "key-hydrovis-prod-pcpanl-incoming-kms-cmk-policy"
+      Statement = [
+        {
+          Action = "kms:*"
+          Effect = "Allow"
+          Principal = {
+            AWS = [
+              "arn:aws:iam::${var.prod_account_id}:root",
+            ]
+          }
+          Resource = "*"
+          Sid      = "Enable IAM User Permissions"
+        },
+        {
+          Action = [
+            "kms:Create*",
+            "kms:Describe*",
+            "kms:Enable*",
+            "kms:List*",
+            "kms:Put*",
+            "kms:Update*",
+            "kms:Revoke*",
+            "kms:Disable*",
+            "kms:Get*",
+            "kms:Delete*",
+            "kms:ScheduleKeyDeletion",
+            "kms:CancelKeyDeletion",
+          ]
+          Effect = "Allow"
+          Principal = {
+            AWS = "arn:aws:iam::${var.prod_account_id}:user/noel.perkins@noaa.gov"
+          }
+          Resource = "*"
+          Sid      = "Allow administration of the key"
+        },
+        {
+          Action = [
+            "kms:DescribeKey",
+            "kms:Encrypt",
+            "kms:Decrypt",
+            "kms:ReEncrypt*",
+            "kms:GenerateDataKey",
+            "kms:GenerateDataKeyWithoutPlaintext",
+          ]
+          Effect = "Allow"
+          Principal = {
+            AWS = [
+              "arn:aws:iam::${var.prod_account_id}:user/zachary.wills@noaa.gov",
+              "arn:aws:iam::${var.prod_account_id}:user/hydrovis-data-prod-ingest-service-user",
+              "arn:aws:iam::${var.prod_account_id}:role/hydrovis-prod-pcpanl-incoming-replication",
+            ]
+          }
+          Resource = "*"
+          Sid      = "Allow use of the key"
+        },
+      ]
+    }
+  )
+}
+
+resource "aws_iam_role" "pcpanl-replication" {
+  count = var.environment == "prod" ? 1 : 0 // This makes sure this is only built when deploying to prod
+  name  = "hydrovis-prod-pcpanl-incoming-replication"
+  assume_role_policy = jsonencode(
+    {
+      Version = "2008-10-17"
+      Statement = [
+        {
+          Action = "sts:AssumeRole"
+          Effect = "Allow"
+          Principal = {
+            Service = "s3.amazonaws.com"
+          }
+        },
+      ]
+
+    }
+  )
+
+  inline_policy {
+    name   = "pcpanlBucketReplicationPolicy"
+    policy = jsonencode(
+      {
+        Version = "2012-10-17"
+        Statement = [
+          {
+            Action   = "iam:PassRole"
+            Effect   = "Allow"
+            Resource = "arn:aws:iam::${var.prod_account_id}:role/hydrovis-prod-pcpanl-incoming-replication"
+            Sid      = "VisualEditor4"
+          },
+          {
+            Action = [
+              "s3:GetObjectVersionTagging",
+              "s3:GetObjectVersionAcl",
+              "s3:GetObjectVersion",
+              "s3:GetObjectVersionForReplication",
+              "s3:ListBucket",
+              "s3:GetBucketVersioning",
+              "s3:GetReplicationConfiguration",
+            ]
+            Effect = "Allow"
+            Resource = [
+              "arn:aws:s3:::hydrovis-prod-pcpanl-incoming-us-east-1/*",
+              "arn:aws:s3:::hydrovis-prod-pcpanl-incoming-us-east-1",
+            ]
+            Sid = "VisualEditor8"
+          },
+          {
+            Action = "kms:Decrypt"
+            Condition = {
+              StringLike = {
+                "kms:ViaService" = "s3.us-east-1.amazonaws.com"
+              }
+            }
+            Effect   = "Allow"
+            Resource = aws_kms_key.hydrovis-pcpanl-incoming-s3[0].arn
+            Sid      = "VisualEditor0"
+          },
+          {
+            Action = "kms:Encrypt"
+            Condition = {
+              "ForAnyValue:StringLike" = {
+                "kms:ResourceAliases" = "alias/hydrovis-*-pcpanl-*"
+              }
+              StringLike = {
+                "kms:ViaService" = "s3.us-east-1.amazonaws.com"
+              }
+            }
+            Effect   = "Allow"
+            Resource = "*"
+            Sid      = "VisualEditor3"
+          },
+          {
+            Action = [
+              "s3:ObjectOwnerOverrideToBucketOwner",
+              "s3:ReplicateObject",
+              "s3:ReplicateTags",
+              "s3:ReplicateDelete",
+            ]
+            Effect = "Allow"
+            Resource = [
+              "arn:aws:s3:::hydrovis-*-pcpanl-*",
+              "arn:aws:s3:::hydrovis-*-pcpanl-*/*",
+            ]
+            Sid = "VisualEditor5"
+          },
+        ]
+      }
+    )
+  }
+}
+
+resource "aws_s3_bucket" "hydrovis-pcpanl-incoming" {
+  count  = var.environment == "prod" ? 1 : 0 // This makes sure this is only built when deploying to prod
+  bucket = "hydrovis-prod-pcpanl-incoming-us-east-1"
+
+  lifecycle_rule {
+    abort_incomplete_multipart_upload_days = 0
+    enabled                                = true
+
+    expiration {
+      days = 30
+    }
+
+    noncurrent_version_expiration {
+      days = 1
+    }
+  }
+
+  replication_configuration {
+    role = aws_iam_role.pcpanl-replication[0].arn
+
+    rules {
+      id       = "pcpanlReplicationRoleToProdPcpanl"
+      priority = 0
+      status   = "Enabled"
+      filter {}
+
+      destination {
+        bucket             = "arn:aws:s3:::hydrovis-prod-pcpanl-us-east-1"
+        replica_kms_key_id = "arn:aws:kms:us-east-1:${var.prod_account_id}:alias/hydrovis-prod-pcpanl-us-east-1-s3"
+      }
+
+      source_selection_criteria {
+        sse_kms_encrypted_objects {
+          enabled = true
+        }
+      }
+    }
+
+    rules {
+      id       = "pcpanlReplicationRoleToUatPcpanl"
+      priority = 1
+      status   = "Enabled"
+      filter {}
+
+      destination {
+        account_id         = "${var.uat_account_id}"
+        bucket             = "arn:aws:s3:::hydrovis-uat-pcpanl-us-east-1"
+        replica_kms_key_id = "arn:aws:kms:us-east-1:${var.uat_account_id}:alias/hydrovis-uat-pcpanl-us-east-1-s3"
+
+        access_control_translation {
+          owner = "Destination"
+        }
+      }
+
+      source_selection_criteria {
+        sse_kms_encrypted_objects {
+          enabled = true
+        }
+      }
+    }
+
+    rules {
+      id       = "pcpanlReplicationRoleToTiPcpanl"
+      priority = 2
+      status   = "Enabled"
+      filter {}
+
+      destination {
+        account_id         = "${var.ti_account_id}"
+        bucket             = "arn:aws:s3:::hydrovis-ti-pcpanl-us-east-1"
+        replica_kms_key_id = "arn:aws:kms:us-east-1:${var.ti_account_id}:alias/hydrovis-ti-pcpanl-us-east-1-s3"
+
+        access_control_translation {
+          owner = "Destination"
+        }
+      }
+
+      source_selection_criteria {
+        sse_kms_encrypted_objects {
+          enabled = true
+        }
+      }
+    }
+  }
+
+  server_side_encryption_configuration {
+    rule {
+      bucket_key_enabled = true
+
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = aws_kms_key.hydrovis-pcpanl-incoming-s3[0].arn
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
+
+  versioning {
+    enabled = true
+  }
+}
+
+resource "aws_s3_bucket_policy" "hydrovis-pcpanl-incoming" {
+  count  = var.environment == "prod" ? 1 : 0 // This makes sure this is only built when deploying to prod
+  bucket = aws_s3_bucket.hydrovis-pcpanl-incoming[0].bucket
+
+  policy = jsonencode(
+    {
+      Version = "2008-10-17"
+      Statement = [
+        {
+          Action = "s3:PutObject"
+          Condition = {
+            StringNotEquals = {
+              "s3:x-amz-server-side-encryption" = "aws:kms"
+            }
+          }
+          Effect    = "Deny"
+          Principal = "*"
+          Resource  = "${aws_s3_bucket.hydrovis-pcpanl-incoming[0].arn}/*"
+          Sid       = "DenyUnEncryptedObjectUploads"
+        },
+      ]
+    }
+  )
+}


### PR DESCRIPTION
This adds a new incoming bucket that IDP can upload the pcpanl data into, as well as the replication role, replication rules, and the destination buckets for the ti/uat/prod environments.

As this update get deployed to the various environments, it should create the destination bucket. Once this update is deployed to prod, it will create the incoming bucket and set up the replication role and replication rules to copy data to the ti/uat/prod destination buckets.

[SmartSheet Card](https://app.smartsheetgov.com/sheets/FwqPVjGh6Qwv9GWh8hG35rj2Rr3g7RFMF3jcj4h1?rowId=4251499992770436)