### PR TITLE
updated rds bastion to include missing schema

### DIFF
--- a/Core/EC2/RDSBastion/scripts/viz/postgresql_setup.sh.tftpl
+++ b/Core/EC2/RDSBastion/scripts/viz/postgresql_setup.sh.tftpl
@@ -56,13 +56,18 @@ psql -h "$${VIZDBHOST}" -U "$${VIZDBUSERNAME}" -p $${VIZDBPORT} -d "$${VIZDBNAME
 
 # Cleaning up Viz DB
 echo "Cleaning up Viz DB..."
-psql -h "$${VIZDBHOST}" -U "$${VIZDBUSERNAME}" -p $${VIZDBPORT} -d "$${VIZDBNAME}" -c "DROP SCHEMA IF EXISTS admin CASCADE; DROP SCHEMA IF EXISTS ingest CASCADE; DROP SCHEMA IF EXISTS derived CASCADE; DROP SCHEMA IF EXISTS fim CASCADE; DROP SCHEMA IF EXISTS cache CASCADE; DROP SCHEMA IF EXISTS publish CASCADE;"
+psql -h "$${VIZDBHOST}" -U "$${VIZDBUSERNAME}" -p $${VIZDBPORT} -d "$${VIZDBNAME}" -c "DROP SCHEMA IF EXISTS admin CASCADE; DROP SCHEMA IF EXISTS archive CASCADE; DROP SCHEMA IF EXISTS ingest CASCADE; DROP SCHEMA IF EXISTS derived CASCADE; DROP SCHEMA IF EXISTS fim CASCADE; DROP SCHEMA IF EXISTS cache CASCADE; DROP SCHEMA IF EXISTS publish CASCADE;"
 
 # Resoring Viz DB Schema Dumps
 echo "Setting up admin schema in the VIZ DB..."
 aws s3 cp "s3://$${DEPLOYMENT_BUCKET}/viz/db_pipeline/db_dumps/vizDB_admin.dump" "$${HOME}/vizDB_admin.dump"
 pg_restore -h "$${VIZDBHOST}" -p $${VIZDBPORT} -d "$${VIZDBNAME}" -U $${VIZDBUSERNAME} -j 4 -v "$${HOME}/vizDB_admin.dump"
 rm "$${HOME}/vizDB_admin.dump"
+
+echo "Setting up archive schema in the VIZ DB..."
+aws s3 cp "s3://$${DEPLOYMENT_BUCKET}/viz/db_pipeline/db_dumps/vizDB_archive.dump" "$${HOME}/vizDB_archive.dump"
+pg_restore -h "$${VIZDBHOST}" -p $${VIZDBPORT} -d "$${VIZDBNAME}" -U $${VIZDBUSERNAME} -j 4 -v "$${HOME}/vizDB_archive.dump"
+rm "$${HOME}/vizDB_archive.dump"
 
 echo "Setting up cache schema in the VIZ DB..."
 aws s3 cp "s3://$${DEPLOYMENT_BUCKET}/viz/db_pipeline/db_dumps/vizDB_cache.dump" "$${HOME}/vizDB_cache.dump"


### PR DESCRIPTION
The RDS bastion viz setup script was missing a needed schema for the step functions. DB Dumps are up to date in S3.