### PR TITLE
Real-time feed schism processing implemented

### DIFF
--- a/Core/LAMBDA/viz_functions/image_based/viz_schism_fim_processing/serverless.yml
+++ b/Core/LAMBDA/viz_functions/image_based/viz_schism_fim_processing/serverless.yml
@@ -14,6 +14,7 @@ functions:
     timeout: 900
     ephemeralStorageSize: 2048
     environment:
+      MAX_VALS_BUCKET: ${env:MAX_VALS_BUCKET}
       INPUTS_BUCKET: ${env:INPUTS_BUCKET}
       INPUTS_PREFIX: ${env:INPUTS_PREFIX}
       OUTPUTS_BUCKET: ${env:OUTPUTS_BUCKET}


### PR DESCRIPTION
Refs #246

This code implements the real-time feed processing of the NWM coastal total water outputs to produce the backend datasets for both the extent and depth services. The code falls short of fully implementing the automatic publishing of these services, as some more extensive changes will be required to be able to publish the depth raster mosaic. The plan is to manually publish both services against the backend datasets. 

## Additions

- "viz_schism_fim_processing" lambda function
- "process_schism_fim" step function

## Removals

None

## Changes

- "viz_pipeline" step function
- "viz_max_flows" lambda function
- "viz_lambda_shared_funcs" lambda layer (specifically the viz_classes.py module)
- "viz_initialize_pipeline" lambda function
- "viz_db_postprocess_sql" lambda function
- "viz_optimize_rasters" lambda function
- "viz_update_egis_data" lambda function

## Notes

This is being rushed into implementation because although we're not ready for the automatic publishing, we want to get eyes on these services as quick as possible. Also, the service will not move into production for months anyway, so we're confident we can iterate on this effectively to have it ready by production by then.

## Todos

Though there are no todos remaining prior to being able to merge this code (unless testing reveals anything), I mention the following just as a documented reminder of the additional work still needed on ticket #246:
- Wrap up and commit the inundation_extent service MAPX files
- Develop the auto-publishing and data updating modifications pertaining to the inundation_depth raster mosaics
