### PR TITLE
Egis bucket permissions update

### DIFF
--- a/Core/eGIS/bucket/main.tf
+++ b/Core/eGIS/bucket/main.tf
@@ -145,6 +145,8 @@ resource "aws_s3_bucket_policy" "hydrovis" {
             "s3:GetObject",
             "s3:PutObject",
             "s3:ListBucket",
+            "s3:DeleteObject",
+            "s3:PutObjectAcl"
           ]
           Effect = "Allow"
           Principal = {


### PR DESCRIPTION
Added `s3:DeleteObject` and `s3:PutObjectAcl` to EGIS Bucket policies.

[SmartSheet Card](https://app.smartsheetgov.com/sheets/FwqPVjGh6Qwv9GWh8hG35rj2Rr3g7RFMF3jcj4h1?rowId=1118580826761092)