### PR TITLE
Viz - Inundation Layers - Min Scale Filter

### DIFF
--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_inundation.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_inundation.mapx
@@ -92,9 +92,9 @@
       }
     ],
     "defaultExtent" : {
-      "xmin" : -15250772.0291557685,
-      "ymin" : 1474107.38979748311,
-      "xmax" : -5851112.10396996513,
+      "xmin" : -16791651.2146173716,
+      "ymin" : 1474107.38979748264,
+      "xmax" : -4310232.918508362,
       "ymax" : 8534243.619137926,
       "spatialReference" : {
         "wkid" : 102100,
@@ -200,6 +200,10 @@
       {
         "type" : "CIMScale",
         "value" : 100000
+      },
+      {
+        "type" : "CIMScale",
+        "value" : 400000
       },
       {
         "type" : "CIMScale",
@@ -5873,6 +5877,7 @@
       },
       "expanded" : true,
       "layerType" : "Operational",
+      "minScale" : 400000,
       "showLegends" : true,
       "visibility" : true,
       "displayCacheType" : "Permanent",

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_inundation_hi.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_inundation_hi.mapx
@@ -203,6 +203,10 @@
       },
       {
         "type" : "CIMScale",
+        "value" : 400000
+      },
+      {
+        "type" : "CIMScale",
         "value" : 500000
       },
       {
@@ -3399,6 +3403,7 @@
       },
       "expanded" : true,
       "layerType" : "Operational",
+      "minScale" : 400000,
       "showLegends" : true,
       "visibility" : true,
       "displayCacheType" : "Permanent",

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_inundation_prvi.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_inundation_prvi.mapx
@@ -203,6 +203,10 @@
       },
       {
         "type" : "CIMScale",
+        "value" : 400000
+      },
+      {
+        "type" : "CIMScale",
         "value" : 500000
       },
       {
@@ -3400,6 +3404,7 @@
       },
       "expanded" : true,
       "layerType" : "Operational",
+      "minScale" : 400000,
       "showLegends" : true,
       "visibility" : true,
       "displayCacheType" : "Permanent",

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_past_14day_max_inundation.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_past_14day_max_inundation.mapx
@@ -203,6 +203,10 @@
       },
       {
         "type" : "CIMScale",
+        "value" : 400000
+      },
+      {
+        "type" : "CIMScale",
         "value" : 500000
       },
       {
@@ -5879,6 +5883,7 @@
       },
       "expanded" : true,
       "layerType" : "Operational",
+      "minScale" : 400000,
       "showLegends" : true,
       "visibility" : false,
       "displayCacheType" : "Permanent",
@@ -12156,6 +12161,7 @@
       },
       "expanded" : true,
       "layerType" : "Operational",
+      "minScale" : 400000,
       "showLegends" : true,
       "visibility" : true,
       "displayCacheType" : "Permanent",

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/mrf_max_inundation.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/mrf_max_inundation.mapx
@@ -204,6 +204,10 @@
       },
       {
         "type" : "CIMScale",
+        "value" : 400000
+      },
+      {
+        "type" : "CIMScale",
         "value" : 500000
       },
       {
@@ -5872,6 +5876,7 @@
         "mapElevationID" : "{84F61CAA-CD53-4C26-BBF2-C7F7CA71C354}"
       },
       "layerType" : "Operational",
+      "minScale" : 400000,
       "showLegends" : true,
       "visibility" : false,
       "displayCacheType" : "Permanent",
@@ -12128,6 +12133,7 @@
         "mapElevationID" : "{84F61CAA-CD53-4C26-BBF2-C7F7CA71C354}"
       },
       "layerType" : "Operational",
+      "minScale" : 400000,
       "showLegends" : true,
       "visibility" : false,
       "displayCacheType" : "Permanent",
@@ -18385,6 +18391,7 @@
         "mapElevationID" : "{84F61CAA-CD53-4C26-BBF2-C7F7CA71C354}"
       },
       "layerType" : "Operational",
+      "minScale" : 400000,
       "showLegends" : true,
       "visibility" : true,
       "displayCacheType" : "Permanent",

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/rfc_5day_max_downstream_inundation.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/rfc_5day_max_downstream_inundation.mapx
@@ -203,6 +203,10 @@
       },
       {
         "type" : "CIMScale",
+        "value" : 400000
+      },
+      {
+        "type" : "CIMScale",
         "value" : 500000
       },
       {
@@ -5882,6 +5886,7 @@
       },
       "expanded" : true,
       "layerType" : "Operational",
+      "minScale" : 400000,
       "showLegends" : true,
       "visibility" : true,
       "displayCacheType" : "Permanent",

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/srf_max_inundation.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/srf_max_inundation.mapx
@@ -203,6 +203,10 @@
       },
       {
         "type" : "CIMScale",
+        "value" : 400000
+      },
+      {
+        "type" : "CIMScale",
         "value" : 500000
       },
       {
@@ -5875,6 +5879,7 @@
       },
       "expanded" : true,
       "layerType" : "Operational",
+      "minScale" : 400000,
       "showLegends" : true,
       "visibility" : true,
       "displayCacheType" : "Permanent",

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/srf_max_inundation_hi.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/srf_max_inundation_hi.mapx
@@ -203,6 +203,10 @@
       },
       {
         "type" : "CIMScale",
+        "value" : 400000
+      },
+      {
+        "type" : "CIMScale",
         "value" : 500000
       },
       {
@@ -3400,6 +3404,7 @@
       },
       "expanded" : true,
       "layerType" : "Operational",
+      "minScale" : 400000,
       "showLegends" : true,
       "visibility" : true,
       "displayCacheType" : "Permanent",

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/srf_max_inundation_prvi.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/srf_max_inundation_prvi.mapx
@@ -203,6 +203,10 @@
       },
       {
         "type" : "CIMScale",
+        "value" : 400000
+      },
+      {
+        "type" : "CIMScale",
         "value" : 500000
       },
       {
@@ -3400,6 +3404,7 @@
       },
       "expanded" : true,
       "layerType" : "Operational",
+      "minScale" : 400000,
       "showLegends" : true,
       "visibility" : true,
       "displayCacheType" : "Permanent",


### PR DESCRIPTION
This PR adds a min scale (1:400,000) so that FIM layers will not render when zoomed out further.

The script on the EC2 machines will need to be ran to re-create inundation sd files on S3, once this is deployed (I can do this if we hotfix).