### PR TITLE
Opensearch Upgrade

### DIFF
--- a/Core/Monitoring/LogIngest/S3/index.js.tftpl
+++ b/Core/Monitoring/LogIngest/S3/index.js.tftpl
@@ -2,6 +2,11 @@ var https = require('https');
 
 const endpoint = '${os_endpoint}'; // e.g. search-domain.region.es.amazonaws.com
 
+// Set this to true if you want to debug why data isn't making it to
+// your OpenSearch cluster. This will enable logging of failed items
+// to CloudWatch Logs.
+var logFailedResponses = true;
+
 exports.handler = async function(event, _context) {
 
     var snsPublishTime = event.Records[0].Sns.Timestamp


### PR DESCRIPTION
- Replaces ElasticSearch domain in place of the new OpenSearch domain
- Adds authentication to monitoring dashboards
- Creates and stores new dashboards credentials in Secrets Manager
- Creates Nginx proxy to expose the OpenSearch Dashboards to a `/_dashboards` url on the public Load Balancer
- Creates private Route53 record for Logstash EC2, so that other EC2 instances can reference the DNS instead of a changing IP address
- Updates Lambdas, used to forward Cloudwatch Logs to Opensearch, to Node.JS version 16
- Updates Viz EC2 Filebeat version to match the new Logstash and OpenSearch versions

SmartSheet Cards:

- [ElasticSearch to OpenSearch upgrade](https://app.smartsheetgov.com/sheets/FwqPVjGh6Qwv9GWh8hG35rj2Rr3g7RFMF3jcj4h1?rowId=5035783737370500)
- [Lambda Node.JS upgrade](https://app.smartsheetgov.com/sheets/FwqPVjGh6Qwv9GWh8hG35rj2Rr3g7RFMF3jcj4h1?rowId=1555468104558468)
- [Nginx Proxy](https://app.smartsheetgov.com/sheets/FwqPVjGh6Qwv9GWh8hG35rj2Rr3g7RFMF3jcj4h1?rowId=8676381795084164)
