### PR TITLE
Mq broker vhost fix UAT

### DIFF
--- a/Core/EC2/RDSBastion/main.tf
+++ b/Core/EC2/RDSBastion/main.tf
@@ -138,7 +138,7 @@ locals {
     "dev" : "development",
     "development" : "development",
     "ti" : "testing_integration",
-    "uat" : "user_acceptance-testing",
+    "uat" : "user_acceptance_testing",
     "prod" : "production",
     "production" : "production",
   }


### PR DESCRIPTION
Changed the MQ Broker Vhost in UAT from `user_acceptance-testing` to `user_acceptance_testing`.