### PR TITLE
Edits main.tf to push db scripts to bastion ec2

### DIFF
--- a/Core/EC2/RDSBastion/main.tf
+++ b/Core/EC2/RDSBastion/main.tf
@@ -199,44 +199,6 @@ data "cloudinit_config" "startup" {
 
   part {
     content_type = "text/x-shellscript"
-    filename                 = "restore_db_from_s3.sh"
-    content                  = templatefile("${path.module}/scripts/restore_db_from_s3.sh.tftpl", {
-      EGIS_PGUSER            = jsondecode(var.egis_db_secret_string)["username"]
-      EGIS_PGPASSWORD        = jsondecode(var.egis_db_secret_string)["password"]
-      EGIS_PGHOST            = var.egis_db_address
-      EGIS_PGPORT            = var.egis_db_port
-      INGEST_PGUSER          = jsondecode(var.ingest_db_secret_string)["username"]
-      INGEST_PGPASSWORD      = jsondecode(var.ingest_db_secret_string)["password"]
-      INGEST_PGHOST          = var.ingest_db_address
-      INGEST_PGPORT          = var.ingest_db_port
-      VIZ_PGUSER             = jsondecode(var.viz_db_secret_string)["username"]
-      VIZ_PGPASSWORD         = jsondecode(var.viz_db_secret_string)["password"]
-      VIZ_PGHOST             = var.viz_db_address
-      VIZ_PGPORT             = var.viz_db_port
-    })
-  }
-
-  part {
-    content_type = "text/x-shellscript"
-    filename                 = "swap_dbs.sh"
-    content                  = templatefile("${path.module}/scripts/swap_dbs.sh.tftpl", {
-      EGIS_PGUSER            = jsondecode(var.egis_db_secret_string)["username"]
-      EGIS_PGPASSWORD        = jsondecode(var.egis_db_secret_string)["password"]
-      EGIS_PGHOST            = var.egis_db_address
-      EGIS_PGPORT            = var.egis_db_port
-      INGEST_PGUSER          = jsondecode(var.ingest_db_secret_string)["username"]
-      INGEST_PGPASSWORD      = jsondecode(var.ingest_db_secret_string)["password"]
-      INGEST_PGHOST          = var.ingest_db_address
-      INGEST_PGPORT          = var.ingest_db_port
-      VIZ_PGUSER             = jsondecode(var.viz_db_secret_string)["username"]
-      VIZ_PGPASSWORD         = jsondecode(var.viz_db_secret_string)["password"]
-      VIZ_PGHOST             = var.viz_db_address
-      VIZ_PGPORT             = var.viz_db_port
-    })
-  }
-
-  part {
-    content_type = "text/x-shellscript"
     filename     = "viz_postgresql_setup.sh"
     content      = templatefile("${path.module}/scripts/viz/postgresql_setup.sh.tftpl", {
       VIZDBNAME              = var.viz_db_name
@@ -311,6 +273,68 @@ data "cloudinit_config" "startup" {
     END
   }
 }
+
+part {
+    content_type = "text/x-shellscript"
+    filename                 = "restore_db_from_s3.sh"
+    content = <<-END
+      #cloud-config
+      ${jsonencode({
+        write_files = [
+          {
+            path        = "/deploy_files/restore_db_from_s3.sql"
+            permissions = "0700"
+            owner       = "ec2-user:ec2-user"
+            content                  = templatefile("${path.module}/scripts/restore_db_from_s3.sh.tftpl", {
+              EGIS_PGUSER            = jsondecode(var.egis_db_secret_string)["username"]
+              EGIS_PGPASSWORD        = jsondecode(var.egis_db_secret_string)["password"]
+              EGIS_PGHOST            = var.egis_db_address
+              EGIS_PGPORT            = var.egis_db_port
+              INGEST_PGUSER          = jsondecode(var.ingest_db_secret_string)["username"]
+              INGEST_PGPASSWORD      = jsondecode(var.ingest_db_secret_string)["password"]
+              INGEST_PGHOST          = var.ingest_db_address
+              INGEST_PGPORT          = var.ingest_db_port
+              VIZ_PGUSER             = jsondecode(var.viz_db_secret_string)["username"]
+              VIZ_PGPASSWORD         = jsondecode(var.viz_db_secret_string)["password"]
+              VIZ_PGHOST             = var.viz_db_address
+              VIZ_PGPORT             = var.viz_db_port
+            })
+          }
+        ]
+      })}
+    END
+  }
+
+  part {
+    content_type = "text/x-shellscript"
+    filename                 = "swap_dbs.sh"
+    content = <<-END
+      #cloud-config
+      ${jsonencode({
+        write_files = [
+          {
+            path        = "/deploy_files/swap_dbs.sql"
+            permissions = "0700"
+            owner       = "ec2-user:ec2-user"
+            content                  = templatefile("${path.module}/scripts/swap_dbs.sh.tftpl", {
+              EGIS_PGUSER            = jsondecode(var.egis_db_secret_string)["username"]
+              EGIS_PGPASSWORD        = jsondecode(var.egis_db_secret_string)["password"]
+              EGIS_PGHOST            = var.egis_db_address
+              EGIS_PGPORT            = var.egis_db_port
+              INGEST_PGUSER          = jsondecode(var.ingest_db_secret_string)["username"]
+              INGEST_PGPASSWORD      = jsondecode(var.ingest_db_secret_string)["password"]
+              INGEST_PGHOST          = var.ingest_db_address
+              INGEST_PGPORT          = var.ingest_db_port
+              VIZ_PGUSER             = jsondecode(var.viz_db_secret_string)["username"]
+              VIZ_PGPASSWORD         = jsondecode(var.viz_db_secret_string)["password"]
+              VIZ_PGHOST             = var.viz_db_address
+              VIZ_PGPORT             = var.viz_db_port
+            })
+          }
+        ]
+      })}
+    END
+  }
 
 output "instance-id" {
   value = aws_instance.rds-bastion.id


### PR DESCRIPTION
The changes recently made to provide the infrastructure for and automation of the WRDS Database Syncing were found to have a bug. The bug was caused by a step function not being able to find a script that was supposed to be on the RDS Bastion EC2 machine. I hadn't modified the main.tf script that provisions and deploys this EC2 instance correctly to ensure that these expected files are properly put into place. The changes within this pull request should resolve that issue.