### PR TITLE
Opensearch Upgrade

### DIFF
--- a/Core/Monitoring/LogIngest/Lambda/index.js.tftpl
+++ b/Core/Monitoring/LogIngest/Lambda/index.js.tftpl
@@ -3,9 +3,8 @@ const viz_js = require("viz_js");
 // v1.1.2
 var https = require('https');
 var zlib = require('zlib');
-var crypto = require('crypto');
 
-var endpoint = '${os_endpoint}';
+const endpoint = '${os_endpoint}';
 
 // Set this to true if you want to debug why data isn't making it to
 // your OpenSearch cluster. This will enable logging of failed items
@@ -74,7 +73,7 @@ function transform(payload) {
         source['@log_group'] = payload.logGroup;
         source['@log_stream'] = payload.logStream;
 
-        source = viz_js.parse_viz_logs(source, payload.logGroup, logEvent.message)
+        source = viz_js.parse_viz_logs(source, payload.logGroup, logEvent.message);
 
         var action = { "index": {} };
         action.index._index = indexName;
@@ -112,7 +111,7 @@ function buildSource(message, extractedFields) {
         return source;
     }
 
-    var jsonSubString = extractJson(message);
+    jsonSubString = extractJson(message);
     if (jsonSubString !== null) {
         return JSON.parse(jsonSubString);
     }
@@ -139,7 +138,7 @@ function isNumeric(n) {
 }
 
 function post(body, callback) {
-    var requestParams = buildRequest(endpoint, body);
+    var requestParams = buildRequest(body);
 
     var request = https.request(requestParams, function(response) {
         var responseBody = '';
@@ -183,17 +182,7 @@ function post(body, callback) {
     request.end(requestParams.body);
 }
 
-function buildRequest(endpoint, body) {
-    var endpointParts = endpoint.match(/^([^\.]+)\.?([^\.]*)\.?([^\.]*)\.amazonaws\.com$/);
-    var region = endpointParts[2];
-    var service = endpointParts[3];
-    var datetime = (new Date()).toISOString().replace(/[:\-]|\.\d{3}/g, '');
-    var date = datetime.substr(0, 8);
-    var kDate = hmac('AWS4' + process.env.AWS_SECRET_ACCESS_KEY, date);
-    var kRegion = hmac(kDate, region);
-    var kService = hmac(kRegion, service);
-    var kSigning = hmac(kService, 'aws4_request');
-
+function buildRequest(body) {
     var request = {
         host: endpoint,
         method: 'POST',
@@ -202,54 +191,12 @@ function buildRequest(endpoint, body) {
         headers: {
             'Content-Type': 'application/json',
             'Host': endpoint,
-            'Content-Length': Buffer.byteLength(body),
-            'X-Amz-Security-Token': process.env.AWS_SESSION_TOKEN,
-            'X-Amz-Date': datetime
-        }
+            'Content-Length': Buffer.byteLength(body)
+        },
+        auth: '${admin_username}:${admin_password}'
     };
 
-    var canonicalHeaders = Object.keys(request.headers)
-        .sort(function(a, b) { return a.toLowerCase() < b.toLowerCase() ? -1 : 1; })
-        .map(function(k) { return k.toLowerCase() + ':' + request.headers[k]; })
-        .join('\n');
-
-    var signedHeaders = Object.keys(request.headers)
-        .map(function(k) { return k.toLowerCase(); })
-        .sort()
-        .join(';');
-
-    var canonicalString = [
-        request.method,
-        request.path, '',
-        canonicalHeaders, '',
-        signedHeaders,
-        hash(request.body, 'hex'),
-    ].join('\n');
-
-    var credentialString = [ date, region, service, 'aws4_request' ].join('/');
-
-    var stringToSign = [
-        'AWS4-HMAC-SHA256',
-        datetime,
-        credentialString,
-        hash(canonicalString, 'hex')
-    ] .join('\n');
-
-    request.headers.Authorization = [
-        'AWS4-HMAC-SHA256 Credential=' + process.env.AWS_ACCESS_KEY_ID + '/' + credentialString,
-        'SignedHeaders=' + signedHeaders,
-        'Signature=' + hmac(kSigning, stringToSign, 'hex')
-    ].join(', ');
-
     return request;
-}
-
-function hmac(key, str, encoding) {
-    return crypto.createHmac('sha256', key).update(str, 'utf8').digest(encoding);
-}
-
-function hash(str, encoding) {
-    return crypto.createHash('sha256').update(str, 'utf8').digest(encoding);
 }
 
 function logFailure(error, failedItems) {

--- a/Core/Monitoring/LogIngest/Lambda/main.tf
+++ b/Core/Monitoring/LogIngest/Lambda/main.tf
@@ -30,13 +30,19 @@ variable "opensearch_domain_endpoint" {
   type = string
 }
 
+variable "master_user_credentials_secret_string" {
+  type = string
+}
+
 
 data "archive_file" "lambda_code" {
   type = "zip"
 
   source {
     content  = templatefile("${path.module}/index.js.tftpl", {
-      os_endpoint = var.opensearch_domain_endpoint
+      os_endpoint    = var.opensearch_domain_endpoint
+      admin_username = jsondecode(var.master_user_credentials_secret_string)["username"]
+      admin_password = jsondecode(var.master_user_credentials_secret_string)["password"]
     })
     filename = "index.js"
   }

--- a/Core/Monitoring/LogIngest/S3/index.js.tftpl
+++ b/Core/Monitoring/LogIngest/S3/index.js.tftpl
@@ -1,7 +1,6 @@
-var AWS = require('aws-sdk');
+var https = require('https');
 
-const region = '${region}'; // e.g. us-west-1
-const domain = '${os_endpoint}'; // e.g. search-domain.region.es.amazonaws.com
+const endpoint = '${os_endpoint}'; // e.g. search-domain.region.es.amazonaws.com
 
 exports.handler = async function(event, _context) {
 
@@ -28,50 +27,99 @@ exports.handler = async function(event, _context) {
             "alert_state": newAlertState,
         };
 
-        return indexDocument(json, messageId, domain, region)
+        return indexDocument(json, messageId)
     }
 };
 
-function indexDocument(json, id, domain, region) {
-    var endpoint = new AWS.Endpoint(domain);
-    var request = new AWS.HttpRequest(endpoint, region);
+function indexDocument(json, id) {
 
-    request.method = 'PUT';
-    request.path += 's3_anomaly_detection/_doc/' + id;
-    request.body = JSON.stringify(json);
-    request.headers['host'] = domain;
-    request.headers['Content-Type'] = 'application/json';
-    request.headers['Content-Length'] = Buffer.byteLength(request.body);
+    // post documents to the Amazon OpenSearch Service
+    post(JSON.stringify(json), id, function(error, success, statusCode, failedItems) {
+        console.log('Response: ' + JSON.stringify({
+            "statusCode": statusCode
+        }));
 
-    var credentials = new AWS.EnvironmentCredentials('AWS');
-    var signer = new AWS.Signers.V4(request, 'es');
-    signer.addAuthorization(credentials, new Date());
-
-
-    var client = new AWS.HttpClient();
-    return new Promise((resolve, reject) => {
-        client.handleRequest(
-            request,
-            null,
-            (response) => {
-                const {statusCode, statusMessage, headers} = response;
-                let body = '';
-                response.on('data', (chunk) => {
-                    body += chunk;
-                });
-                response.on('end', () => {
-                    const data = {statusCode, statusMessage, headers};
-                    if (body) {
-                        data.body = body;
-                    }
-                    resolve(data);
-                console.log("Response body:" + body);
-                });
-            },
-            (error) => {
-                reject(error);
-                console.log("Error:" + error)
-            }
-        );
-    })
+        if (error) {
+            logFailure(error, failedItems);
+            context.fail(JSON.stringify(error));
+        } else {
+            console.log('Success: ' + JSON.stringify(success));
+            context.succeed('Success');
+        }
+    });
 };
+
+
+
+function post(body, id, callback) {
+    var requestParams = buildRequest(body, id);
+
+    var request = https.request(requestParams, function(response) {
+        var responseBody = '';
+        response.on('data', function(chunk) {
+            responseBody += chunk;
+        });
+
+        response.on('end', function() {
+            var info = JSON.parse(responseBody);
+            var failedItems;
+            var success;
+            var error;
+
+            if (response.statusCode >= 200 && response.statusCode < 299) {
+                failedItems = info.items.filter(function(x) {
+                    return x.index.status >= 300;
+                });
+
+                success = {
+                    "attemptedItems": info.items.length,
+                    "successfulItems": info.items.length - failedItems.length,
+                    "failedItems": failedItems.length
+                };
+            }
+
+            if (response.statusCode !== 200 || info.errors === true) {
+                // prevents logging of failed entries, but allows logging
+                // of other errors such as access restrictions
+                delete info.items;
+                error = {
+                    statusCode: response.statusCode,
+                    responseBody: info
+                };
+            }
+
+            callback(error, success, response.statusCode, failedItems);
+        });
+    }).on('error', function(e) {
+        callback(e);
+    });
+    request.end(requestParams.body);
+}
+
+function buildRequest(body, id) {
+    var request = {
+        host: endpoint,
+        method: 'PUT',
+        path: '/s3_anomaly_detection/_doc/' + id,
+        body: body,
+        headers: {
+            'Content-Type': 'application/json',
+            'Host': endpoint,
+            'Content-Length': Buffer.byteLength(body)
+        },
+        auth: '${admin_username}:${admin_password}'
+    };
+
+    return request;
+}
+
+function logFailure(error, failedItems) {
+    if (logFailedResponses) {
+        console.log('Error: ' + JSON.stringify(error, null, 2));
+
+        if (failedItems && failedItems.length > 0) {
+            console.log("Failed Items: " +
+                JSON.stringify(failedItems, null, 2));
+        }
+    }
+}

--- a/Core/Monitoring/LogIngest/S3/main.tf
+++ b/Core/Monitoring/LogIngest/S3/main.tf
@@ -30,6 +30,10 @@ variable "buckets_and_parameters" {
   type = map(map(string))
 }
 
+variable "master_user_credentials_secret_string" {
+  type = string
+}
+
 
 module "bucket" {
   source   = "./bucket"
@@ -49,7 +53,8 @@ data "archive_file" "lambda_code" {
   source {
     content  = templatefile("${path.module}/index.js.tftpl", {
       os_endpoint = var.opensearch_domain_endpoint
-      region      = var.region
+      admin_username = jsondecode(var.master_user_credentials_secret_string)["username"]
+      admin_password = jsondecode(var.master_user_credentials_secret_string)["password"]
     })
     filename = "index.js"
   }

--- a/Core/Monitoring/LogIngest/main.tf
+++ b/Core/Monitoring/LogIngest/main.tf
@@ -114,11 +114,12 @@ module "lambda" {
   account_id             = var.account_id
   region                 = var.region
 
-  data_subnet_ids               = var.data_subnet_ids
-  opensearch_security_group_ids = var.opensearch_security_group_ids
-  lambda_trigger_functions      = var.lambda_trigger_functions
-  opensearch_domain_arn         = var.opensearch_domain_arn
-  opensearch_domain_endpoint  = var.opensearch_domain_endpoint
+  data_subnet_ids                            = var.data_subnet_ids
+  opensearch_security_group_ids              = var.opensearch_security_group_ids
+  lambda_trigger_functions                   = var.lambda_trigger_functions
+  opensearch_domain_arn                      = var.opensearch_domain_arn
+  opensearch_domain_endpoint                 = var.opensearch_domain_endpoint
+  master_user_credentials_secret_string      = var.master_user_credentials_secret_string
 }
 
 # Creates Lambda Function that reads CloudWatch logs from replicated S3 Buckets and sends them to OpenSearch.
@@ -129,10 +130,11 @@ module "s3" {
   account_id             = var.account_id
   region                 = var.region
 
-  data_subnet_ids               = var.data_subnet_ids
-  opensearch_security_group_ids = var.opensearch_security_group_ids
-  opensearch_domain_endpoint    = var.opensearch_domain_endpoint
-  lambda_role_arn               = module.lambda.role_arn
+  data_subnet_ids                            = var.data_subnet_ids
+  opensearch_security_group_ids              = var.opensearch_security_group_ids
+  opensearch_domain_endpoint                 = var.opensearch_domain_endpoint
+  lambda_role_arn                            = module.lambda.role_arn
+  master_user_credentials_secret_string      = var.master_user_credentials_secret_string
 
   buckets_and_parameters = var.buckets_and_parameters
 }


### PR DESCRIPTION
- Replaces ElasticSearch domain in place of the new OpenSearch domain
- Adds authentication to monitoring dashboards
- Creates and stores new dashboards credentials in Secrets Manager
- Creates Nginx proxy to expose the OpenSearch Dashboards to a `/_dashboards` url on the public Load Balancer
- Creates private Route53 record for Logstash EC2, so that other EC2 instances can reference the DNS instead of a changing IP address
- Updates Lambdas, used to forward Cloudwatch Logs to Opensearch, to Node.JS version 16
- Updates Viz EC2 Filebeat version to match the new Logstash and OpenSearch versions

SmartSheet Cards:

- [ElasticSearch to OpenSearch upgrade](https://app.smartsheetgov.com/sheets/FwqPVjGh6Qwv9GWh8hG35rj2Rr3g7RFMF3jcj4h1?rowId=5035783737370500)
- [Lambda Node.JS upgrade](https://app.smartsheetgov.com/sheets/FwqPVjGh6Qwv9GWh8hG35rj2Rr3g7RFMF3jcj4h1?rowId=1555468104558468)
- [Nginx Proxy](https://app.smartsheetgov.com/sheets/FwqPVjGh6Qwv9GWh8hG35rj2Rr3g7RFMF3jcj4h1?rowId=8676381795084164)
