### PR TITLE
Opensearch Upgrade

### DIFF
--- a/Core/Monitoring/LogIngest/EC2/parser_templates/viz_logstash.conf
+++ b/Core/Monitoring/LogIngest/EC2/parser_templates/viz_logstash.conf
@@ -71,6 +71,7 @@ filter {
             add_field => { "process_status_code" => 0 }
             add_field => { "watcher_status_code" => 7 }
             add_field => { "service_status_code" => 4 }
+            add_field => { "service_finish_code" => 0 }
             add_field => { "metric_type" => ["process_status", "watcher_status"] }
         }
 
@@ -78,6 +79,7 @@ filter {
             match => { "[message]" => "Process launched for %%{TIMESTAMP_ISO8601:latest_data_time} by the %%{GREEDYDATA:watcher} Watcher has exited" }
             add_field => { "process_status_code" => 8 }
             add_field => { "service_status_code" => 10 }
+            add_field => { "service_finish_code" => 1 }
             add_field => { "metric_type" => "process_status" }
         }
 
@@ -247,7 +249,7 @@ filter {
     #########################
     # Data type conversions #
     #########################
-    if "[type]" == "viz" {
+    if [type] == "viz" {
         mutate {
             convert => {
                 "process_status_code" => "integer"
@@ -255,6 +257,7 @@ filter {
                 "total_resources" => "integer"
                 "resources_fetched" => "integer"
                 "service_status_code" => "integer"
+                "service_finish_code" => "integer"
                 "total_processes" => "integer"
             }
         }


### PR DESCRIPTION
- Replaces ElasticSearch domain in place of the new OpenSearch domain
- Adds authentication to monitoring dashboards
- Creates and stores new dashboards credentials in Secrets Manager
- Creates Nginx proxy to expose the OpenSearch Dashboards to a `/_dashboards` url on the public Load Balancer
- Creates private Route53 record for Logstash EC2, so that other EC2 instances can reference the DNS instead of a changing IP address
- Updates Lambdas, used to forward Cloudwatch Logs to Opensearch, to Node.JS version 16
- Updates Viz EC2 Filebeat version to match the new Logstash and OpenSearch versions

SmartSheet Cards:

- [ElasticSearch to OpenSearch upgrade](https://app.smartsheetgov.com/sheets/FwqPVjGh6Qwv9GWh8hG35rj2Rr3g7RFMF3jcj4h1?rowId=5035783737370500)
- [Lambda Node.JS upgrade](https://app.smartsheetgov.com/sheets/FwqPVjGh6Qwv9GWh8hG35rj2Rr3g7RFMF3jcj4h1?rowId=1555468104558468)
- [Nginx Proxy](https://app.smartsheetgov.com/sheets/FwqPVjGh6Qwv9GWh8hG35rj2Rr3g7RFMF3jcj4h1?rowId=8676381795084164)
