### PR TITLE
Rapid Onset Flooding Probability Logic Update

### DIFF
--- a/Core/VIZ/EC2/code/aws_loosa/pipelines/mrf_gfs_rapid_onset_flooding_probability_para/mrf_gfs_rapid_onset_flooding_probability_hucs_para.sql
+++ b/Core/VIZ/EC2/code/aws_loosa/pipelines/mrf_gfs_rapid_onset_flooding_probability_para/mrf_gfs_rapid_onset_flooding_probability_hucs_para.sql
@@ -16,5 +16,5 @@ SELECT
 INTO publish.mrf_gfs_rapid_onset_flooding_probability_hucs_para
 FROM derived.huc8s_conus AS hucs
 JOIN derived.featureid_huc_crosswalk AS crosswalk ON hucs.huc8 = crosswalk.huc8
-JOIN publish.mrf_rapid_onset_flooding_probability AS rofp ON crosswalk.feature_id = rofp.feature_id
+JOIN publish.mrf_gfs_rapid_onset_flooding_probability_para AS rofp ON crosswalk.feature_id = rofp.feature_id
 GROUP BY hucs.huc8, hucs.low_order_reach_count, hucs.total_low_order_reach_length, hucs.total_low_order_reach_miles, hucs.geom

--- a/Core/VIZ/EC2/code/aws_loosa/pipelines/srf_rapid_onset_flooding_probability_para/srf_rapid_onset_flooding_probability_hucs_para.sql
+++ b/Core/VIZ/EC2/code/aws_loosa/pipelines/srf_rapid_onset_flooding_probability_para/srf_rapid_onset_flooding_probability_hucs_para.sql
@@ -16,5 +16,5 @@ SELECT
 INTO publish.srf_rapid_onset_flooding_probability_hucs_para
 FROM derived.huc10s_conus AS hucs
 JOIN derived.featureid_huc_crosswalk AS crosswalk ON hucs.huc10 = crosswalk.huc10
-JOIN publish.srf_rapid_onset_flooding_probability AS rofp ON crosswalk.feature_id = rofp.feature_id
+JOIN publish.srf_rapid_onset_flooding_probability_para AS rofp ON crosswalk.feature_id = rofp.feature_id
 GROUP BY hucs.huc10, hucs.low_order_reach_count, hucs.total_low_order_reach_length, hucs.total_low_order_reach_miles, hucs.geom


### PR DESCRIPTION
Current workflow for rapid onset flooding probability looks at the first instance of ROF among all the members. I updated the logic to track ROF conditions for all instances and tracked which days experienced ROF. I then used that to calculate the probability. I also updated some of the workflow to use more pandas as well as update some of the short range version variables to better align with the NWM file language of model initialization and model output.