### PR TITLE
Disables auto version updating for RDS Instances and MQ Brokers

### DIFF
--- a/Core/MQ/ingest/main.tf
+++ b/Core/MQ/ingest/main.tf
@@ -17,10 +17,10 @@ variable "mq_ingest_security_groups" {
 resource "aws_mq_broker" "ingest" {
   # Don't ask
   broker_name                = "hydrovis-${var.environment}-dataingest-rabbitmq-${substr(md5(jsondecode(var.mq_ingest_secret_string)["password"]), 0, 6)}"
-  auto_minor_version_upgrade = true
+  auto_minor_version_upgrade = false
   apply_immediately          = true
   engine_type                = "RabbitMQ"
-  engine_version             = "3.8.23"
+  engine_version             = "3.8.27"
   host_instance_type         = "mq.t3.micro"
   publicly_accessible        = false
   security_groups            = var.mq_ingest_security_groups

--- a/Core/RDS/ingest/main.tf
+++ b/Core/RDS/ingest/main.tf
@@ -37,7 +37,7 @@ resource "aws_db_instance" "ingest" {
   allocated_storage            = 100
   storage_type                 = "gp2"
   engine                       = "postgres"
-  engine_version               = "12.7"
+  engine_version               = "12.8"
   username                     = jsondecode(var.db_ingest_secret_string)["username"]
   password                     = jsondecode(var.db_ingest_secret_string)["password"]
   db_subnet_group_name         = aws_db_subnet_group.ingest.name
@@ -48,6 +48,7 @@ resource "aws_db_instance" "ingest" {
   performance_insights_enabled = true
   backup_retention_period      = 7
   skip_final_snapshot          = true
+  auto_minor_version_upgrade   = false
   tags = {
     "hydrovis-${var.environment}-data-ingest-rdsdbtag" : "hydrovis-${var.environment}-data-ingest-rdsdbtag"
   }

--- a/Core/RDS/viz/main.tf
+++ b/Core/RDS/viz/main.tf
@@ -41,7 +41,7 @@ resource "aws_db_instance" "viz-processing" {
   allocated_storage            = 200
   storage_type                 = "gp2"
   engine                       = "postgres"
-  engine_version               = "12.7"
+  engine_version               = "12.8"
   username                     = jsondecode(var.db_viz_processing_secret_string)["username"]
   password                     = jsondecode(var.db_viz_processing_secret_string)["password"]
   db_subnet_group_name         = aws_db_subnet_group.viz-processing.name
@@ -52,6 +52,7 @@ resource "aws_db_instance" "viz-processing" {
   performance_insights_enabled = true
   backup_retention_period      = 7
   skip_final_snapshot          = true
+  auto_minor_version_upgrade   = false
   tags = {
     "hydrovis-${var.environment}-viz-processing-rdsdbtag" : "hydrovis-${var.environment}-viz-processing-rdsdbtag"
   }


### PR DESCRIPTION
In order to keep Terraform in sync with the AWS resources, this will disable AWS's ability to automatically update minor version numbers of RDS Instances and MQ Brokers. The will require for version updating to instead be manually applied via the Terraform configurations.

[SmartSheet Card](https://app.smartsheetgov.com/sheets/FwqPVjGh6Qwv9GWh8hG35rj2Rr3g7RFMF3jcj4h1?rowId=3838846346520452)