### PR TITLE
Adds resources for auto-sync of wrds location db

### DIFF
--- a/Core/SyncWrdsLocationDB/main.tf
+++ b/Core/SyncWrdsLocationDB/main.tf
@@ -43,6 +43,11 @@ variable "lambda_subnets" {
   type        = list(any)
 }
 
+variable "db_dumps_bucket" {
+  description = "The bucket that the WRDS Location DB dumps are being uploaded to"
+  type       = string
+}
+
 ########################################################################################################################################
 ########################################################################################################################################
 data "aws_caller_identity" "current" {}
@@ -59,7 +64,7 @@ resource "aws_cloudwatch_event_rule" "detect_location_db_dump" {
     "detail-type": ["Object Created"],
     "detail": {
       "bucket": {
-        "name": ["hydrovis-${var.environment}-deployment-us-east-1"]
+        "name": ["${var.db_dumps_bucket}"]
       },
       "object": {
         "key": [{
@@ -430,4 +435,9 @@ resource "aws_cloudwatch_event_target" "step_function_failure_sns" {
   target_id   = "SendToSNS"
   arn         = var.email_sns_topics["viz_lambda_errors"].arn
   input_path  = "$.detail.name"
+}
+
+resource "aws_s3_bucket_notification" "nwm_bucket_notification" {
+  bucket = var.db_dumps_bucket
+  eventbridge = true
 }

--- a/Core/main.tf
+++ b/Core/main.tf
@@ -581,4 +581,5 @@ module "sync_wrds_location_db" {
   test_data_services_id     = module.data-services.dataservices-test-instance-id
   lambda_security_groups    = [module.security-groups.hydrovis-RDS.id]
   lambda_subnets            = [module.vpc.subnet_hydrovis-sn-prv-data1a.id, module.vpc.subnet_hydrovis-sn-prv-data1b.id]
+  db_dumps_bucket           = module.s3.buckets["deployment"].bucket
 }


### PR DESCRIPTION
This adds the configuration for all of the resources needed for the sync-wrds-location-db workflow. The main workflow is in the form of a step function state machine named "sync-wrds-location-db". This step function does the following:

Starts up the test instance of the data services API machine (the creation of which is also configured herein), which points to the "wrds_location3_ondeck" database that will be deployed in the next step.

Calls another custom step function state machine configure herein called "restore_db_from_s3" which:

Starts up the RDS Bastion machine (if not already started)
Uses the SendCommand API of the SystemsManager service to kick off a bash script called "restore_db_from_s3.sh" on the RDS Bastion machine. This script is now copied to the machine on deploy and contains the logic to pull a sql.gz file from S3 and restore it to the specified database. In the case of this workflow, the args provided initiate a copy of the current-date-stamped S3 file from s3://hydrovis-ti-deployment-us-east-1/location/database/wrds_location3_YYYYMMDD.sql.gz and deploys it to the ingest RDS instance into the "wrds_location3_ondeck" database.
Kicks off the "wrds_location_api_tests" lambda function that pings the test data services API which points to the just-deployed "wrds_location3_ondeck" database.

Uses the SendCommand API of the SystemsManager service to kick off a bash script called "swap_dbs.sh" on the RDS Bastion machine. This script is now copied to the machine on deploy and contains the logic to do a blue/green type swap of databases, where the active get renamed as "_retired", the "_ondeck" gets renamed as the active.

Shuts down the test data services API machine and the RDS Bastion machine.

SmartSheet Card: https://app.smartsheetgov.com/sheets/FwqPVjGh6Qwv9GWh8hG35rj2Rr3g7RFMF3jcj4h1?rowId=1662786318165892