### PR TITLE
Adding Service Account for the FIM team to use to push FIM artifacts …

### DIFF
--- a/Core/IAM/Users/fim-service-account-policy.json.tftpl
+++ b/Core/IAM/Users/fim-service-account-policy.json.tftpl
@@ -1,0 +1,14 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutObject",
+                "s3:ListBucket"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/Core/IAM/Users/main.tf
+++ b/Core/IAM/Users/main.tf
@@ -10,8 +10,7 @@ variable "region" {
   type = string
 }
 
-
-# HydrovisESRISSMDeploy Role
+# WRDS Service Account
 resource "aws_iam_user" "WRDSServiceAccount" {
   name = "wrds-service-account"
 }
@@ -33,6 +32,32 @@ resource "local_file" "WRDSServiceAccount" {
 }
 
 
+# FIM Service Account
+resource "aws_iam_user" "FIMServiceAccount" {
+  name = "fim-service-account"
+}
+
+resource "aws_iam_user_policy" "FIMServiceAccount" {
+  name = "fim-service-account"
+  user = aws_iam_user.FIMServiceAccount.name
+
+  policy = templatefile("${path.module}/fim-service-account-policy.json.tftpl", {})
+}
+
+resource "aws_iam_access_key" "FIMServiceAccount" {
+  user = aws_iam_user.FIMServiceAccount.name
+}
+
+resource "local_file" "FIMServiceAccount" {
+  content  = "ID: ${aws_iam_access_key.FIMServiceAccount.id}\nSecret: ${aws_iam_access_key.FIMServiceAccount.secret}"
+  filename = "${path.root}/sensitive/Certs/${aws_iam_user.FIMServiceAccount.name}-${var.environment}"
+}
+
+
 output "user_WRDSServiceAccount" {
   value = aws_iam_user.WRDSServiceAccount
+}
+
+output "user_FIMServiceAccount" {
+  value = aws_iam_user.FIMServiceAccount
 }

--- a/Core/main.tf
+++ b/Core/main.tf
@@ -121,7 +121,8 @@ module "s3" {
     ]
     "fim" = [
       module.iam-roles.role_HydrovisESRISSMDeploy.arn,
-      module.iam-roles.role_hydrovis-viz-proc-pipeline-lambda.arn
+      module.iam-roles.role_hydrovis-viz-proc-pipeline-lambda.arn,
+      module.iam-users.user_FIMServiceAccount.arn
     ]
     "hml-backup" = [
       module.iam-roles.role_hydrovis-hml-ingest-role.arn


### PR DESCRIPTION
Adding Service Account for the FIM team to use to push FIM artifacts to the FIM S3 bucket.

SmartSheet Card: https://app.smartsheetgov.com/sheets/FwqPVjGh6Qwv9GWh8hG35rj2Rr3g7RFMF3jcj4h1?rowId=6599380456236932