### PR TITLE
Viz - FIMpact Building Footprints & SRC Skill

### DIFF
--- a/Core/EC2/RDSBastion/scripts/viz/postgresql_setup.sh.tftpl
+++ b/Core/EC2/RDSBastion/scripts/viz/postgresql_setup.sh.tftpl
@@ -56,7 +56,7 @@ psql -h "$${VIZDBHOST}" -U "$${VIZDBUSERNAME}" -p $${VIZDBPORT} -d "$${VIZDBNAME
 
 # Cleaning up Viz DB
 echo "Cleaning up Viz DB..."
-psql -h "$${VIZDBHOST}" -U "$${VIZDBUSERNAME}" -p $${VIZDBPORT} -d "$${VIZDBNAME}" -c "DROP SCHEMA IF EXISTS admin CASCADE; DROP SCHEMA IF EXISTS archive CASCADE; DROP SCHEMA IF EXISTS ingest CASCADE; DROP SCHEMA IF EXISTS derived CASCADE; DROP SCHEMA IF EXISTS fim CASCADE; DROP SCHEMA IF EXISTS cache CASCADE; DROP SCHEMA IF EXISTS publish CASCADE;"
+psql -h "$${VIZDBHOST}" -U "$${VIZDBUSERNAME}" -p $${VIZDBPORT} -d "$${VIZDBNAME}" -c "DROP SCHEMA IF EXISTS admin CASCADE; DROP SCHEMA IF EXISTS archive CASCADE; DROP SCHEMA IF EXISTS ingest CASCADE; DROP SCHEMA IF EXISTS derived CASCADE; DROP SCHEMA IF EXISTS external CASCADE; DROP SCHEMA IF EXISTS fim CASCADE; DROP SCHEMA IF EXISTS cache CASCADE; DROP SCHEMA IF EXISTS publish CASCADE;"
 
 # Resoring Viz DB Schema Dumps
 echo "Setting up admin schema in the VIZ DB..."
@@ -78,6 +78,11 @@ echo "Setting up derived schema in the VIZ DB..."
 aws s3 cp "s3://$${DEPLOYMENT_BUCKET}/viz/db_pipeline/db_dumps/vizDB_derived.dump" "$${HOME}/vizDB_derived.dump"
 pg_restore -h "$${VIZDBHOST}" -p $${VIZDBPORT} -d "$${VIZDBNAME}" -U $${VIZDBUSERNAME} -j 4 -v "$${HOME}/vizDB_derived.dump"
 rm "$${HOME}/vizDB_derived.dump"
+
+echo "Setting up external schema in the VIZ DB..."
+aws s3 cp "s3://$${DEPLOYMENT_BUCKET}/viz/db_pipeline/db_dumps/vizDB_external.dump" "$${HOME}/vizDB_external.dump"
+pg_restore -h "$${VIZDBHOST}" -p $${VIZDBPORT} -d "$${VIZDBNAME}" -U $${VIZDBUSERNAME} -j 4 -v "$${HOME}/vizDB_external.dump"
+rm "$${HOME}/vizDB_external.dump"
 
 echo "Setting up ingest schema in the VIZ DB..."
 aws s3 cp "s3://$${DEPLOYMENT_BUCKET}/viz/db_pipeline/db_dumps/vizDB_ingest.dump" "$${HOME}/vizDB_ingest.dump"

--- a/Core/RDS/viz/main.tf
+++ b/Core/RDS/viz/main.tf
@@ -37,8 +37,8 @@ resource "aws_db_subnet_group" "viz-processing" {
 resource "aws_db_instance" "viz-processing" {
   identifier                   = "hydrovis-${var.environment}-viz-processing"
   db_name                      = var.viz_db_name
-  instance_class               = "db.r6g.xlarge"
-  allocated_storage            = 400
+  instance_class               = "db.m6g.xlarge"
+  allocated_storage            = 500
   storage_type                 = "gp2"
   engine                       = "postgres"
   engine_version               = "12.8"


### PR DESCRIPTION
This is a viz update for the Inundation map services, including the new QC FIM layers for FIMpact Building Footprints and SRC Skill.

**Updates Include:**
- RDS: Tweaks to the Viz DB Size
- RDSBastion: New loading of External schema in the Viz DB

**Remaining ToDos (We'll need to wait on these to merge):**
- [x] DB_Dump: Update the derived db_dump file to reflect the new src skill rating curve data (I already did this for the hotfixes this week, and copied to UAT already).
- [ ] Lambda: Update to the viz_postprocess_sql lambda function
- [ ] Viz Repo: Corey will need to update the TI branch our Viz repo for the new mapx files to get deployed, once they are complete.
- [ ] FIM4: Reconcile and Update with Corey's FIM4 iterative tweaks, notably moving the update_egis_data function to happen at the fim config level. We'll need to tweak the src and fimpact sql files to point to the specific tables, instead of the main table with a config where clause as currently exists.

**Other ToDos / Considerations:**
- [ ] I still haven't added the service metadata for these new service enhancements to our admin schema / db_dump files. I'm a little torn on how best to do this, and will talk more with Corey about it.
- [ ] I believe that the RDS changes will need to be made manually as this is deployed forward?