### PR TITLE
PR: Adding 1ft intervals to Stage-Based CatFIM

### DIFF
--- a/Core/EC2/RDSBastion/scripts/viz/postgresql_setup.sh.tftpl
+++ b/Core/EC2/RDSBastion/scripts/viz/postgresql_setup.sh.tftpl
@@ -21,14 +21,14 @@ VIZ_PROC_DEV_RW_PASS="${VIZ_PROC_DEV_RW_PASS}"
 
 ### set correct db dump file names / versions here - These should be in the S3 bucket at {DEPLOYMENT_BUCKET}/viz/db_pipeline/db_dumps ###
 egisDB_services="egisDB_services_2023_0214.dump"
-egisDB_reference="egisDB_reference_2023_0214.dump"
-egisDB_aep_fim="egisDB_aep_fim_2023_0214.dump"
-egisDB_fim_catchments="egisDB_fim_catchments_2023_0214.dump"
+egisDB_reference="egisDB_reference_2023_0406.dump"
+egisDB_aep_fim="egisDB_aep_fim_2023_0406.dump"
+egisDB_fim_catchments="egisDB_fim_catchments_2023_0406.dump"
 
 vizDB_admin="vizDB_admin_2023_0214.dump"
 vizDB_archive="vizDB_archive_2023_0214.dump"
 vizDB_cache="vizDB_cache_2023_0214.dump"
-vizDB_derived="vizDB_derived_2023_0214.dump"
+vizDB_derived="vizDB_derived_2023_0406.dump"
 vizDB_ingest="vizDB_ingest_2023_0214.dump"
 vizDB_publish="vizDB_publish_2023_0214.dump"
 vizDB_external="vizDB_external_2023_0214.dump"

--- a/Core/VIZ/EC2/code/VIZCHANGELOG.md
+++ b/Core/VIZ/EC2/code/VIZCHANGELOG.md
@@ -7,8 +7,11 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 This merge activates the 1ft intervals for Stage-Based CatFIM. Intervals begin at Action stage and increment by 1 ft until the Major stage + 5ft is reached. Sublayers are created for each category. Each category has an intervals layer and the threshold layer.
 
+Also includes a minor update to all inundation map services, to limit the scale of drawing, in order to improve render performance.
+
 ## Changes
 - `/hydrovis/Core/VIZ/EC2/code/aws_loos/pro_projects/db_pipeline/stage_based_catfim.mapx`
+- `/hydrovis/Core/VIZ/EC2/code/aws_loos/pro_projects/db_pipeline/<service>_inundation.mapx`
 
 <br/><br/>
 

--- a/Core/VIZ/EC2/code/VIZCHANGELOG.md
+++ b/Core/VIZ/EC2/code/VIZCHANGELOG.md
@@ -3,6 +3,15 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 <br/><br/>
 
+## v3.2.0 - 2023-4-5 - [PR #403](https://github.com/NOAA-OWP/hydrovis/pull/403)
+
+This merge activates the 1ft intervals for Stage-Based CatFIM. Intervals begin at Action stage and increment by 1 ft until the Major stage + 5ft is reached. Sublayers are created for each category. Each category has an intervals layer and the threshold layer.
+
+## Changes
+- `/hydrovis/Core/VIZ/EC2/code/aws_loos/pro_projects/db_pipeline/stage_based_catfim.mapx`
+
+<br/><br/>
+
 
 ## v3.1.0 - 2023-3-30 - [PR #371](https://github.com/NOAA-OWP/hydrovis/pull/371)
 

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_inundation.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_inundation.mapx
@@ -92,9 +92,9 @@
       }
     ],
     "defaultExtent" : {
-      "xmin" : -15250772.0291557685,
-      "ymin" : 1474107.38979748311,
-      "xmax" : -5851112.10396996513,
+      "xmin" : -16791651.2146173716,
+      "ymin" : 1474107.38979748264,
+      "xmax" : -4310232.918508362,
       "ymax" : 8534243.619137926,
       "spatialReference" : {
         "wkid" : 102100,
@@ -200,6 +200,10 @@
       {
         "type" : "CIMScale",
         "value" : 100000
+      },
+      {
+        "type" : "CIMScale",
+        "value" : 400000
       },
       {
         "type" : "CIMScale",
@@ -5873,6 +5877,7 @@
       },
       "expanded" : true,
       "layerType" : "Operational",
+      "minScale" : 400000,
       "showLegends" : true,
       "visibility" : true,
       "displayCacheType" : "Permanent",

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_inundation_hi.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_inundation_hi.mapx
@@ -203,6 +203,10 @@
       },
       {
         "type" : "CIMScale",
+        "value" : 400000
+      },
+      {
+        "type" : "CIMScale",
         "value" : 500000
       },
       {
@@ -3399,6 +3403,7 @@
       },
       "expanded" : true,
       "layerType" : "Operational",
+      "minScale" : 400000,
       "showLegends" : true,
       "visibility" : true,
       "displayCacheType" : "Permanent",

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_inundation_prvi.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_inundation_prvi.mapx
@@ -203,6 +203,10 @@
       },
       {
         "type" : "CIMScale",
+        "value" : 400000
+      },
+      {
+        "type" : "CIMScale",
         "value" : 500000
       },
       {
@@ -3400,6 +3404,7 @@
       },
       "expanded" : true,
       "layerType" : "Operational",
+      "minScale" : 400000,
       "showLegends" : true,
       "visibility" : true,
       "displayCacheType" : "Permanent",

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_past_14day_max_inundation.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_past_14day_max_inundation.mapx
@@ -203,6 +203,10 @@
       },
       {
         "type" : "CIMScale",
+        "value" : 400000
+      },
+      {
+        "type" : "CIMScale",
         "value" : 500000
       },
       {
@@ -5879,6 +5883,7 @@
       },
       "expanded" : true,
       "layerType" : "Operational",
+      "minScale" : 400000,
       "showLegends" : true,
       "visibility" : false,
       "displayCacheType" : "Permanent",
@@ -12156,6 +12161,7 @@
       },
       "expanded" : true,
       "layerType" : "Operational",
+      "minScale" : 400000,
       "showLegends" : true,
       "visibility" : true,
       "displayCacheType" : "Permanent",

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/mrf_max_inundation.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/mrf_max_inundation.mapx
@@ -204,6 +204,10 @@
       },
       {
         "type" : "CIMScale",
+        "value" : 400000
+      },
+      {
+        "type" : "CIMScale",
         "value" : 500000
       },
       {
@@ -5872,6 +5876,7 @@
         "mapElevationID" : "{84F61CAA-CD53-4C26-BBF2-C7F7CA71C354}"
       },
       "layerType" : "Operational",
+      "minScale" : 400000,
       "showLegends" : true,
       "visibility" : false,
       "displayCacheType" : "Permanent",
@@ -12128,6 +12133,7 @@
         "mapElevationID" : "{84F61CAA-CD53-4C26-BBF2-C7F7CA71C354}"
       },
       "layerType" : "Operational",
+      "minScale" : 400000,
       "showLegends" : true,
       "visibility" : false,
       "displayCacheType" : "Permanent",
@@ -18385,6 +18391,7 @@
         "mapElevationID" : "{84F61CAA-CD53-4C26-BBF2-C7F7CA71C354}"
       },
       "layerType" : "Operational",
+      "minScale" : 400000,
       "showLegends" : true,
       "visibility" : true,
       "displayCacheType" : "Permanent",

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/rfc_5day_max_downstream_inundation.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/rfc_5day_max_downstream_inundation.mapx
@@ -203,6 +203,10 @@
       },
       {
         "type" : "CIMScale",
+        "value" : 400000
+      },
+      {
+        "type" : "CIMScale",
         "value" : 500000
       },
       {
@@ -5882,6 +5886,7 @@
       },
       "expanded" : true,
       "layerType" : "Operational",
+      "minScale" : 400000,
       "showLegends" : true,
       "visibility" : true,
       "displayCacheType" : "Permanent",

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/srf_max_inundation.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/srf_max_inundation.mapx
@@ -203,6 +203,10 @@
       },
       {
         "type" : "CIMScale",
+        "value" : 400000
+      },
+      {
+        "type" : "CIMScale",
         "value" : 500000
       },
       {
@@ -5875,6 +5879,7 @@
       },
       "expanded" : true,
       "layerType" : "Operational",
+      "minScale" : 400000,
       "showLegends" : true,
       "visibility" : true,
       "displayCacheType" : "Permanent",

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/srf_max_inundation_hi.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/srf_max_inundation_hi.mapx
@@ -203,6 +203,10 @@
       },
       {
         "type" : "CIMScale",
+        "value" : 400000
+      },
+      {
+        "type" : "CIMScale",
         "value" : 500000
       },
       {
@@ -3400,6 +3404,7 @@
       },
       "expanded" : true,
       "layerType" : "Operational",
+      "minScale" : 400000,
       "showLegends" : true,
       "visibility" : true,
       "displayCacheType" : "Permanent",

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/srf_max_inundation_prvi.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/srf_max_inundation_prvi.mapx
@@ -203,6 +203,10 @@
       },
       {
         "type" : "CIMScale",
+        "value" : 400000
+      },
+      {
+        "type" : "CIMScale",
         "value" : 500000
       },
       {
@@ -3400,6 +3404,7 @@
       },
       "expanded" : true,
       "layerType" : "Operational",
+      "minScale" : 400000,
       "showLegends" : true,
       "visibility" : true,
       "displayCacheType" : "Permanent",

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/stage_based_catfim.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/stage_based_catfim.mapx
@@ -26,20 +26,19 @@
     },
     "layers" : [
       "CIMPATH=map/hydrovis_reference_nws_flood_categorical_hand_fim_sites.xml",
-      "CIMPATH=map/stage_based_catfim__action.xml",
-      "CIMPATH=map/stage_based_catfim4.xml",
-      "CIMPATH=map/stage_based_catfim3.xml",
-      "CIMPATH=map/stage_based_catfim2.xml",
-      "CIMPATH=map/stage_based_catfim.xml",
+      "CIMPATH=map/new_group_layer.xml",
+      "CIMPATH=map/new_group_layer2.xml",
+      "CIMPATH=map/new_group_layer3.xml",
+      "CIMPATH=map/new_group_layer4.xml",
       "CIMPATH=map/hydrovis_reference_nws_flood_categorical_hand_fim.xml"
     ],
     "defaultViewingMode" : "Map",
     "mapType" : "Map",
     "defaultExtent" : {
-      "xmin" : -12620435.75982672,
-      "ymin" : 5177987.40641214326,
-      "xmax" : -10692420.8154191747,
-      "ymax" : 6539592.43051562831,
+      "xmin" : -10042414.0540662669,
+      "ymin" : 3795213.49250532547,
+      "xmax" : -10037550.6777432077,
+      "ymax" : 3797622.76879439736,
       "spatialReference" : {
         "wkid" : 102100,
         "latestWkid" : 3857
@@ -1673,7 +1672,7 @@
     {
       "type" : "CIMFeatureLayer",
       "name" : "Stage-Based CatFIM: 1ft Intervals",
-      "uRI" : "CIMPATH=map/stage_based_catfim__action.xml",
+      "uRI" : "CIMPATH=map/stage_based_catfim__1ft_intervals.xml",
       "sourceModifiedTime" : {
         "type" : "TimeInstant",
         "start" : 978307200000
@@ -1689,6 +1688,7 @@
       "layerType" : "Operational",
       "minScale" : 82589.936619314918,
       "showLegends" : true,
+      "transparency" : 50,
       "visibility" : true,
       "displayCacheType" : "Permanent",
       "maxDisplayCacheAge" : 5,
@@ -1708,6 +1708,11 @@
             "type" : "CIMDefinitionFilter",
             "name" : "Query 1",
             "definitionExpression" : "interval_stage <> 0"
+          },
+          {
+            "type" : "CIMDefinitionFilter",
+            "name" : "Query 2",
+            "definitionExpression" : "magnitude = 'action'"
           }
         ],
         "displayField" : "name",
@@ -2199,9 +2204,23 @@
         }
       ],
       "renderer" : {
-        "type" : "CIMSimpleRenderer",
-        "patch" : "Default",
-        "symbol" : {
+        "type" : "CIMUniqueValueRenderer",
+        "colorRamp" : {
+          "type" : "CIMRandomHSVColorRamp",
+          "colorSpace" : {
+            "type" : "CIMICCColorSpace",
+            "url" : "Default RGB"
+          },
+          "maxH" : 360,
+          "minS" : 15,
+          "maxS" : 30,
+          "minV" : 99,
+          "maxV" : 100,
+          "minAlpha" : 100,
+          "maxAlpha" : 100
+        },
+        "defaultLabel" : "<all other values>",
+        "defaultSymbol" : {
           "type" : "CIMSymbolReference",
           "symbol" : {
             "type" : "CIMPolygonSymbol",
@@ -2213,13 +2232,13 @@
                 "joinStyle" : "Round",
                 "lineStyle3D" : "Strip",
                 "miterLimit" : 10,
-                "width" : 0.5,
+                "width" : 0.69999999999999996,
                 "color" : {
                   "type" : "CIMRGBColor",
                   "values" : [
-                    130,
-                    130,
-                    130,
+                    110,
+                    110,
+                    110,
                     100
                   ]
                 }
@@ -2233,13 +2252,79 @@
                     130,
                     130,
                     130,
-                    0
+                    100
                   ]
                 }
               }
             ]
           }
-        }
+        },
+        "defaultSymbolPatch" : "Default",
+        "fields" : [
+          "magnitude"
+        ],
+        "groups" : [
+          {
+            "type" : "CIMUniqueValueGroup",
+            "classes" : [
+              {
+                "type" : "CIMUniqueValueClass",
+                "label" : "Action 1ft Intervals",
+                "patch" : "Default",
+                "symbol" : {
+                  "type" : "CIMSymbolReference",
+                  "symbol" : {
+                    "type" : "CIMPolygonSymbol",
+                    "symbolLayers" : [
+                      {
+                        "type" : "CIMSolidStroke",
+                        "enable" : true,
+                        "capStyle" : "Round",
+                        "joinStyle" : "Round",
+                        "lineStyle3D" : "Strip",
+                        "miterLimit" : 10,
+                        "width" : 0.69999999999999996,
+                        "color" : {
+                          "type" : "CIMRGBColor",
+                          "values" : [
+                            255,
+                            255,
+                            0,
+                            100
+                          ]
+                        }
+                      },
+                      {
+                        "type" : "CIMSolidFill",
+                        "enable" : true,
+                        "color" : {
+                          "type" : "CIMRGBColor",
+                          "values" : [
+                            255,
+                            255,
+                            0,
+                            0
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                },
+                "values" : [
+                  {
+                    "type" : "CIMUniqueValue",
+                    "fieldValues" : [
+                      "action"
+                    ]
+                  }
+                ],
+                "visible" : true
+              }
+            ],
+            "heading" : "Magnitude"
+          }
+        ],
+        "polygonSymbolColorTarget" : "Fill"
       },
       "scaleSymbols" : true,
       "snappable" : true,
@@ -2249,7 +2334,7 @@
     },
     {
       "type" : "CIMFeatureLayer",
-      "name" : "Stage-Based CatFIM: Action",
+      "name" : "Stage-Based CatFIM: Action Threshold",
       "uRI" : "CIMPATH=map/stage_based_catfim4.xml",
       "sourceModifiedTime" : {
         "type" : "TimeInstant",
@@ -2924,8 +3009,693 @@
       }
     },
     {
+      "type" : "CIMGroupLayer",
+      "name" : "Stage-Based CatFIM: Action",
+      "uRI" : "CIMPATH=map/new_group_layer.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant"
+      },
+      "metadataURI" : "CIMPATH=Metadata/b22945b8486342a73c9cc385edb3ef2c.xml",
+      "useSourceMetadata" : true,
+      "description" : "New Group Layer",
+      "layerElevation" : {
+        "type" : "CIMLayerElevationSurface",
+        "mapElevationID" : "{2040A0DA-3625-405D-8B32-E14FA806A248}"
+      },
+      "layerType" : "Operational",
+      "showLegends" : true,
+      "visibility" : true,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "layers" : [
+        "CIMPATH=map/stage_based_catfim__1ft_intervals.xml",
+        "CIMPATH=map/stage_based_catfim4.xml"
+      ]
+    },
+    {
       "type" : "CIMFeatureLayer",
-      "name" : "Stage-Based CatFIM: Minor",
+      "name" : "Stage-Based CatFIM: 1ft Intervals",
+      "uRI" : "CIMPATH=map/stage_based_catfim__action.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant",
+        "start" : 978307200000
+      },
+      "metadataURI" : "CIMPATH=Metadata/2daef7e5de38aaa23c7db4cfd117aca3.xml",
+      "useSourceMetadata" : true,
+      "description" : "hydrovis.reference.nws_flood_categorical_hand_fim",
+      "layerElevation" : {
+        "type" : "CIMLayerElevationSurface",
+        "mapElevationID" : "{2040A0DA-3625-405D-8B32-E14FA806A248}"
+      },
+      "expanded" : true,
+      "layerType" : "Operational",
+      "minScale" : 82589.936619314918,
+      "showLegends" : true,
+      "visibility" : true,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "autoGenerateFeatureTemplates" : true,
+      "featureElevationExpression" : "0",
+      "featureTable" : {
+        "type" : "CIMFeatureTable",
+        "definitionExpression" : "interval_stage <> 0",
+        "definitionExpressionName" : "Query 1",
+        "definitionFilterChoices" : [
+          {
+            "type" : "CIMDefinitionFilter",
+            "name" : "Query 1",
+            "definitionExpression" : "interval_stage <> 0"
+          }
+        ],
+        "displayField" : "name",
+        "editable" : true,
+        "fieldDescriptions" : [
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "oid",
+            "fieldName" : "oid",
+            "numberFormat" : {
+              "type" : "CIMNumericFormat",
+              "alignmentOption" : "esriAlignRight",
+              "alignmentWidth" : 0,
+              "roundingOption" : "esriRoundNumberOfDecimals",
+              "roundingValue" : 0
+            },
+            "readOnly" : true,
+            "visible" : false,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "NWS LID",
+            "fieldName" : "ahps_lid",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Name",
+            "fieldName" : "name",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "USGS HUC8",
+            "fieldName" : "huc8",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "WFO",
+            "fieldName" : "wfo",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "RFC",
+            "fieldName" : "rfc",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "State",
+            "fieldName" : "state",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "County",
+            "fieldName" : "county",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "FIM Version",
+            "fieldName" : "version",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Magnitude",
+            "fieldName" : "magnitude",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Stage",
+            "fieldName" : "interval_stage",
+            "numberFormat" : {
+              "type" : "CIMNumericFormat",
+              "alignmentOption" : "esriAlignRight",
+              "alignmentWidth" : 0,
+              "roundingOption" : "esriRoundNumberOfSignificantDigits",
+              "roundingValue" : 2
+            },
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Stage",
+            "fieldName" : "stage",
+            "numberFormat" : {
+              "type" : "CIMNumericFormat",
+              "alignmentOption" : "esriAlignRight",
+              "alignmentWidth" : 0,
+              "roundingOption" : "esriRoundNumberOfSignificantDigits",
+              "roundingValue" : 2
+            },
+            "visible" : false,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Stage Units",
+            "fieldName" : "stage_uni",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Stage Source",
+            "fieldName" : "s_src",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Viz",
+            "fieldName" : "viz",
+            "visible" : false,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "geom",
+            "fieldName" : "geom",
+            "visible" : false,
+            "searchMode" : "Exact"
+          }
+        ],
+        "dataConnection" : {
+          "type" : "CIMSqlQueryDataConnection",
+          "workspaceConnectionString" : "ENCRYPTED_PASSWORD=00022e6879663255762b434e664e5a785855566c644d746b6f6c7a4d54515449774d564d504b6974473670574e43453d2a00;SERVER=hv-ti-egis-rds-pg-egdb.c4vzypepnkx3.us-east-1.rds.amazonaws.com;INSTANCE=sde:postgresql:hv-ti-egis-rds-pg-egdb.c4vzypepnkx3.us-east-1.rds.amazonaws.com;DBCLIENT=postgresql;DB_CONNECTION_PROPERTIES=hv-ti-egis-rds-pg-egdb.c4vzypepnkx3.us-east-1.rds.amazonaws.com;DATABASE=hydrovis;USER=hydrovis;AUTHENTICATION_MODE=DBMS",
+          "workspaceFactory" : "SDE",
+          "dataset" : "hydrovis.reference.%nws_flood_categorical_hand_fim_1_3_3",
+          "datasetType" : "esriDTFeatureClass",
+          "sqlQuery" : "select oid,ahps_lid,magnitude,version,huc8,interval_stage,name,wfo,rfc,state,county,stage,stage_uni,s_src,viz,geom from hydrovis.reference.stage_based_catfim",
+          "srid" : "3857",
+          "spatialReference" : {
+            "wkid" : 102100,
+            "latestWkid" : 3857
+          },
+          "oIDFields" : "oid",
+          "geometryType" : "esriGeometryPolygon",
+          "extent" : {
+            "xmin" : -20037700,
+            "ymin" : -30241100,
+            "xmax" : 900699887774.099,
+            "ymax" : 900689684374.099,
+            "spatialReference" : {
+              "wkid" : 102100,
+              "latestWkid" : 3857
+            }
+          },
+          "queryFields" : [
+            {
+              "name" : "oid",
+              "type" : "esriFieldTypeInteger",
+              "alias" : "oid"
+            },
+            {
+              "name" : "ahps_lid",
+              "type" : "esriFieldTypeString",
+              "alias" : "ahps_lid",
+              "length" : 60000
+            },
+            {
+              "name" : "magnitude",
+              "type" : "esriFieldTypeString",
+              "alias" : "magnitude",
+              "length" : 60000
+            },
+            {
+              "name" : "version",
+              "type" : "esriFieldTypeString",
+              "alias" : "version",
+              "length" : 60000
+            },
+            {
+              "name" : "huc8",
+              "type" : "esriFieldTypeString",
+              "alias" : "huc8",
+              "length" : 60000
+            },
+            {
+              "name" : "interval_stage",
+              "type" : "esriFieldTypeDouble",
+              "alias" : "interval_stage"
+            },
+            {
+              "name" : "name",
+              "type" : "esriFieldTypeString",
+              "alias" : "name",
+              "length" : 60000
+            },
+            {
+              "name" : "wfo",
+              "type" : "esriFieldTypeString",
+              "alias" : "wfo",
+              "length" : 60000
+            },
+            {
+              "name" : "rfc",
+              "type" : "esriFieldTypeString",
+              "alias" : "rfc",
+              "length" : 60000
+            },
+            {
+              "name" : "state",
+              "type" : "esriFieldTypeString",
+              "alias" : "state",
+              "length" : 60000
+            },
+            {
+              "name" : "county",
+              "type" : "esriFieldTypeString",
+              "alias" : "county",
+              "length" : 60000
+            },
+            {
+              "name" : "stage",
+              "type" : "esriFieldTypeDouble",
+              "alias" : "stage"
+            },
+            {
+              "name" : "stage_uni",
+              "type" : "esriFieldTypeString",
+              "alias" : "stage_uni",
+              "length" : 60000
+            },
+            {
+              "name" : "s_src",
+              "type" : "esriFieldTypeString",
+              "alias" : "s_src",
+              "length" : 60000
+            },
+            {
+              "name" : "viz",
+              "type" : "esriFieldTypeString",
+              "alias" : "viz",
+              "length" : 60000
+            },
+            {
+              "name" : "geom",
+              "type" : "esriFieldTypeGeometry",
+              "alias" : "geom",
+              "geometryDef" : {
+                "avgNumPoints" : 0,
+                "geometryType" : "esriGeometryPolygon",
+                "hasM" : false,
+                "hasZ" : false,
+                "spatialReference" : {
+                  "wkid" : 102100,
+                  "latestWkid" : 3857
+                }
+              }
+            }
+          ],
+          "spatialStorageType" : 8
+        },
+        "studyAreaSpatialRel" : "esriSpatialRelUndefined",
+        "searchOrder" : "esriSearchOrderSpatial"
+      },
+      "htmlPopupEnabled" : true,
+      "selectable" : true,
+      "featureCacheType" : "Session",
+      "displayFiltersType" : "ByScale",
+      "featureBlendingMode" : "Alpha",
+      "labelClasses" : [
+        {
+          "type" : "CIMLabelClass",
+          "expression" : "$feature.name",
+          "expressionEngine" : "Arcade",
+          "featuresToLabel" : "AllVisibleFeatures",
+          "maplexLabelPlacementProperties" : {
+            "type" : "CIMMaplexLabelPlacementProperties",
+            "featureType" : "Polygon",
+            "avoidPolygonHoles" : true,
+            "canOverrunFeature" : true,
+            "canPlaceLabelOutsidePolygon" : true,
+            "canRemoveOverlappingLabel" : true,
+            "canStackLabel" : true,
+            "connectionType" : "Unambiguous",
+            "constrainOffset" : "NoConstraint",
+            "contourAlignmentType" : "Page",
+            "contourLadderType" : "Straight",
+            "contourMaximumAngle" : 90,
+            "enableConnection" : true,
+            "featureWeight" : 0,
+            "fontHeightReductionLimit" : 4,
+            "fontHeightReductionStep" : 0.5,
+            "fontWidthReductionLimit" : 90,
+            "fontWidthReductionStep" : 5,
+            "graticuleAlignmentType" : "Straight",
+            "keyNumberGroupName" : "Default",
+            "labelBuffer" : 15,
+            "labelLargestPolygon" : true,
+            "labelPriority" : -1,
+            "labelStackingProperties" : {
+              "type" : "CIMMaplexLabelStackingProperties",
+              "stackAlignment" : "ChooseBest",
+              "maximumNumberOfLines" : 3,
+              "minimumNumberOfCharsPerLine" : 3,
+              "maximumNumberOfCharsPerLine" : 24,
+              "separators" : [
+                {
+                  "type" : "CIMMaplexStackingSeparator",
+                  "separator" : " ",
+                  "splitAfter" : true
+                },
+                {
+                  "type" : "CIMMaplexStackingSeparator",
+                  "separator" : ",",
+                  "visible" : true,
+                  "splitAfter" : true
+                }
+              ]
+            },
+            "lineFeatureType" : "General",
+            "linePlacementMethod" : "OffsetCurvedFromLine",
+            "maximumLabelOverrun" : 80,
+            "maximumLabelOverrunUnit" : "Point",
+            "minimumFeatureSizeUnit" : "Map",
+            "multiPartOption" : "OneLabelPerPart",
+            "offsetAlongLineProperties" : {
+              "type" : "CIMMaplexOffsetAlongLineProperties",
+              "placementMethod" : "BestPositionAlongLine",
+              "labelAnchorPoint" : "CenterOfLabel",
+              "distanceUnit" : "Percentage",
+              "useLineDirection" : true
+            },
+            "pointExternalZonePriorities" : {
+              "type" : "CIMMaplexExternalZonePriorities",
+              "aboveLeft" : 4,
+              "aboveCenter" : 2,
+              "aboveRight" : 1,
+              "centerRight" : 3,
+              "belowRight" : 5,
+              "belowCenter" : 7,
+              "belowLeft" : 8,
+              "centerLeft" : 6
+            },
+            "pointPlacementMethod" : "AroundPoint",
+            "polygonAnchorPointType" : "GeometricCenter",
+            "polygonBoundaryWeight" : 0,
+            "polygonExternalZones" : {
+              "type" : "CIMMaplexExternalZonePriorities",
+              "aboveLeft" : 4,
+              "aboveCenter" : 2,
+              "aboveRight" : 1,
+              "centerRight" : 3,
+              "belowRight" : 5,
+              "belowCenter" : 7,
+              "belowLeft" : 8,
+              "centerLeft" : 6
+            },
+            "polygonFeatureType" : "General",
+            "polygonInternalZones" : {
+              "type" : "CIMMaplexInternalZonePriorities",
+              "center" : 1
+            },
+            "polygonPlacementMethod" : "HorizontalInPolygon",
+            "primaryOffset" : 1,
+            "primaryOffsetUnit" : "Point",
+            "removeExtraWhiteSpace" : true,
+            "repetitionIntervalUnit" : "Point",
+            "rotationProperties" : {
+              "type" : "CIMMaplexRotationProperties",
+              "rotationType" : "Arithmetic",
+              "alignmentType" : "Straight"
+            },
+            "secondaryOffset" : 100,
+            "strategyPriorities" : {
+              "type" : "CIMMaplexStrategyPriorities",
+              "stacking" : 1,
+              "overrun" : 2,
+              "fontCompression" : 3,
+              "fontReduction" : 4,
+              "abbreviation" : 5
+            },
+            "thinningDistanceUnit" : "Point",
+            "truncationMarkerCharacter" : ".",
+            "truncationMinimumLength" : 1,
+            "truncationPreferredCharacters" : "aeiou",
+            "truncationExcludedCharacters" : "0123456789",
+            "polygonAnchorPointPerimeterInsetUnit" : "Point"
+          },
+          "name" : "Class 1",
+          "priority" : -1,
+          "standardLabelPlacementProperties" : {
+            "type" : "CIMStandardLabelPlacementProperties",
+            "featureType" : "Line",
+            "featureWeight" : "None",
+            "labelWeight" : "High",
+            "numLabelsOption" : "OneLabelPerName",
+            "lineLabelPosition" : {
+              "type" : "CIMStandardLineLabelPosition",
+              "above" : true,
+              "inLine" : true,
+              "parallel" : true
+            },
+            "lineLabelPriorities" : {
+              "type" : "CIMStandardLineLabelPriorities",
+              "aboveStart" : 3,
+              "aboveAlong" : 3,
+              "aboveEnd" : 3,
+              "centerStart" : 3,
+              "centerAlong" : 3,
+              "centerEnd" : 3,
+              "belowStart" : 3,
+              "belowAlong" : 3,
+              "belowEnd" : 3
+            },
+            "pointPlacementMethod" : "AroundPoint",
+            "pointPlacementPriorities" : {
+              "type" : "CIMStandardPointPlacementPriorities",
+              "aboveLeft" : 2,
+              "aboveCenter" : 2,
+              "aboveRight" : 1,
+              "centerLeft" : 3,
+              "centerRight" : 2,
+              "belowLeft" : 3,
+              "belowCenter" : 3,
+              "belowRight" : 2
+            },
+            "rotationType" : "Arithmetic",
+            "polygonPlacementMethod" : "AlwaysHorizontal"
+          },
+          "textSymbol" : {
+            "type" : "CIMSymbolReference",
+            "symbol" : {
+              "type" : "CIMTextSymbol",
+              "blockProgression" : "TTB",
+              "depth3D" : 1,
+              "extrapolateBaselines" : true,
+              "fontEffects" : "Normal",
+              "fontEncoding" : "Unicode",
+              "fontFamilyName" : "Tahoma",
+              "fontStyleName" : "Regular",
+              "fontType" : "Unspecified",
+              "haloSize" : 1,
+              "height" : 10,
+              "hinting" : "Default",
+              "horizontalAlignment" : "Left",
+              "kerning" : true,
+              "letterWidth" : 100,
+              "ligatures" : true,
+              "lineGapType" : "ExtraLeading",
+              "symbol" : {
+                "type" : "CIMPolygonSymbol",
+                "symbolLayers" : [
+                  {
+                    "type" : "CIMSolidFill",
+                    "enable" : true,
+                    "color" : {
+                      "type" : "CIMRGBColor",
+                      "values" : [
+                        0,
+                        0,
+                        0,
+                        100
+                      ]
+                    }
+                  }
+                ]
+              },
+              "textCase" : "Normal",
+              "textDirection" : "LTR",
+              "verticalAlignment" : "Bottom",
+              "verticalGlyphOrientation" : "Right",
+              "wordSpacing" : 100,
+              "billboardMode3D" : "FaceNearPlane"
+            }
+          },
+          "useCodedValue" : true,
+          "visibility" : true,
+          "iD" : -1
+        }
+      ],
+      "renderer" : {
+        "type" : "CIMUniqueValueRenderer",
+        "colorRamp" : {
+          "type" : "CIMRandomHSVColorRamp",
+          "colorSpace" : {
+            "type" : "CIMICCColorSpace",
+            "url" : "Default RGB"
+          },
+          "maxH" : 360,
+          "minS" : 15,
+          "maxS" : 30,
+          "minV" : 99,
+          "maxV" : 100,
+          "minAlpha" : 100,
+          "maxAlpha" : 100
+        },
+        "defaultLabel" : "<all other values>",
+        "defaultSymbol" : {
+          "type" : "CIMSymbolReference",
+          "symbol" : {
+            "type" : "CIMPolygonSymbol",
+            "symbolLayers" : [
+              {
+                "type" : "CIMSolidStroke",
+                "enable" : true,
+                "capStyle" : "Round",
+                "joinStyle" : "Round",
+                "lineStyle3D" : "Strip",
+                "miterLimit" : 10,
+                "width" : 0.69999999999999996,
+                "color" : {
+                  "type" : "CIMRGBColor",
+                  "values" : [
+                    110,
+                    110,
+                    110,
+                    100
+                  ]
+                }
+              },
+              {
+                "type" : "CIMSolidFill",
+                "enable" : true,
+                "color" : {
+                  "type" : "CIMRGBColor",
+                  "values" : [
+                    130,
+                    130,
+                    130,
+                    100
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "defaultSymbolPatch" : "Default",
+        "fields" : [
+          "magnitude"
+        ],
+        "groups" : [
+          {
+            "type" : "CIMUniqueValueGroup",
+            "classes" : [
+              {
+                "type" : "CIMUniqueValueClass",
+                "label" : "Minor 1ft Intervals",
+                "patch" : "Default",
+                "symbol" : {
+                  "type" : "CIMSymbolReference",
+                  "symbol" : {
+                    "type" : "CIMPolygonSymbol",
+                    "symbolLayers" : [
+                      {
+                        "type" : "CIMSolidStroke",
+                        "enable" : true,
+                        "capStyle" : "Round",
+                        "joinStyle" : "Round",
+                        "lineStyle3D" : "Strip",
+                        "miterLimit" : 10,
+                        "width" : 0.69999999999999996,
+                        "color" : {
+                          "type" : "CIMRGBColor",
+                          "values" : [
+                            255,
+                            170,
+                            0,
+                            100
+                          ]
+                        }
+                      },
+                      {
+                        "type" : "CIMSolidFill",
+                        "enable" : true,
+                        "color" : {
+                          "type" : "CIMRGBColor",
+                          "values" : [
+                            255,
+                            170,
+                            0,
+                            0
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                },
+                "values" : [
+                  {
+                    "type" : "CIMUniqueValue",
+                    "fieldValues" : [
+                      "minor"
+                    ]
+                  }
+                ],
+                "visible" : true
+              }
+            ],
+            "heading" : "Magnitude"
+          }
+        ],
+        "polygonSymbolColorTarget" : "Fill"
+      },
+      "scaleSymbols" : true,
+      "snappable" : true,
+      "symbolLayerDrawing" : {
+        "type" : "CIMSymbolLayerDrawing"
+      }
+    },
+    {
+      "type" : "CIMFeatureLayer",
+      "name" : "Stage-Based CatFIM: Minor Threshold",
       "uRI" : "CIMPATH=map/stage_based_catfim3.xml",
       "sourceModifiedTime" : {
         "type" : "TimeInstant",
@@ -3600,8 +4370,694 @@
       }
     },
     {
+      "type" : "CIMGroupLayer",
+      "name" : "Stage-Based CatFIM: Minor",
+      "uRI" : "CIMPATH=map/new_group_layer2.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant"
+      },
+      "metadataURI" : "CIMPATH=Metadata/7fa0b861c006c1e089b64f9cf7b3e45b.xml",
+      "useSourceMetadata" : true,
+      "description" : "New Group Layer",
+      "layerElevation" : {
+        "type" : "CIMLayerElevationSurface",
+        "mapElevationID" : "{2040A0DA-3625-405D-8B32-E14FA806A248}"
+      },
+      "layerType" : "Operational",
+      "showLegends" : true,
+      "visibility" : true,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "layers" : [
+        "CIMPATH=map/stage_based_catfim__action.xml",
+        "CIMPATH=map/stage_based_catfim3.xml"
+      ]
+    },
+    {
       "type" : "CIMFeatureLayer",
-      "name" : "Stage-Based CatFIM: Moderate",
+      "name" : "Stage-Based CatFIM: 1ft Intervals",
+      "uRI" : "CIMPATH=map/stage_based_catfim__1ft_intervals4.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant",
+        "start" : 978307200000
+      },
+      "metadataURI" : "CIMPATH=Metadata/2daef7e5de38aaa23c7db4cfd117aca3.xml",
+      "useSourceMetadata" : true,
+      "description" : "hydrovis.reference.nws_flood_categorical_hand_fim",
+      "layerElevation" : {
+        "type" : "CIMLayerElevationSurface",
+        "mapElevationID" : "{2040A0DA-3625-405D-8B32-E14FA806A248}"
+      },
+      "expanded" : true,
+      "layerType" : "Operational",
+      "minScale" : 82589.936619314918,
+      "showLegends" : true,
+      "visibility" : true,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "autoGenerateFeatureTemplates" : true,
+      "featureElevationExpression" : "0",
+      "featureTable" : {
+        "type" : "CIMFeatureTable",
+        "definitionExpression" : "interval_stage <> 0",
+        "definitionExpressionName" : "Query 1",
+        "definitionFilterChoices" : [
+          {
+            "type" : "CIMDefinitionFilter",
+            "name" : "Query 1",
+            "definitionExpression" : "interval_stage <> 0"
+          }
+        ],
+        "displayField" : "name",
+        "editable" : true,
+        "fieldDescriptions" : [
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "oid",
+            "fieldName" : "oid",
+            "numberFormat" : {
+              "type" : "CIMNumericFormat",
+              "alignmentOption" : "esriAlignRight",
+              "alignmentWidth" : 0,
+              "roundingOption" : "esriRoundNumberOfDecimals",
+              "roundingValue" : 0
+            },
+            "readOnly" : true,
+            "visible" : false,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "NWS LID",
+            "fieldName" : "ahps_lid",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Name",
+            "fieldName" : "name",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "USGS HUC8",
+            "fieldName" : "huc8",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "WFO",
+            "fieldName" : "wfo",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "RFC",
+            "fieldName" : "rfc",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "State",
+            "fieldName" : "state",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "County",
+            "fieldName" : "county",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "FIM Version",
+            "fieldName" : "version",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Magnitude",
+            "fieldName" : "magnitude",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Stage",
+            "fieldName" : "interval_stage",
+            "numberFormat" : {
+              "type" : "CIMNumericFormat",
+              "alignmentOption" : "esriAlignRight",
+              "alignmentWidth" : 0,
+              "roundingOption" : "esriRoundNumberOfSignificantDigits",
+              "roundingValue" : 2
+            },
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Stage",
+            "fieldName" : "stage",
+            "numberFormat" : {
+              "type" : "CIMNumericFormat",
+              "alignmentOption" : "esriAlignRight",
+              "alignmentWidth" : 0,
+              "roundingOption" : "esriRoundNumberOfSignificantDigits",
+              "roundingValue" : 2
+            },
+            "visible" : false,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Stage Units",
+            "fieldName" : "stage_uni",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Stage Source",
+            "fieldName" : "s_src",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Viz",
+            "fieldName" : "viz",
+            "visible" : false,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "geom",
+            "fieldName" : "geom",
+            "visible" : false,
+            "searchMode" : "Exact"
+          }
+        ],
+        "selectionSetURI" : "CIMPATH=SelectionSet/56a46e6e95c1a603351043391bb018b6.dat",
+        "dataConnection" : {
+          "type" : "CIMSqlQueryDataConnection",
+          "workspaceConnectionString" : "ENCRYPTED_PASSWORD=00022e6879663255762b434e664e5a785855566c644d746b6f6c7a4d54515449774d564d504b6974473670574e43453d2a00;SERVER=hv-ti-egis-rds-pg-egdb.c4vzypepnkx3.us-east-1.rds.amazonaws.com;INSTANCE=sde:postgresql:hv-ti-egis-rds-pg-egdb.c4vzypepnkx3.us-east-1.rds.amazonaws.com;DBCLIENT=postgresql;DB_CONNECTION_PROPERTIES=hv-ti-egis-rds-pg-egdb.c4vzypepnkx3.us-east-1.rds.amazonaws.com;DATABASE=hydrovis;USER=hydrovis;AUTHENTICATION_MODE=DBMS",
+          "workspaceFactory" : "SDE",
+          "dataset" : "hydrovis.reference.%nws_flood_categorical_hand_fim_1_3_3",
+          "datasetType" : "esriDTFeatureClass",
+          "sqlQuery" : "select oid,ahps_lid,magnitude,version,huc8,interval_stage,name,wfo,rfc,state,county,stage,stage_uni,s_src,viz,geom from hydrovis.reference.stage_based_catfim",
+          "srid" : "3857",
+          "spatialReference" : {
+            "wkid" : 102100,
+            "latestWkid" : 3857
+          },
+          "oIDFields" : "oid",
+          "geometryType" : "esriGeometryPolygon",
+          "extent" : {
+            "xmin" : -20037700,
+            "ymin" : -30241100,
+            "xmax" : 900699887774.099,
+            "ymax" : 900689684374.099,
+            "spatialReference" : {
+              "wkid" : 102100,
+              "latestWkid" : 3857
+            }
+          },
+          "queryFields" : [
+            {
+              "name" : "oid",
+              "type" : "esriFieldTypeInteger",
+              "alias" : "oid"
+            },
+            {
+              "name" : "ahps_lid",
+              "type" : "esriFieldTypeString",
+              "alias" : "ahps_lid",
+              "length" : 60000
+            },
+            {
+              "name" : "magnitude",
+              "type" : "esriFieldTypeString",
+              "alias" : "magnitude",
+              "length" : 60000
+            },
+            {
+              "name" : "version",
+              "type" : "esriFieldTypeString",
+              "alias" : "version",
+              "length" : 60000
+            },
+            {
+              "name" : "huc8",
+              "type" : "esriFieldTypeString",
+              "alias" : "huc8",
+              "length" : 60000
+            },
+            {
+              "name" : "interval_stage",
+              "type" : "esriFieldTypeDouble",
+              "alias" : "interval_stage"
+            },
+            {
+              "name" : "name",
+              "type" : "esriFieldTypeString",
+              "alias" : "name",
+              "length" : 60000
+            },
+            {
+              "name" : "wfo",
+              "type" : "esriFieldTypeString",
+              "alias" : "wfo",
+              "length" : 60000
+            },
+            {
+              "name" : "rfc",
+              "type" : "esriFieldTypeString",
+              "alias" : "rfc",
+              "length" : 60000
+            },
+            {
+              "name" : "state",
+              "type" : "esriFieldTypeString",
+              "alias" : "state",
+              "length" : 60000
+            },
+            {
+              "name" : "county",
+              "type" : "esriFieldTypeString",
+              "alias" : "county",
+              "length" : 60000
+            },
+            {
+              "name" : "stage",
+              "type" : "esriFieldTypeDouble",
+              "alias" : "stage"
+            },
+            {
+              "name" : "stage_uni",
+              "type" : "esriFieldTypeString",
+              "alias" : "stage_uni",
+              "length" : 60000
+            },
+            {
+              "name" : "s_src",
+              "type" : "esriFieldTypeString",
+              "alias" : "s_src",
+              "length" : 60000
+            },
+            {
+              "name" : "viz",
+              "type" : "esriFieldTypeString",
+              "alias" : "viz",
+              "length" : 60000
+            },
+            {
+              "name" : "geom",
+              "type" : "esriFieldTypeGeometry",
+              "alias" : "geom",
+              "geometryDef" : {
+                "avgNumPoints" : 0,
+                "geometryType" : "esriGeometryPolygon",
+                "hasM" : false,
+                "hasZ" : false,
+                "spatialReference" : {
+                  "wkid" : 102100,
+                  "latestWkid" : 3857
+                }
+              }
+            }
+          ],
+          "spatialStorageType" : 8
+        },
+        "studyAreaSpatialRel" : "esriSpatialRelUndefined",
+        "searchOrder" : "esriSearchOrderSpatial"
+      },
+      "htmlPopupEnabled" : true,
+      "selectable" : true,
+      "featureCacheType" : "Session",
+      "displayFiltersType" : "ByScale",
+      "featureBlendingMode" : "Alpha",
+      "labelClasses" : [
+        {
+          "type" : "CIMLabelClass",
+          "expression" : "$feature.name",
+          "expressionEngine" : "Arcade",
+          "featuresToLabel" : "AllVisibleFeatures",
+          "maplexLabelPlacementProperties" : {
+            "type" : "CIMMaplexLabelPlacementProperties",
+            "featureType" : "Polygon",
+            "avoidPolygonHoles" : true,
+            "canOverrunFeature" : true,
+            "canPlaceLabelOutsidePolygon" : true,
+            "canRemoveOverlappingLabel" : true,
+            "canStackLabel" : true,
+            "connectionType" : "Unambiguous",
+            "constrainOffset" : "NoConstraint",
+            "contourAlignmentType" : "Page",
+            "contourLadderType" : "Straight",
+            "contourMaximumAngle" : 90,
+            "enableConnection" : true,
+            "featureWeight" : 0,
+            "fontHeightReductionLimit" : 4,
+            "fontHeightReductionStep" : 0.5,
+            "fontWidthReductionLimit" : 90,
+            "fontWidthReductionStep" : 5,
+            "graticuleAlignmentType" : "Straight",
+            "keyNumberGroupName" : "Default",
+            "labelBuffer" : 15,
+            "labelLargestPolygon" : true,
+            "labelPriority" : -1,
+            "labelStackingProperties" : {
+              "type" : "CIMMaplexLabelStackingProperties",
+              "stackAlignment" : "ChooseBest",
+              "maximumNumberOfLines" : 3,
+              "minimumNumberOfCharsPerLine" : 3,
+              "maximumNumberOfCharsPerLine" : 24,
+              "separators" : [
+                {
+                  "type" : "CIMMaplexStackingSeparator",
+                  "separator" : " ",
+                  "splitAfter" : true
+                },
+                {
+                  "type" : "CIMMaplexStackingSeparator",
+                  "separator" : ",",
+                  "visible" : true,
+                  "splitAfter" : true
+                }
+              ]
+            },
+            "lineFeatureType" : "General",
+            "linePlacementMethod" : "OffsetCurvedFromLine",
+            "maximumLabelOverrun" : 80,
+            "maximumLabelOverrunUnit" : "Point",
+            "minimumFeatureSizeUnit" : "Map",
+            "multiPartOption" : "OneLabelPerPart",
+            "offsetAlongLineProperties" : {
+              "type" : "CIMMaplexOffsetAlongLineProperties",
+              "placementMethod" : "BestPositionAlongLine",
+              "labelAnchorPoint" : "CenterOfLabel",
+              "distanceUnit" : "Percentage",
+              "useLineDirection" : true
+            },
+            "pointExternalZonePriorities" : {
+              "type" : "CIMMaplexExternalZonePriorities",
+              "aboveLeft" : 4,
+              "aboveCenter" : 2,
+              "aboveRight" : 1,
+              "centerRight" : 3,
+              "belowRight" : 5,
+              "belowCenter" : 7,
+              "belowLeft" : 8,
+              "centerLeft" : 6
+            },
+            "pointPlacementMethod" : "AroundPoint",
+            "polygonAnchorPointType" : "GeometricCenter",
+            "polygonBoundaryWeight" : 0,
+            "polygonExternalZones" : {
+              "type" : "CIMMaplexExternalZonePriorities",
+              "aboveLeft" : 4,
+              "aboveCenter" : 2,
+              "aboveRight" : 1,
+              "centerRight" : 3,
+              "belowRight" : 5,
+              "belowCenter" : 7,
+              "belowLeft" : 8,
+              "centerLeft" : 6
+            },
+            "polygonFeatureType" : "General",
+            "polygonInternalZones" : {
+              "type" : "CIMMaplexInternalZonePriorities",
+              "center" : 1
+            },
+            "polygonPlacementMethod" : "HorizontalInPolygon",
+            "primaryOffset" : 1,
+            "primaryOffsetUnit" : "Point",
+            "removeExtraWhiteSpace" : true,
+            "repetitionIntervalUnit" : "Point",
+            "rotationProperties" : {
+              "type" : "CIMMaplexRotationProperties",
+              "rotationType" : "Arithmetic",
+              "alignmentType" : "Straight"
+            },
+            "secondaryOffset" : 100,
+            "strategyPriorities" : {
+              "type" : "CIMMaplexStrategyPriorities",
+              "stacking" : 1,
+              "overrun" : 2,
+              "fontCompression" : 3,
+              "fontReduction" : 4,
+              "abbreviation" : 5
+            },
+            "thinningDistanceUnit" : "Point",
+            "truncationMarkerCharacter" : ".",
+            "truncationMinimumLength" : 1,
+            "truncationPreferredCharacters" : "aeiou",
+            "truncationExcludedCharacters" : "0123456789",
+            "polygonAnchorPointPerimeterInsetUnit" : "Point"
+          },
+          "name" : "Class 1",
+          "priority" : -1,
+          "standardLabelPlacementProperties" : {
+            "type" : "CIMStandardLabelPlacementProperties",
+            "featureType" : "Line",
+            "featureWeight" : "None",
+            "labelWeight" : "High",
+            "numLabelsOption" : "OneLabelPerName",
+            "lineLabelPosition" : {
+              "type" : "CIMStandardLineLabelPosition",
+              "above" : true,
+              "inLine" : true,
+              "parallel" : true
+            },
+            "lineLabelPriorities" : {
+              "type" : "CIMStandardLineLabelPriorities",
+              "aboveStart" : 3,
+              "aboveAlong" : 3,
+              "aboveEnd" : 3,
+              "centerStart" : 3,
+              "centerAlong" : 3,
+              "centerEnd" : 3,
+              "belowStart" : 3,
+              "belowAlong" : 3,
+              "belowEnd" : 3
+            },
+            "pointPlacementMethod" : "AroundPoint",
+            "pointPlacementPriorities" : {
+              "type" : "CIMStandardPointPlacementPriorities",
+              "aboveLeft" : 2,
+              "aboveCenter" : 2,
+              "aboveRight" : 1,
+              "centerLeft" : 3,
+              "centerRight" : 2,
+              "belowLeft" : 3,
+              "belowCenter" : 3,
+              "belowRight" : 2
+            },
+            "rotationType" : "Arithmetic",
+            "polygonPlacementMethod" : "AlwaysHorizontal"
+          },
+          "textSymbol" : {
+            "type" : "CIMSymbolReference",
+            "symbol" : {
+              "type" : "CIMTextSymbol",
+              "blockProgression" : "TTB",
+              "depth3D" : 1,
+              "extrapolateBaselines" : true,
+              "fontEffects" : "Normal",
+              "fontEncoding" : "Unicode",
+              "fontFamilyName" : "Tahoma",
+              "fontStyleName" : "Regular",
+              "fontType" : "Unspecified",
+              "haloSize" : 1,
+              "height" : 10,
+              "hinting" : "Default",
+              "horizontalAlignment" : "Left",
+              "kerning" : true,
+              "letterWidth" : 100,
+              "ligatures" : true,
+              "lineGapType" : "ExtraLeading",
+              "symbol" : {
+                "type" : "CIMPolygonSymbol",
+                "symbolLayers" : [
+                  {
+                    "type" : "CIMSolidFill",
+                    "enable" : true,
+                    "color" : {
+                      "type" : "CIMRGBColor",
+                      "values" : [
+                        0,
+                        0,
+                        0,
+                        100
+                      ]
+                    }
+                  }
+                ]
+              },
+              "textCase" : "Normal",
+              "textDirection" : "LTR",
+              "verticalAlignment" : "Bottom",
+              "verticalGlyphOrientation" : "Right",
+              "wordSpacing" : 100,
+              "billboardMode3D" : "FaceNearPlane"
+            }
+          },
+          "useCodedValue" : true,
+          "visibility" : true,
+          "iD" : -1
+        }
+      ],
+      "renderer" : {
+        "type" : "CIMUniqueValueRenderer",
+        "colorRamp" : {
+          "type" : "CIMRandomHSVColorRamp",
+          "colorSpace" : {
+            "type" : "CIMICCColorSpace",
+            "url" : "Default RGB"
+          },
+          "maxH" : 360,
+          "minS" : 15,
+          "maxS" : 30,
+          "minV" : 99,
+          "maxV" : 100,
+          "minAlpha" : 100,
+          "maxAlpha" : 100
+        },
+        "defaultLabel" : "<all other values>",
+        "defaultSymbol" : {
+          "type" : "CIMSymbolReference",
+          "symbol" : {
+            "type" : "CIMPolygonSymbol",
+            "symbolLayers" : [
+              {
+                "type" : "CIMSolidStroke",
+                "enable" : true,
+                "capStyle" : "Round",
+                "joinStyle" : "Round",
+                "lineStyle3D" : "Strip",
+                "miterLimit" : 10,
+                "width" : 0.69999999999999996,
+                "color" : {
+                  "type" : "CIMRGBColor",
+                  "values" : [
+                    110,
+                    110,
+                    110,
+                    100
+                  ]
+                }
+              },
+              {
+                "type" : "CIMSolidFill",
+                "enable" : true,
+                "color" : {
+                  "type" : "CIMRGBColor",
+                  "values" : [
+                    130,
+                    130,
+                    130,
+                    100
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "defaultSymbolPatch" : "Default",
+        "fields" : [
+          "magnitude"
+        ],
+        "groups" : [
+          {
+            "type" : "CIMUniqueValueGroup",
+            "classes" : [
+              {
+                "type" : "CIMUniqueValueClass",
+                "label" : "moderate",
+                "patch" : "Default",
+                "symbol" : {
+                  "type" : "CIMSymbolReference",
+                  "symbol" : {
+                    "type" : "CIMPolygonSymbol",
+                    "symbolLayers" : [
+                      {
+                        "type" : "CIMSolidStroke",
+                        "enable" : true,
+                        "capStyle" : "Round",
+                        "joinStyle" : "Round",
+                        "lineStyle3D" : "Strip",
+                        "miterLimit" : 10,
+                        "width" : 0.69999999999999996,
+                        "color" : {
+                          "type" : "CIMRGBColor",
+                          "values" : [
+                            255,
+                            0,
+                            0,
+                            100
+                          ]
+                        }
+                      },
+                      {
+                        "type" : "CIMSolidFill",
+                        "enable" : true,
+                        "color" : {
+                          "type" : "CIMHSVColor",
+                          "values" : [
+                            212.75,
+                            27.329999999999998,
+                            99.930000000000007,
+                            0
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                },
+                "values" : [
+                  {
+                    "type" : "CIMUniqueValue",
+                    "fieldValues" : [
+                      "moderate"
+                    ]
+                  }
+                ],
+                "visible" : true
+              }
+            ],
+            "heading" : "Magnitude"
+          }
+        ],
+        "polygonSymbolColorTarget" : "Fill"
+      },
+      "scaleSymbols" : true,
+      "snappable" : true,
+      "symbolLayerDrawing" : {
+        "type" : "CIMSymbolLayerDrawing"
+      }
+    },
+    {
+      "type" : "CIMFeatureLayer",
+      "name" : "Stage-Based CatFIM: Moderate Threshold",
       "uRI" : "CIMPATH=map/stage_based_catfim2.xml",
       "sourceModifiedTime" : {
         "type" : "TimeInstant",
@@ -4276,8 +5732,694 @@
       }
     },
     {
+      "type" : "CIMGroupLayer",
+      "name" : "Stage-Based CatFIM: Moderate",
+      "uRI" : "CIMPATH=map/new_group_layer3.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant"
+      },
+      "metadataURI" : "CIMPATH=Metadata/7f4d35799c1abbf1d50723fd94edd74a.xml",
+      "useSourceMetadata" : true,
+      "description" : "New Group Layer",
+      "layerElevation" : {
+        "type" : "CIMLayerElevationSurface",
+        "mapElevationID" : "{2040A0DA-3625-405D-8B32-E14FA806A248}"
+      },
+      "layerType" : "Operational",
+      "showLegends" : true,
+      "visibility" : true,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "layers" : [
+        "CIMPATH=map/stage_based_catfim__1ft_intervals4.xml",
+        "CIMPATH=map/stage_based_catfim2.xml"
+      ]
+    },
+    {
       "type" : "CIMFeatureLayer",
-      "name" : "Stage-Based CatFIM: Major",
+      "name" : "Stage-Based CatFIM: 1ft Intervals",
+      "uRI" : "CIMPATH=map/stage_based_catfim__1ft_intervals2.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant",
+        "start" : 978307200000
+      },
+      "metadataURI" : "CIMPATH=Metadata/2daef7e5de38aaa23c7db4cfd117aca3.xml",
+      "useSourceMetadata" : true,
+      "description" : "hydrovis.reference.nws_flood_categorical_hand_fim",
+      "layerElevation" : {
+        "type" : "CIMLayerElevationSurface",
+        "mapElevationID" : "{2040A0DA-3625-405D-8B32-E14FA806A248}"
+      },
+      "expanded" : true,
+      "layerType" : "Operational",
+      "minScale" : 82589.936619314918,
+      "showLegends" : true,
+      "visibility" : true,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "autoGenerateFeatureTemplates" : true,
+      "featureElevationExpression" : "0",
+      "featureTable" : {
+        "type" : "CIMFeatureTable",
+        "definitionExpression" : "interval_stage <> 0",
+        "definitionExpressionName" : "Query 1",
+        "definitionFilterChoices" : [
+          {
+            "type" : "CIMDefinitionFilter",
+            "name" : "Query 1",
+            "definitionExpression" : "interval_stage <> 0"
+          }
+        ],
+        "displayField" : "name",
+        "editable" : true,
+        "fieldDescriptions" : [
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "oid",
+            "fieldName" : "oid",
+            "numberFormat" : {
+              "type" : "CIMNumericFormat",
+              "alignmentOption" : "esriAlignRight",
+              "alignmentWidth" : 0,
+              "roundingOption" : "esriRoundNumberOfDecimals",
+              "roundingValue" : 0
+            },
+            "readOnly" : true,
+            "visible" : false,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "NWS LID",
+            "fieldName" : "ahps_lid",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Name",
+            "fieldName" : "name",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "USGS HUC8",
+            "fieldName" : "huc8",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "WFO",
+            "fieldName" : "wfo",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "RFC",
+            "fieldName" : "rfc",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "State",
+            "fieldName" : "state",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "County",
+            "fieldName" : "county",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "FIM Version",
+            "fieldName" : "version",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Magnitude",
+            "fieldName" : "magnitude",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Stage",
+            "fieldName" : "interval_stage",
+            "numberFormat" : {
+              "type" : "CIMNumericFormat",
+              "alignmentOption" : "esriAlignRight",
+              "alignmentWidth" : 0,
+              "roundingOption" : "esriRoundNumberOfSignificantDigits",
+              "roundingValue" : 2
+            },
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Stage",
+            "fieldName" : "stage",
+            "numberFormat" : {
+              "type" : "CIMNumericFormat",
+              "alignmentOption" : "esriAlignRight",
+              "alignmentWidth" : 0,
+              "roundingOption" : "esriRoundNumberOfSignificantDigits",
+              "roundingValue" : 2
+            },
+            "visible" : false,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Stage Units",
+            "fieldName" : "stage_uni",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Stage Source",
+            "fieldName" : "s_src",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Viz",
+            "fieldName" : "viz",
+            "visible" : false,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "geom",
+            "fieldName" : "geom",
+            "visible" : false,
+            "searchMode" : "Exact"
+          }
+        ],
+        "selectionSetURI" : "CIMPATH=SelectionSet/56a46e6e95c1a603351043391bb018b6.dat",
+        "dataConnection" : {
+          "type" : "CIMSqlQueryDataConnection",
+          "workspaceConnectionString" : "ENCRYPTED_PASSWORD=00022e6879663255762b434e664e5a785855566c644d746b6f6c7a4d54515449774d564d504b6974473670574e43453d2a00;SERVER=hv-ti-egis-rds-pg-egdb.c4vzypepnkx3.us-east-1.rds.amazonaws.com;INSTANCE=sde:postgresql:hv-ti-egis-rds-pg-egdb.c4vzypepnkx3.us-east-1.rds.amazonaws.com;DBCLIENT=postgresql;DB_CONNECTION_PROPERTIES=hv-ti-egis-rds-pg-egdb.c4vzypepnkx3.us-east-1.rds.amazonaws.com;DATABASE=hydrovis;USER=hydrovis;AUTHENTICATION_MODE=DBMS",
+          "workspaceFactory" : "SDE",
+          "dataset" : "hydrovis.reference.%nws_flood_categorical_hand_fim_1_3_3",
+          "datasetType" : "esriDTFeatureClass",
+          "sqlQuery" : "select oid,ahps_lid,magnitude,version,huc8,interval_stage,name,wfo,rfc,state,county,stage,stage_uni,s_src,viz,geom from hydrovis.reference.stage_based_catfim",
+          "srid" : "3857",
+          "spatialReference" : {
+            "wkid" : 102100,
+            "latestWkid" : 3857
+          },
+          "oIDFields" : "oid",
+          "geometryType" : "esriGeometryPolygon",
+          "extent" : {
+            "xmin" : -20037700,
+            "ymin" : -30241100,
+            "xmax" : 900699887774.099,
+            "ymax" : 900689684374.099,
+            "spatialReference" : {
+              "wkid" : 102100,
+              "latestWkid" : 3857
+            }
+          },
+          "queryFields" : [
+            {
+              "name" : "oid",
+              "type" : "esriFieldTypeInteger",
+              "alias" : "oid"
+            },
+            {
+              "name" : "ahps_lid",
+              "type" : "esriFieldTypeString",
+              "alias" : "ahps_lid",
+              "length" : 60000
+            },
+            {
+              "name" : "magnitude",
+              "type" : "esriFieldTypeString",
+              "alias" : "magnitude",
+              "length" : 60000
+            },
+            {
+              "name" : "version",
+              "type" : "esriFieldTypeString",
+              "alias" : "version",
+              "length" : 60000
+            },
+            {
+              "name" : "huc8",
+              "type" : "esriFieldTypeString",
+              "alias" : "huc8",
+              "length" : 60000
+            },
+            {
+              "name" : "interval_stage",
+              "type" : "esriFieldTypeDouble",
+              "alias" : "interval_stage"
+            },
+            {
+              "name" : "name",
+              "type" : "esriFieldTypeString",
+              "alias" : "name",
+              "length" : 60000
+            },
+            {
+              "name" : "wfo",
+              "type" : "esriFieldTypeString",
+              "alias" : "wfo",
+              "length" : 60000
+            },
+            {
+              "name" : "rfc",
+              "type" : "esriFieldTypeString",
+              "alias" : "rfc",
+              "length" : 60000
+            },
+            {
+              "name" : "state",
+              "type" : "esriFieldTypeString",
+              "alias" : "state",
+              "length" : 60000
+            },
+            {
+              "name" : "county",
+              "type" : "esriFieldTypeString",
+              "alias" : "county",
+              "length" : 60000
+            },
+            {
+              "name" : "stage",
+              "type" : "esriFieldTypeDouble",
+              "alias" : "stage"
+            },
+            {
+              "name" : "stage_uni",
+              "type" : "esriFieldTypeString",
+              "alias" : "stage_uni",
+              "length" : 60000
+            },
+            {
+              "name" : "s_src",
+              "type" : "esriFieldTypeString",
+              "alias" : "s_src",
+              "length" : 60000
+            },
+            {
+              "name" : "viz",
+              "type" : "esriFieldTypeString",
+              "alias" : "viz",
+              "length" : 60000
+            },
+            {
+              "name" : "geom",
+              "type" : "esriFieldTypeGeometry",
+              "alias" : "geom",
+              "geometryDef" : {
+                "avgNumPoints" : 0,
+                "geometryType" : "esriGeometryPolygon",
+                "hasM" : false,
+                "hasZ" : false,
+                "spatialReference" : {
+                  "wkid" : 102100,
+                  "latestWkid" : 3857
+                }
+              }
+            }
+          ],
+          "spatialStorageType" : 8
+        },
+        "studyAreaSpatialRel" : "esriSpatialRelUndefined",
+        "searchOrder" : "esriSearchOrderSpatial"
+      },
+      "htmlPopupEnabled" : true,
+      "selectable" : true,
+      "featureCacheType" : "Session",
+      "displayFiltersType" : "ByScale",
+      "featureBlendingMode" : "Alpha",
+      "labelClasses" : [
+        {
+          "type" : "CIMLabelClass",
+          "expression" : "$feature.name",
+          "expressionEngine" : "Arcade",
+          "featuresToLabel" : "AllVisibleFeatures",
+          "maplexLabelPlacementProperties" : {
+            "type" : "CIMMaplexLabelPlacementProperties",
+            "featureType" : "Polygon",
+            "avoidPolygonHoles" : true,
+            "canOverrunFeature" : true,
+            "canPlaceLabelOutsidePolygon" : true,
+            "canRemoveOverlappingLabel" : true,
+            "canStackLabel" : true,
+            "connectionType" : "Unambiguous",
+            "constrainOffset" : "NoConstraint",
+            "contourAlignmentType" : "Page",
+            "contourLadderType" : "Straight",
+            "contourMaximumAngle" : 90,
+            "enableConnection" : true,
+            "featureWeight" : 0,
+            "fontHeightReductionLimit" : 4,
+            "fontHeightReductionStep" : 0.5,
+            "fontWidthReductionLimit" : 90,
+            "fontWidthReductionStep" : 5,
+            "graticuleAlignmentType" : "Straight",
+            "keyNumberGroupName" : "Default",
+            "labelBuffer" : 15,
+            "labelLargestPolygon" : true,
+            "labelPriority" : -1,
+            "labelStackingProperties" : {
+              "type" : "CIMMaplexLabelStackingProperties",
+              "stackAlignment" : "ChooseBest",
+              "maximumNumberOfLines" : 3,
+              "minimumNumberOfCharsPerLine" : 3,
+              "maximumNumberOfCharsPerLine" : 24,
+              "separators" : [
+                {
+                  "type" : "CIMMaplexStackingSeparator",
+                  "separator" : " ",
+                  "splitAfter" : true
+                },
+                {
+                  "type" : "CIMMaplexStackingSeparator",
+                  "separator" : ",",
+                  "visible" : true,
+                  "splitAfter" : true
+                }
+              ]
+            },
+            "lineFeatureType" : "General",
+            "linePlacementMethod" : "OffsetCurvedFromLine",
+            "maximumLabelOverrun" : 80,
+            "maximumLabelOverrunUnit" : "Point",
+            "minimumFeatureSizeUnit" : "Map",
+            "multiPartOption" : "OneLabelPerPart",
+            "offsetAlongLineProperties" : {
+              "type" : "CIMMaplexOffsetAlongLineProperties",
+              "placementMethod" : "BestPositionAlongLine",
+              "labelAnchorPoint" : "CenterOfLabel",
+              "distanceUnit" : "Percentage",
+              "useLineDirection" : true
+            },
+            "pointExternalZonePriorities" : {
+              "type" : "CIMMaplexExternalZonePriorities",
+              "aboveLeft" : 4,
+              "aboveCenter" : 2,
+              "aboveRight" : 1,
+              "centerRight" : 3,
+              "belowRight" : 5,
+              "belowCenter" : 7,
+              "belowLeft" : 8,
+              "centerLeft" : 6
+            },
+            "pointPlacementMethod" : "AroundPoint",
+            "polygonAnchorPointType" : "GeometricCenter",
+            "polygonBoundaryWeight" : 0,
+            "polygonExternalZones" : {
+              "type" : "CIMMaplexExternalZonePriorities",
+              "aboveLeft" : 4,
+              "aboveCenter" : 2,
+              "aboveRight" : 1,
+              "centerRight" : 3,
+              "belowRight" : 5,
+              "belowCenter" : 7,
+              "belowLeft" : 8,
+              "centerLeft" : 6
+            },
+            "polygonFeatureType" : "General",
+            "polygonInternalZones" : {
+              "type" : "CIMMaplexInternalZonePriorities",
+              "center" : 1
+            },
+            "polygonPlacementMethod" : "HorizontalInPolygon",
+            "primaryOffset" : 1,
+            "primaryOffsetUnit" : "Point",
+            "removeExtraWhiteSpace" : true,
+            "repetitionIntervalUnit" : "Point",
+            "rotationProperties" : {
+              "type" : "CIMMaplexRotationProperties",
+              "rotationType" : "Arithmetic",
+              "alignmentType" : "Straight"
+            },
+            "secondaryOffset" : 100,
+            "strategyPriorities" : {
+              "type" : "CIMMaplexStrategyPriorities",
+              "stacking" : 1,
+              "overrun" : 2,
+              "fontCompression" : 3,
+              "fontReduction" : 4,
+              "abbreviation" : 5
+            },
+            "thinningDistanceUnit" : "Point",
+            "truncationMarkerCharacter" : ".",
+            "truncationMinimumLength" : 1,
+            "truncationPreferredCharacters" : "aeiou",
+            "truncationExcludedCharacters" : "0123456789",
+            "polygonAnchorPointPerimeterInsetUnit" : "Point"
+          },
+          "name" : "Class 1",
+          "priority" : -1,
+          "standardLabelPlacementProperties" : {
+            "type" : "CIMStandardLabelPlacementProperties",
+            "featureType" : "Line",
+            "featureWeight" : "None",
+            "labelWeight" : "High",
+            "numLabelsOption" : "OneLabelPerName",
+            "lineLabelPosition" : {
+              "type" : "CIMStandardLineLabelPosition",
+              "above" : true,
+              "inLine" : true,
+              "parallel" : true
+            },
+            "lineLabelPriorities" : {
+              "type" : "CIMStandardLineLabelPriorities",
+              "aboveStart" : 3,
+              "aboveAlong" : 3,
+              "aboveEnd" : 3,
+              "centerStart" : 3,
+              "centerAlong" : 3,
+              "centerEnd" : 3,
+              "belowStart" : 3,
+              "belowAlong" : 3,
+              "belowEnd" : 3
+            },
+            "pointPlacementMethod" : "AroundPoint",
+            "pointPlacementPriorities" : {
+              "type" : "CIMStandardPointPlacementPriorities",
+              "aboveLeft" : 2,
+              "aboveCenter" : 2,
+              "aboveRight" : 1,
+              "centerLeft" : 3,
+              "centerRight" : 2,
+              "belowLeft" : 3,
+              "belowCenter" : 3,
+              "belowRight" : 2
+            },
+            "rotationType" : "Arithmetic",
+            "polygonPlacementMethod" : "AlwaysHorizontal"
+          },
+          "textSymbol" : {
+            "type" : "CIMSymbolReference",
+            "symbol" : {
+              "type" : "CIMTextSymbol",
+              "blockProgression" : "TTB",
+              "depth3D" : 1,
+              "extrapolateBaselines" : true,
+              "fontEffects" : "Normal",
+              "fontEncoding" : "Unicode",
+              "fontFamilyName" : "Tahoma",
+              "fontStyleName" : "Regular",
+              "fontType" : "Unspecified",
+              "haloSize" : 1,
+              "height" : 10,
+              "hinting" : "Default",
+              "horizontalAlignment" : "Left",
+              "kerning" : true,
+              "letterWidth" : 100,
+              "ligatures" : true,
+              "lineGapType" : "ExtraLeading",
+              "symbol" : {
+                "type" : "CIMPolygonSymbol",
+                "symbolLayers" : [
+                  {
+                    "type" : "CIMSolidFill",
+                    "enable" : true,
+                    "color" : {
+                      "type" : "CIMRGBColor",
+                      "values" : [
+                        0,
+                        0,
+                        0,
+                        100
+                      ]
+                    }
+                  }
+                ]
+              },
+              "textCase" : "Normal",
+              "textDirection" : "LTR",
+              "verticalAlignment" : "Bottom",
+              "verticalGlyphOrientation" : "Right",
+              "wordSpacing" : 100,
+              "billboardMode3D" : "FaceNearPlane"
+            }
+          },
+          "useCodedValue" : true,
+          "visibility" : true,
+          "iD" : -1
+        }
+      ],
+      "renderer" : {
+        "type" : "CIMUniqueValueRenderer",
+        "colorRamp" : {
+          "type" : "CIMRandomHSVColorRamp",
+          "colorSpace" : {
+            "type" : "CIMICCColorSpace",
+            "url" : "Default RGB"
+          },
+          "maxH" : 360,
+          "minS" : 15,
+          "maxS" : 30,
+          "minV" : 99,
+          "maxV" : 100,
+          "minAlpha" : 100,
+          "maxAlpha" : 100
+        },
+        "defaultLabel" : "<all other values>",
+        "defaultSymbol" : {
+          "type" : "CIMSymbolReference",
+          "symbol" : {
+            "type" : "CIMPolygonSymbol",
+            "symbolLayers" : [
+              {
+                "type" : "CIMSolidStroke",
+                "enable" : true,
+                "capStyle" : "Round",
+                "joinStyle" : "Round",
+                "lineStyle3D" : "Strip",
+                "miterLimit" : 10,
+                "width" : 0.69999999999999996,
+                "color" : {
+                  "type" : "CIMRGBColor",
+                  "values" : [
+                    110,
+                    110,
+                    110,
+                    100
+                  ]
+                }
+              },
+              {
+                "type" : "CIMSolidFill",
+                "enable" : true,
+                "color" : {
+                  "type" : "CIMRGBColor",
+                  "values" : [
+                    130,
+                    130,
+                    130,
+                    100
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "defaultSymbolPatch" : "Default",
+        "fields" : [
+          "magnitude"
+        ],
+        "groups" : [
+          {
+            "type" : "CIMUniqueValueGroup",
+            "classes" : [
+              {
+                "type" : "CIMUniqueValueClass",
+                "label" : "Major 1ft Intervals",
+                "patch" : "Default",
+                "symbol" : {
+                  "type" : "CIMSymbolReference",
+                  "symbol" : {
+                    "type" : "CIMPolygonSymbol",
+                    "symbolLayers" : [
+                      {
+                        "type" : "CIMSolidStroke",
+                        "enable" : true,
+                        "capStyle" : "Round",
+                        "joinStyle" : "Round",
+                        "lineStyle3D" : "Strip",
+                        "miterLimit" : 10,
+                        "width" : 0.69999999999999996,
+                        "color" : {
+                          "type" : "CIMRGBColor",
+                          "values" : [
+                            169,
+                            0,
+                            230,
+                            100
+                          ]
+                        }
+                      },
+                      {
+                        "type" : "CIMSolidFill",
+                        "enable" : true,
+                        "color" : {
+                          "type" : "CIMHSVColor",
+                          "values" : [
+                            299.64999999999998,
+                            29.27,
+                            99.709999999999994,
+                            0
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                },
+                "values" : [
+                  {
+                    "type" : "CIMUniqueValue",
+                    "fieldValues" : [
+                      "major"
+                    ]
+                  }
+                ],
+                "visible" : true
+              }
+            ],
+            "heading" : "Magnitude"
+          }
+        ],
+        "polygonSymbolColorTarget" : "Fill"
+      },
+      "scaleSymbols" : true,
+      "snappable" : true,
+      "symbolLayerDrawing" : {
+        "type" : "CIMSymbolLayerDrawing"
+      }
+    },
+    {
+      "type" : "CIMFeatureLayer",
+      "name" : "Stage-Based CatFIM: Major Threshold",
       "uRI" : "CIMPATH=map/stage_based_catfim.xml",
       "sourceModifiedTime" : {
         "type" : "TimeInstant",
@@ -4950,6 +7092,35 @@
         ],
         "useSymbolLayerDrawing" : true
       }
+    },
+    {
+      "type" : "CIMGroupLayer",
+      "name" : "Stage-Based CatFIM: Major",
+      "uRI" : "CIMPATH=map/new_group_layer4.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant"
+      },
+      "metadataURI" : "CIMPATH=Metadata/5ba8c64060e7681a3d9f46f3d8e9ea05.xml",
+      "useSourceMetadata" : true,
+      "description" : "New Group Layer",
+      "layerElevation" : {
+        "type" : "CIMLayerElevationSurface",
+        "mapElevationID" : "{2040A0DA-3625-405D-8B32-E14FA806A248}"
+      },
+      "layerType" : "Operational",
+      "showLegends" : true,
+      "visibility" : true,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "layers" : [
+        "CIMPATH=map/stage_based_catfim__1ft_intervals2.xml",
+        "CIMPATH=map/stage_based_catfim.xml"
+      ]
     },
     {
       "type" : "CIMFeatureLayer",
@@ -5641,8 +7812,28 @@
     },
     {
       "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/5ba8c64060e7681a3d9f46f3d8e9ea05.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230403</CreaDate><CreaTime>19413200</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>New Group Layer</resTitle></idCitation><idAbs>New Group Layer</idAbs><idCredit></idCredit><idPurp></idPurp><resConst><Consts><useLimit></useLimit></Consts></resConst></dataIdInfo></metadata>\r\n"
+    },
+    {
+      "type" : "CIMBinaryReference",
       "uRI" : "CIMPATH=Metadata/745bebf5c7272e12653fc7d60400af25.xml",
       "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20220623</CreaDate><CreaTime>20130400</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>Map</resTitle></idCitation></dataIdInfo><Binary><Thumbnail><Data EsriPropertyType=\"PictureX\">/9j/4AAQSkZJRgABAQEAAAAAAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a\r\nHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy\r\nMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCADIASwDAREA\r\nAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA\r\nAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3\r\nODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm\r\np6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA\r\nAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx\r\nBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK\r\nU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3\r\nuLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3t3X5\r\nfmHWgBJCDtww6+tJ6gO3AKORn60AG5SMEjH1pgQW7CNzFtwOSv0oZEdHYmDASNk+lBYu9cjmgATk\r\nH60ANdgsTbumDQAkPKL6Y4oAfKcRmgA3r6n8qAGu4469fSgBS47Z/KgBNwLgjPHtQA4cnNAB/E34\r\nUAIc4xQA9RgUAVNQGYUOORIuPzoAnDn+JSPegBGdeeefpQAruNwGaTAGZSVO4daYCBgZc7hxQA4n\r\nIOOaAEIwucdKTAQOp5YgH0oTAeGXH3h+dACIy88jr60wHFh6j86AGow2DkUARXBGzIbJBzj1oJls\r\nSFleHIPFA0LvXd97il1GI0illwehpgOLrjrQAu9fWgBjY+UkDrQA3gyjGMZqVuA8gb14qgFbAHag\r\nCupDXpIyQF69hQR9olJxI3y5FBY4MvsKAGrIOcc89qACR8RsXUgYNADosbAR0wMUAEh+WgB5GcUm\r\nA1/4frTAdQAhxmgAB5x6UrgNwfMPPYUwF6tQA6gCpfH90vH/AC1T+dJAWTncPSjqA2Qd6YCvjHag\r\nBgUjbkd6WtwEkHDcfSi7ARM5GRgnrQwJ+owaYEZ2h26Z7ZpALjK8AUMAUBRyKYDsL6DFAAVXaeBQ\r\nA1VUoOnSgCOZNqF04PcetBLVtUETBx/smpTGnckl+VV24HNUMch3Lk0ALtoArG/t+zn/AL5P+FAF\r\nY6nEM4DbVPLHoCeg9e4oAhj8RWMjjfJ5eMgsR8uQcdfrQBLLrdhE6xtMSzjghCR0yOcUACahZxyA\r\nyXH7xsjGDj+X60EpdWaAcFyeenpQUKWU9VJ/CgBEYYPB6+lABI48t8q2MHPFAAjDy1wrYx6UAI7c\r\nDAPX0oAkyRQA1uSv1oAd0HSgBGJ3AUAKF5LGlYBqnLt+FFwFXpn1pgNDsSflPWgCC+LeUmQAPMXv\r\n70AWj0oAbJzHmgBjIc56+1So6gJukLAkYGelUBICWHI5FJagIWAYdelMBQ44zn8qSAQAMz4osANk\r\nHv0pPcBVHBJpoAzu4BxigAPK470ACuAo4PT0pgQXNzEqmNmO9hwApJoAqpeLChR1lwCMEpt/nSJi\r\nraDjqUMsYZFcr8xDADt1plCx6nEHjiCSlmXdwlICx9sH/PCf/vimAxlYWqujLkjqelJ7AUIY7e4b\r\nL7GQcbu2RQhNpAunWA2LDaxnk59PX+dDGWJdMt5Pml2DvwB6Y/lQF0VjZQmT7gA52nZxg/8A6qND\r\nPnZcjtCq7oLhlc9ccg/hQWnceLi5hH76Dev96P8AwoQyWC6hmyFcZz0PBpgSy48l9xwNpzQA5QAg\r\nA6YoAH6D60AOoAjf7yjvmgB2T3oAQ/6wfQ0ALnnFICMZDPnvikgJOgqgGp/F9aAIL8/uU/66J/Og\r\nCxnjFK4CMflwfUCmAufmpAD9R9RTAGpMBByw+lNAKT/OgBNwDng0AL5g9/yoAQOuODQAhI42nrSs\r\nA7PHvTArzXDb/JgG6Q9T2X3NACxwLChOS0jcsx6mgCG7tmecSjaeMAHsaCWn0IY4LSOYoQoDL06d\r\n8/1pXHrexaKWocOrKrDuKYyTeO0oxSuBzEVprJtIrSR45YEAGVyv5mvPxFHFVY+zhNRT69S04rVm\r\nna2Yt4BbjcypzlRgMTzxXZSpeypxprorGbfM9C9HaorAsGLdvatLC5UTCNAceWSfeiw+VEgzjlDR\r\nYZA64csnyMPbg0rEtdUOE7YGY2z9OPzouHMMeOC54kj2v+R/OmNMhkguI4XEc+6Pacq/p9aSbGSr\r\nemLAuImj/wBrqv51QFjzUkQNGwYZ7GgB25v7p/OgBrFsr8vf1oAcWbIG3r70ANJbzRx29aABi2R8\r\noz9aTAQBy5YqMfWmA7L+n60AIhbDHHegCpqO8QRlRn94uc/WgC2SEQGkBWlkWV4+RwwODTAX7aiv\r\nt8tgASM8UrgT796qwB5PSmA47mzxge9JgJ3GPSjoA5sfjRcBEzk/QUwHDvQAxTtGCD+VADcjPBU5\r\nqQK092GYxRMFxw0h6L/9eqAfEUiQJArOTyT6++aQDzHcOcEqi/maVgFMKAjcSxyOSaaAbc24aMug\r\nUFQe1BMr20E8gIFkRAfUY60aha2qH+b/ANMD+lK4c3kKqedgniMdFHeqDcfIAu3AFLYoUEM4J7Ch\r\nagIWPmDaM8UwH5bHI59KAGBhubcMe1ACHG4BODnpigBHUPw689iKTE1cgmBSF1eVhEVILH+H3pJk\r\n6onE8ZIXOR0zjiqK5kRyWETNvTMb/wB5DikMbi9hHVZ0/wC+W/woABeRMVSTdE3o/H69KEBaXk56\r\njsaAGZbz8HGMUwJNvzCgAJoAaS3PAP40ANTft7c+9AFTUx+6iZucSDgD+dAEZndwse8AfSpAZMGU\r\nFd4II9KLjI1BdcHk9yKQjShZ9sQYD65qkATSSpKOQF7e9DAQTMzZCcj1NFwJQ5bcCuMdD60APXgn\r\n8KEAtMCGW4jhUF2wew7n8KQFYRTXXJzDGf8Avo/4UAEdnEsfmKvIPy55pWI1tcvIQ6K2O1MpbETu\r\nxk2RkA4ySRmi4m9bIY0TvlpOCMYwf1oFZvcWMPLuV3+VTjAGM/WmmCu9yx07cUiwxnnFKwCDd2X9\r\naYDJGYbSQMZpgK24+mMetADYwyn7o4GOtACsx3AE9+cUAOAAoAZ1JJ6CgBwyQc8+1AEVyiyW0kcj\r\nbVZCC3pxSaAeYwYSoI9qVrCa0I7e6inG0SKXXhhmrcZJXaMKWJpVG4xkm0WjSOgxNSvUtbgvJMsq\r\nAY+zgDI961pUnUdkefmGPhg4KUtW+g+1kjuLQXFrK0ScllbkA1NSm4SszXBYuGLpe0gJNrEdnH5k\r\n7oyLwXjOf0qVGT2N6lanTspu1yzaapa3sfm288ciH0NDjJWuiIYmlNtKW25cUZXOevNSbjGLHdgn\r\nHNAEMlyYQBtzxmk3YGytPL5wCsxxg9vWpcxXIIQWUdd2cH61Qxzgq5BoAri7gDlfNAIk8sj/AGsZ\r\nx+VFgL8d6hK8j5OpPSmlYBJb+N5IlaRF3NtHucEj9AaGBZU7TUlD1YCUjjDDjnmmiRZbqG33GRwD\r\n2Hc1QFX7Tc3LBIFEan+J+tFxNksdq8Z3na8ndmOTSYtSUySD7yjHt1pXC7Ehzsw2cZ4HtSCOw5Y5\r\nUBVGG3tntVWCzWxJFHsBycseppjSsLL/AKs0DIoi20sMYY8UkrCQ9nZcdKYx2X9qAAyDsCfpQAxi\r\nX+UqR65FACDHTHSgByjrQA2XIx60ABYsduMUAJklTgDC9aAHsSBuHegCvcp9ot5E3r8ykZpANkvI\r\nkuFiYsrN907Dg/j0oAxr/Q5/tDT2UgV2Oducc11Rrq1pHzOMySp7X2uGla/yM6PWNT0+ZkvUkO08\r\no/ceoNX7KFVe6cTxuNy+vyVnzL8/QyI7e5uNQubwW0shmJO3BIWtYUlSW+pnicbUx0lL2TcV6/mX\r\n7CfURbHToYSJXbcQUPT8egpz5LqUjKhPGJOhh4tJu/8ATGS6HqplaP7MWGcnbjbThWpJXTJr5fmE\r\n6lpxcmuvQWLw/qUZ2xWrIPZxSVamuonlePk7uDNHTL6eK7+x3tw6EHaDkcH0NYVKSl70T1cuzSpS\r\nq/VsT00v2OkaG6VfluFYH+8n+BrjZ9UVpYL1mBLKeMfIMfzNS7MBj24VVaT7Rj2A4/IUWQWIjG6F\r\nmgldgxyQ6ZNPQBrLdYycdM8qRQBRe0Dl5DEpYHefm707jLS2ly8RPl5U8nnAz60CEXTGkEbm1BCO\r\nHT5jwQCM9Pc0XA02e8Bx5SD6DNICrdtLFE0s06RxryTjB/DrTim3ZE1KkacXKbskY/8AbtmpDQwS\r\nySYBJl4A/wDr1usNJv3jw8Vn1CnH9z7zOhsL1L9I5IwBgZYZ6H0rOdPklY9DBYyOLpqpH5mpUncN\r\ncfKcdaVgIlUnHFRZiJGYque+KsYqDCimAknKGgCEHEnkYIHUEelBKdnYlKgFfrQUPoAZwoAJ6UAB\r\nIwCDnBoAhORIxxxnmkBIDnPUc0wFYZIIFADdo3Y6elACnCnAHbkUARsx28AkAdutIDLtrcf6SqyO\r\nxlQ53Y+T26CgBzrnUkJ8ksCBgj5ugoGbBAGT3NMRDJHFIQSis3YkZxTUmtjOdKE/jSY4IEYBcL9K\r\nRailoiX5/QfWgY1M7yCfekgJaYGHqugxX7GeJvLnx+DfWt6dZxVmeJmOTQxLdSDtL8GYUGs6np7G\r\nCdC4j4+ZM4/Guh0adT3l1PEhmWOwb9lNX5dNV+pt2PiS0niY3DLE6jJ9D9KwlhpL4T2MJntGpF+2\r\n91o0oby3vYBLBIHTdjisKkHB2keth8TSxMOek7onJQ9SAPrUWubOSW7IbhcorKC2DwF60crDm0ut\r\nTjbnXbuG5eD7OqsQQynjIrteHpqHNc+Tr8QVqNVRnCyW6N211NZba3lLvhhwgGa5vZy5uU+hjj6U\r\nqMa0dUyy2vaejYN1yOCNvQ1caE5K6RnXzXC0Jcs5amXfeJWdzFYpuHTzCP5CtlhktZHjYvP3J8mG\r\nXz/4BhXV9cX2xZpSViPKtxk+4q1TjDVLXyPGxGY4qrD2VV6GtpOkpdlLi5KiLGRGP4setZOSo+6n\r\nd/lc9DK8reIarVfh7dzpba3jtyFt4ljiHYDrXPKTk7s+soYenQjy01ZF2kbkXzuOoA+lADvmA6r+\r\nVAEbl2VgNpGOaQD1D4HzfpTAHDBD836UAV1KidnZtp6EnvQTpe5Ywdy/NmgofQAzhs0AIAd3XAoA\r\nMfM3vQAxSNzKOef0pASLgcUwAr8nHUUAIo3Lk9TQA11K9OABSAzbVGfzkX5WeMkEn7xz1oQxx+zD\r\nVNpYmXOSo6dOtAGm30zTENGQNxHJ6UgBh8w/vdaYD94xxQAhHIOcNQAu1v736UAIq5HJ70mgOf1u\r\n+1C2dYYLOORZTgPwSB9K2pqN0rnm4p1lSqPlT7HKi2AuAtyrR5BP1NdeKq1YU70Vd3X3HwsKS5/3\r\n2m5dtlv7E26QzrELiQKqE88gnOPwpVqlO9pq7PZyzBY7k56UuVP8Tdj8OSON13fSsWOSFOBWTxVt\r\nIxPRjkcp+9Wqtt9ijdLJoc32q2vBLAjANEz8/StVKNRcs1ZnHPD18FP2uGlzxW6ILmA+IdUWVImi\r\niIC7mHfFUpRow5Xqc9TDzzXFOcI8sdNy1P4cmtoVS2uHJJxtPFZrEQk/fR2TyXEUI/7PU17F7SvD\r\n8NkGkulE0zdyMgCoq4ly0jojsy/JYUbzr+9I1ltLbnbCqn/dxXM5SfU9eOGoxd4xRnjw7p8TmRYN\r\n0jNkl2z1q41pxVkzCtl+Gqy55QTZoxwxxYjjUDbWT1d2dcKcYRUYqyHt+727m79BRYscZvRG/KmA\r\nkbMQBwKAHFeeSSKAFYAI2PSgBVPHNACSfcoAimC7ANoLMcCgmRJjGwZoKH0AM4UY9aAGjcR2/GgA\r\n+bOcj0xigBFyGY4HbqaAFG/HRaAAFypAwMcdKAAbgMcUAJlunBzQBmW6O/2pFwrsCEPA4/M96SAJ\r\nYt+rBgu5lwCckgcemMD86BmpnjDA59qYh6kHt07GgBGH7wH2oAQY2dfegB+MigBCSKAGopOTuI56\r\nUAch4m0+1k1FblnuDchPlwRsA+h6VpBQhapN6HhZxjeSLw8U7tXujDX5Z0WUtnjnPbvXocymuaOq\r\nPi1pL3jso/D2mfb4tSEbNOAuws5IUY7CvNnJtu5+lUIQVOPJtZWNwgEEZ61Js1dWM9NG0+Nw4to2\r\nfOd7DJqpVJT3MKGFpYdNU1a5NMgS5tgowMnj8Kk3tbYnjO8l8cds0CWupIRmgogk3eeACQpHUUCY\r\nvk7AWLsWz1oCwpXn5ScnqaBjlQLz1PqaAA8t16dqAEjB2+hoAfigBsnKEA9qAHKOKAEk+7+IoAgl\r\nO9fubiDlQOOamLbJkPwTsBOG71VxoXleNzUrjBQd3JoAcQDTAApHIpAIBhyD3FMB205zQAL1b60A\r\nOJFK4EcgyOOtMDOtkcs2VZSQyrufpz6UgFLNBcDzGkPyqWCnAHbn1oGanbNMRHy7bhkDFACMSjDP\r\nIz1oAXJViAMjrQA7f0BBGaAHZoAYv3m+tAFLUtNh1G3Ksq+YB8jntWlOo4+h52YZfDFw/vdGcxo9\r\nrEdamtr6ONivTPTIrrk3GkuRny+W4el9clSxCTt+Z2RCbRjBwQK4H5n28Wre6SbF9BQURSeWm3IH\r\nWgVyC4Aa6t1Vccnn8KALXloo6cChjFCKRnmgCN4gz9SCB1oE0NXDDyyx3DrzQCJFwCVzx2oGOBBH\r\nWgAHXmgBqHAP1oAepz1FADX4U/SgBwyOTQBG53L+NADJE3OqKcA8mklYl66DiD5inNK2tyiUdORz\r\nTQEYBCgn15pgOAJyP1oAB93FJgNUtv6ZOKUQHF2zjb+tUA0F9+cDmgAO/PK8expNXAcHJyNvSmBQ\r\nSGVNSaTy28sjg5H/AOukBUvROotyYiWHDHB9e5oA2FlJQZXHHemAqFtg+X9aAByxXlf1oAUAjov6\r\n0AI24gEL096AAFmGeBQAmxievX2oAVVYk/N0PpQBi6j4eS9Z54ZTHOTnPY100sQ46M8HH5JCvJ1a\r\nbtJlfw27xx3NpcOfPSUfK55x7VWK1aktiMhvCNSlN+8nsdAAxZlVsAH0rkPf1YpVVKZHOetFx2Ip\r\n3BurcDnDHp9KBlj5j1wBQAY/2jQA0KDJ68UAQoN08nAAxjHrQT1JWBx06dMUFCAALk9+gpAPHB6U\r\nwGgEE+oNADvcmkAjKChOT0oAbsJXqTS1AGQBOnJqgEKBZg3YjB9qCXuOdVJWkyh4QY6UAGPkH0pg\r\nL3I9aAEwFbPap2AapAl+opoBTy54zxTAQDn5VpAOz60wETG5vrQA+gCtEH2KJM7snr9eKALI6UAF\r\nADX+7QApbAyaADPFADUwVFADxQBQuNW06zleO4vYI5ANxRpAGx9OtF+gXM288TWotEmsZoZS3OH3\r\nDj8BWsKE5q6R5+JzTC4eXLUlr2ONS+urrxDa3d20aSNdKRt6KuMAV0TpSjR16Hk4XF0q2Z89LZx/\r\nE9KEqh2U4znOR3riPpVuPbD7dxyM9KBkUuPttuoUADcf5UAWWYAUAMyMdDmgAI4zyGxSAZExYliM\r\nZ4pkrXUmAI4FBQxcB2yOQe1IBQctmhMBSFP3gM0wBMbBQA3PyuM9qmIDgwC9aoBruu3qDSAbKybd\r\npw244ApoUh5KgpyOPegY/cv94fnQAxtwXO4flQA8dMmgBGOeMGkBEFPmDjjHehKwEnO7Ix0pgA3+\r\n1AC/P6CgBq5DNx+VAD8juaAK8LM0GJM78n+fFAEwyO1IB+RTAqXt7DaRBpHHJAxTSuTKSW5Smnu5\r\nZzFGdo3gg44K9evvT0RLbuUHs75IWVNSIRcli/v3p8y7E2l0ZqWNxC1vDE93G0pTOQevvUs1W2pV\r\nudUu49RlS3gFxawRhpSrfMM56evApDOQtfDreJddvrx5Y/7P+1+YGKnewA4APpXDLBqWKWI5notu\r\nhyywylWVW/yNy98IJKLhrWcoGB2Kw4B+vpXsU8S4Q5LHnYnJoVsV9YuW5/DNrcpazuWS6iijAKHg\r\nFe+O/NYqrNJxT0Z6f1WjzKfKro2ijtcJwDtHJrM2d7llhxxQUVLg7bmCUn5RlSfTNAFtsY680AR5\r\n4wB+NIB7DOOM0wI0yjsmQSTke1BK0ZN0OTQURZJdjtNJgOwMjI5NHUCTHNMBiqNvSgBsiDacDHFJ\r\noBwUYHyimASABDxQBHMANhI/iHagmQ9hyvAoKFx7ClqAZBBFMBSfloAXtQA1vvj6UmAvQZoQC0wA\r\nsAaTYDA2Sfc0XAQ/6wZHGKAG2pZoAXGGyc8YpgV9QvxZQkhd7/3c/qfamlcmUrIyhLqWoTHeVtYS\r\nMKOck8d6rRGd5PfQsDS4nbfIZJXJHLDj60rj5S+qgzCIjITjHtUjW9h81tbvIjugLD/PSguyKv8A\r\nYtjukka2DF2ycscj6UBYtW9rDAhSGIImfuigZMkUcSYVFUDsBgUAOUjB6daAGMV2ELj8KAEhAy57\r\n55oJRKTxjNBRHcIHgkUjqpoAjtj5lujt/doAlYg4C0AObIHBoAgkwm2RuoPU9qETLuThSeTQUJgF\r\nzn60AKeucigB2fagBi5xx60ADZIIPcUAKpAUcjNACSfdNAEc0i7McnkdqBPYfvXIwTx14oGL5q+/\r\n5UAKeB0oATGSB2FADuozSQDf+Wn4UwH4oAaTgdKAAdeRQA0AZPODmpdgFA+bPYcVQFCdZbnTyoYi\r\nXOfTOD0oWhMldFO1s40ffMTJJ/CDztP1qmyEjUCAD5mLYXABHSpLUe5KsQCBVc4oGlYjhVRK+Gw5\r\nPPFAla5KOSTnI6ZNBQ4DJoAaM5ZR0oAUc5z60ANQDc3GeaQEcjsvyheWpJCbJVQJFjP1NUCVgGSM\r\nDg9qBjsMB97NAFWEeRO9v/ARvX29qALB6gAd6AHEHHFAEUqhtisc5PSgT10JeSODQMa64weeKAFI\r\nwOAKAHc9qAGrnn60ALg4JPpQA3YCBSsgFb7p9KYDZFzGcHihCewqYGR70DI8nJ4PWgCxQA3GKAFB\r\n6UkAn/LT8KYDqACgBDQBGFDbvmxzSauAmNrbd/vTAqxEzLE+7k5GB/OkQ9WWo41jBB5+tMpKwpQe\r\nVyKBjsIOOlAEBKm4QA46/wAqCXuixkY60FAM/hQAhOC2OpxQAv3RjFADUyM49aAIbtwFQHgluKCZ\r\ndCxjPOaChOS3TigAGSfQCgCvJkX0eMH5DQBMC5IO3j60ADPk42nIoAjBLTqNp+UZoF1Jd+GxtOaB\r\ngXLAjYaAG7yeNpz0oAeH/wBk0AND8Y2nOaAHM5242mgBoZsAbTmgAcnYRtNACHcUKHhscCkhPYVH\r\n/gIwwFME+ghR89aBkm1v77fpQAxg2R856+1ADgh/vt+lKwCbT5g+duntTAdtb++36UAIAdxG9v0o\r\nANvH3moAhkWSPGwgjPO6gTbG/ZXkYu8hU9tp6UCs2NtIgYhKTtPIwOKQ1FIsIAvzNzTGOdgUODQA\r\ngwCT1NICHYDd+YTjC0ybe9cm6dB9aCh4JxyMUAMTLEsemaAFBy1AAnVvrQBFcpvRcDJB69xQTJEq\r\nt+7B7YoKFyGoACPloArT5jljnCllUEMAO3rQBYDh1VlOVPINADdv70k9MUkALgTN0yRTF1FH+tag\r\nY4Z9RxQA1R87E0AOWgBBwp+tADjzSAF6ZpgNP3CaAFOM+9ADXXGH5ytAn3HhsjNAyP5ieDUWdwHE\r\nYC+xqkA7vTAQn51/GgB1ADBnzD9KQCSSpHgHqelMTdhkUatliSxz1oEl1JQ3OAKCiCKUyxK5XHJG\r\nPxpATAkDkUwGvllAxjmgAAC9etICNPnnY5+7wBTJ6k6juTmgoGHymgBOi5z1oAVRgUAM34LAA9aA\r\nGyFzE21SDg80CewkIby14GB60AtiYbz6UDEYOR1FACDdgrwRQBXsTm2Cjs7D/wAeNAFk44PekBGw\r\nKSI/vtNMT3uSAHJJ4oGL3yO9ADWB3+gNADlHy4FADF3ZPQ4NIBS24DoM0wHHheOKAEb/AFZFAAfp\r\nSYBuByMdqSYEGZU+VM7e1VcjUnHB60FiO3yj60ADSKn3s57CgVxHlVNrswC56mgLirIGJHQ+hoC4\r\n3zkLjDjkce9AXQwbpZGX5flbr6CgnVsnPy4AGB7UFjBnfz+FIBsLh4d+3HzHgfWmA5SScngH1oAV\r\njwuPWgBcd8fnQBHGB5kmBjnn60Erck3cZoKF3ZyO9AADhcHtQAu7igBi4JY4zzQASNtjPbigTCJS\r\nsSg9ccmgEKSW4GfrikMAMA5/KgAB+bGOKAK1kCYGXt5j8/8AAjTAtDG32FAEUzZQkdByTQKWxMME\r\ncUDAdKAGv0HPcUAOHU0ANjHX60ALtAPSgB2KAGt9xvpQAuMn6UARj7xHrULcBQcZHvVWAifJK4Un\r\nPBHtTJY4x4GAZPxPSgdhQkavu2sWPrzQFkMaAMu07ivXaRxQLlJCsbAK8efQEZoHZEZjiVvlQjjp\r\nQHKhYwwkJ2gKQMetAluTZNBQw9Sx/ACkAyFxJDuVdoyRj8aYD8EfMTk9qAFbBK9e9ACNllO00gCF\r\nFEYA/GmJEmKBjSQgz+lADSxI4XrQAgQYx5eD7UACbl3ADv3NAEU5c7QDznoBQTIsgZUUFC7qAEYj\r\nGD1pMBuQvGCKEgK8DeTcPA33XJZD/MUwLeAKAIiC+RnAoAdCv7lAewxQJbCnJYgNikMZtJcgt0NF\r\ntQHjcD979KYCIG2/e/SgAbdtzu/SkwFG/AO7r7UwAhjkbhz7UAB3g43D8qQEbhgc5qZAOBYDr156\r\nU7gJCi5DDOfeqJS6kxOBQURscbWPY0ABfJoAUnDKfY0ARSShsquN3agTY+NcIueTjrQCVkPYgdTQ\r\nMapLHJ49KQDbdkaHKDAyRj8aYCnLtjsB2pAK2CVJpgKxAGKAI4PvOB03cUEomBOfagoacGX6CgAy\r\nCaAGyMxACdT39KBMjHnYYADPrQLUk27I+euOfrQNDhyuM0DFOAooAMHnHWgBOQeQTQBFcw+eoX7r\r\nDlW9DQAQTmSMhxiReHX3oAlUZzxgelACRE7nU9jxQJDsYbNKwxF+831pgL0PFAAn3KAA9D70rAKP\r\nuj6UwAdaAAgE5pWAQgHg0NXAMBeKLAH8YGe1MBCvzZ3nPvQA1juOM8DqaAHLt28UAVmzLMQDt28H\r\nigl6uyJlVVYKo9yaB2HK2Bt9DQMcFDc/rmgBrKcHB60AR25Ro8IhVQxHPrnmgCR+mOg9AOtIBzAb\r\nDjtTAYMY560AJDjZxxg+lAkS5PpQMZuyxII9M0AL7sc0AMOXlXaOF60Ce5IMAmgYjnK8frSYDUXK\r\ngliRTAeDk+3agA5yecUADZwBnqaAGsmGXk/nQBWuUaGUXEeSQPnHqKAJwVaNWRiQ3IOalsByKCM5\r\nOfrTTAGU7T8xoYCRqSD85600ApQgj52oAQL8oO9sUAKyfu87m6UAG07RhjSdwFK453t+lMA2H++3\r\n6UANdenzt19qAHbT/fb9KABV29epoATCA5JyfegBpwWOBn0pAOwQOvbrTAh4F4B3284oJe5MRjJ9\r\naRQx2xKQM9MmgBQx2n5ePrTAX5yuScegFADINuwmMlVDNnPrnmgB6tz8x+lADm/1bfSgBm7Yvcn2\r\npAJCpAYk8k5xTEkSklVJNAxoCgDIoASRxGhbFAm7IWJWEZ3HJPNAIcmOaBiMMrn0pMAjztFMB/eg\r\nBCOKAGsMqOe9AC7ADn0oARvvjPpQBUA+zXAQ/wCqkPyex9KTQF0cDimAdcigBsYxuHvQA49KAGKf\r\nkWgB7/6tvpQAingCgBWAxQAueKAGt1X60AGD60Af/9k=</Data></Thumbnail></Binary></metadata>\r\n"
+    },
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/7f4d35799c1abbf1d50723fd94edd74a.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230403</CreaDate><CreaTime>19382300</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>New Group Layer</resTitle></idCitation><idAbs>New Group Layer</idAbs><idCredit></idCredit><idPurp></idPurp><resConst><Consts><useLimit></useLimit></Consts></resConst></dataIdInfo></metadata>\r\n"
+    },
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/7fa0b861c006c1e089b64f9cf7b3e45b.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230403</CreaDate><CreaTime>19321800</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>New Group Layer</resTitle></idCitation><idAbs>New Group Layer</idAbs><idCredit></idCredit><idPurp></idPurp><resConst><Consts><useLimit></useLimit></Consts></resConst></dataIdInfo></metadata>\r\n"
+    },
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/b22945b8486342a73c9cc385edb3ef2c.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230403</CreaDate><CreaTime>19215600</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>New Group Layer</resTitle></idCitation><idAbs>New Group Layer</idAbs><idCredit></idCredit><idPurp></idPurp><resConst><Consts><useLimit></useLimit></Consts></resConst></dataIdInfo></metadata>\r\n"
     },
     {
       "type" : "CIMBinaryReference",

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/stage_based_catfim.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/stage_based_catfim.mapx
@@ -35,10 +35,10 @@
     "defaultViewingMode" : "Map",
     "mapType" : "Map",
     "defaultExtent" : {
-      "xmin" : -10042414.0540662669,
-      "ymin" : 3794700.82092288323,
-      "xmax" : -10037550.6777432077,
-      "ymax" : 3798135.4403768396,
+      "xmin" : -10043933.54418171,
+      "ymin" : 3794757.52702452661,
+      "xmax" : -10036031.1876277644,
+      "ymax" : 3798078.73427519621,
       "spatialReference" : {
         "wkid" : 102100,
         "latestWkid" : 3857
@@ -1701,18 +1701,13 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "definitionExpression" : "interval_stage <> 0",
+        "definitionExpression" : "interval_stage <> 0 And magnitude = 'action'",
         "definitionExpressionName" : "Query 1",
         "definitionFilterChoices" : [
           {
             "type" : "CIMDefinitionFilter",
             "name" : "Query 1",
-            "definitionExpression" : "interval_stage <> 0"
-          },
-          {
-            "type" : "CIMDefinitionFilter",
-            "name" : "Query 2",
-            "definitionExpression" : "magnitude = 'action'"
+            "definitionExpression" : "interval_stage <> 0 And magnitude = 'action'"
           }
         ],
         "displayField" : "name",
@@ -3017,6 +3012,7 @@
         "type" : "CIMLayerElevationSurface",
         "mapElevationID" : "{2040A0DA-3625-405D-8B32-E14FA806A248}"
       },
+      "expanded" : true,
       "layerType" : "Operational",
       "showLegends" : true,
       "visibility" : true,
@@ -3063,13 +3059,13 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "definitionExpression" : "interval_stage <> 0",
+        "definitionExpression" : "interval_stage <> 0 And magnitude = 'minor'",
         "definitionExpressionName" : "Query 1",
         "definitionFilterChoices" : [
           {
             "type" : "CIMDefinitionFilter",
             "name" : "Query 1",
-            "definitionExpression" : "interval_stage <> 0"
+            "definitionExpression" : "interval_stage <> 0 And magnitude = 'minor'"
           }
         ],
         "displayField" : "name",
@@ -4373,6 +4369,7 @@
         "type" : "CIMLayerElevationSurface",
         "mapElevationID" : "{2040A0DA-3625-405D-8B32-E14FA806A248}"
       },
+      "expanded" : true,
       "layerType" : "Operational",
       "showLegends" : true,
       "visibility" : true,
@@ -4419,13 +4416,13 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "definitionExpression" : "interval_stage <> 0",
+        "definitionExpression" : "interval_stage <> 0 And magnitude = 'moderate'",
         "definitionExpressionName" : "Query 1",
         "definitionFilterChoices" : [
           {
             "type" : "CIMDefinitionFilter",
             "name" : "Query 1",
-            "definitionExpression" : "interval_stage <> 0"
+            "definitionExpression" : "interval_stage <> 0 And magnitude = 'moderate'"
           }
         ],
         "displayField" : "name",
@@ -5730,6 +5727,7 @@
         "type" : "CIMLayerElevationSurface",
         "mapElevationID" : "{2040A0DA-3625-405D-8B32-E14FA806A248}"
       },
+      "expanded" : true,
       "layerType" : "Operational",
       "showLegends" : true,
       "visibility" : true,
@@ -5776,13 +5774,13 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "definitionExpression" : "interval_stage <> 0",
+        "definitionExpression" : "interval_stage <> 0 And magnitude = 'major'",
         "definitionExpressionName" : "Query 1",
         "definitionFilterChoices" : [
           {
             "type" : "CIMDefinitionFilter",
             "name" : "Query 1",
-            "definitionExpression" : "interval_stage <> 0"
+            "definitionExpression" : "interval_stage <> 0 And magnitude = 'major'"
           }
         ],
         "displayField" : "name",
@@ -7087,6 +7085,7 @@
         "type" : "CIMLayerElevationSurface",
         "mapElevationID" : "{2040A0DA-3625-405D-8B32-E14FA806A248}"
       },
+      "expanded" : true,
       "layerType" : "Operational",
       "showLegends" : true,
       "visibility" : true,
@@ -7117,6 +7116,7 @@
         "type" : "CIMLayerElevationSurface",
         "mapElevationID" : "{019DF820-BDA4-4783-84EF-8DA6118FA665}"
       },
+      "expanded" : true,
       "layerType" : "Operational",
       "minScale" : 750000,
       "showLegends" : true,
@@ -7132,18 +7132,13 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "definitionExpression" : "interval_stage = 0",
+        "definitionExpression" : "interval_stage = 0 AND magnitude = 'record'",
         "definitionExpressionName" : "Query 1",
         "definitionFilterChoices" : [
           {
             "type" : "CIMDefinitionFilter",
             "name" : "Query 1",
-            "definitionExpression" : "interval_stage = 0"
-          },
-          {
-            "type" : "CIMDefinitionFilter",
-            "name" : "Query 2",
-            "definitionExpression" : "magnitude = 'record'"
+            "definitionExpression" : "interval_stage = 0 AND magnitude = 'record'"
           }
         ],
         "displayField" : "name",

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/stage_based_catfim.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/stage_based_catfim.mapx
@@ -36,10 +36,10 @@
     "defaultViewingMode" : "Map",
     "mapType" : "Map",
     "defaultExtent" : {
-      "xmin" : -9175887.30386825278,
-      "ymin" : 4870907.1256162459,
-      "xmax" : -9170790.87684677914,
-      "ymax" : 4874506.33041367028,
+      "xmin" : -12620435.75982672,
+      "ymin" : 5177987.40641214326,
+      "xmax" : -10692420.8154191747,
+      "ymax" : 6539592.43051562831,
       "spatialReference" : {
         "wkid" : 102100,
         "latestWkid" : 3857
@@ -1083,7 +1083,7 @@
       "labelClasses" : [
         {
           "type" : "CIMLabelClass",
-          "expression" : "$feature.ahps_lid + \": \" + $feature.status",
+          "expression" : "Upper($feature.ahps_lid)",
           "expressionEngine" : "Arcade",
           "featuresToLabel" : "AllVisibleFeatures",
           "maplexLabelPlacementProperties" : {
@@ -1250,18 +1250,11 @@
               "extrapolateBaselines" : true,
               "fontEffects" : "Normal",
               "fontEncoding" : "Unicode",
-              "fontFamilyName" : "Tahoma",
-              "fontStyleName" : "Regular",
-              "fontType" : "Unspecified",
+              "fontFamilyName" : "Verdana",
+              "fontStyleName" : "Bold",
+              "fontType" : "TTOpenType",
               "haloSize" : 1,
-              "height" : 10,
-              "hinting" : "Default",
-              "horizontalAlignment" : "Left",
-              "kerning" : true,
-              "letterWidth" : 100,
-              "ligatures" : true,
-              "lineGapType" : "ExtraLeading",
-              "symbol" : {
+              "haloSymbol" : {
                 "type" : "CIMPolygonSymbol",
                 "symbolLayers" : [
                   {
@@ -1278,6 +1271,56 @@
                     }
                   }
                 ]
+              },
+              "height" : 10,
+              "hinting" : "Default",
+              "horizontalAlignment" : "Left",
+              "kerning" : true,
+              "letterWidth" : 100,
+              "ligatures" : true,
+              "lineGapType" : "ExtraLeading",
+              "symbol" : {
+                "type" : "CIMPolygonSymbol",
+                "symbolLayers" : [
+                  {
+                    "type" : "CIMSolidStroke",
+                    "enable" : true,
+                    "capStyle" : "Round",
+                    "joinStyle" : "Round",
+                    "lineStyle3D" : "Strip",
+                    "miterLimit" : 10,
+                    "width" : 0,
+                    "color" : {
+                      "type" : "CIMRGBColor",
+                      "values" : [
+                        0,
+                        0,
+                        0,
+                        0
+                      ]
+                    }
+                  },
+                  {
+                    "type" : "CIMSolidFill",
+                    "enable" : true,
+                    "color" : {
+                      "type" : "CIMRGBColor",
+                      "values" : [
+                        85,
+                        255,
+                        0,
+                        100
+                      ]
+                    }
+                  }
+                ]
+              },
+              "symbol3DProperties" : {
+                "type" : "CIM3DSymbolProperties",
+                "dominantSizeAxis3D" : "Z",
+                "rotationOrder3D" : "YXZ",
+                "scaleZ" : 1,
+                "scaleY" : 1
               },
               "textCase" : "Normal",
               "textDirection" : "LTR",
@@ -1805,6 +1848,7 @@
             "searchMode" : "Exact"
           }
         ],
+        "selectionSetURI" : "CIMPATH=SelectionSet/56a46e6e95c1a603351043391bb018b6.dat",
         "dataConnection" : {
           "type" : "CIMSqlQueryDataConnection",
           "workspaceConnectionString" : "ENCRYPTED_PASSWORD=00022e6879663255762b434e664e5a785855566c644d746b6f6c7a4d54515449774d564d504b6974473670574e43453d2a00;SERVER=hv-ti-egis-rds-pg-egdb.c4vzypepnkx3.us-east-1.rds.amazonaws.com;INSTANCE=sde:postgresql:hv-ti-egis-rds-pg-egdb.c4vzypepnkx3.us-east-1.rds.amazonaws.com;DBCLIENT=postgresql;DB_CONNECTION_PROPERTIES=hv-ti-egis-rds-pg-egdb.c4vzypepnkx3.us-east-1.rds.amazonaws.com;DATABASE=hydrovis;USER=hydrovis;AUTHENTICATION_MODE=DBMS",
@@ -2222,7 +2266,7 @@
       "layerType" : "Operational",
       "minScale" : 750000,
       "showLegends" : true,
-      "visibility" : false,
+      "visibility" : true,
       "displayCacheType" : "Permanent",
       "maxDisplayCacheAge" : 5,
       "showPopups" : true,
@@ -2898,7 +2942,7 @@
       "layerType" : "Operational",
       "minScale" : 750000,
       "showLegends" : true,
-      "visibility" : false,
+      "visibility" : true,
       "displayCacheType" : "Permanent",
       "maxDisplayCacheAge" : 5,
       "showPopups" : true,
@@ -3574,7 +3618,7 @@
       "layerType" : "Operational",
       "minScale" : 750000,
       "showLegends" : true,
-      "visibility" : false,
+      "visibility" : true,
       "displayCacheType" : "Permanent",
       "maxDisplayCacheAge" : 5,
       "showPopups" : true,
@@ -4250,7 +4294,7 @@
       "layerType" : "Operational",
       "minScale" : 750000,
       "showLegends" : true,
-      "visibility" : false,
+      "visibility" : true,
       "displayCacheType" : "Permanent",
       "maxDisplayCacheAge" : 5,
       "showPopups" : true,
@@ -4926,7 +4970,7 @@
       "layerType" : "Operational",
       "minScale" : 750000,
       "showLegends" : true,
-      "visibility" : false,
+      "visibility" : true,
       "displayCacheType" : "Permanent",
       "maxDisplayCacheAge" : 5,
       "showPopups" : true,
@@ -5599,6 +5643,11 @@
       "type" : "CIMBinaryReference",
       "uRI" : "CIMPATH=Metadata/745bebf5c7272e12653fc7d60400af25.xml",
       "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20220623</CreaDate><CreaTime>20130400</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>Map</resTitle></idCitation></dataIdInfo><Binary><Thumbnail><Data EsriPropertyType=\"PictureX\">/9j/4AAQSkZJRgABAQEAAAAAAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a\r\nHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy\r\nMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCADIASwDAREA\r\nAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA\r\nAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3\r\nODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm\r\np6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA\r\nAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx\r\nBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK\r\nU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3\r\nuLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3t3X5\r\nfmHWgBJCDtww6+tJ6gO3AKORn60AG5SMEjH1pgQW7CNzFtwOSv0oZEdHYmDASNk+lBYu9cjmgATk\r\nH60ANdgsTbumDQAkPKL6Y4oAfKcRmgA3r6n8qAGu4469fSgBS47Z/KgBNwLgjPHtQA4cnNAB/E34\r\nUAIc4xQA9RgUAVNQGYUOORIuPzoAnDn+JSPegBGdeeefpQAruNwGaTAGZSVO4daYCBgZc7hxQA4n\r\nIOOaAEIwucdKTAQOp5YgH0oTAeGXH3h+dACIy88jr60wHFh6j86AGow2DkUARXBGzIbJBzj1oJls\r\nSFleHIPFA0LvXd97il1GI0illwehpgOLrjrQAu9fWgBjY+UkDrQA3gyjGMZqVuA8gb14qgFbAHag\r\nCupDXpIyQF69hQR9olJxI3y5FBY4MvsKAGrIOcc89qACR8RsXUgYNADosbAR0wMUAEh+WgB5GcUm\r\nA1/4frTAdQAhxmgAB5x6UrgNwfMPPYUwF6tQA6gCpfH90vH/AC1T+dJAWTncPSjqA2Qd6YCvjHag\r\nBgUjbkd6WtwEkHDcfSi7ARM5GRgnrQwJ+owaYEZ2h26Z7ZpALjK8AUMAUBRyKYDsL6DFAAVXaeBQ\r\nA1VUoOnSgCOZNqF04PcetBLVtUETBx/smpTGnckl+VV24HNUMch3Lk0ALtoArG/t+zn/AL5P+FAF\r\nY6nEM4DbVPLHoCeg9e4oAhj8RWMjjfJ5eMgsR8uQcdfrQBLLrdhE6xtMSzjghCR0yOcUACahZxyA\r\nyXH7xsjGDj+X60EpdWaAcFyeenpQUKWU9VJ/CgBEYYPB6+lABI48t8q2MHPFAAjDy1wrYx6UAI7c\r\nDAPX0oAkyRQA1uSv1oAd0HSgBGJ3AUAKF5LGlYBqnLt+FFwFXpn1pgNDsSflPWgCC+LeUmQAPMXv\r\n70AWj0oAbJzHmgBjIc56+1So6gJukLAkYGelUBICWHI5FJagIWAYdelMBQ44zn8qSAQAMz4osANk\r\nHv0pPcBVHBJpoAzu4BxigAPK470ACuAo4PT0pgQXNzEqmNmO9hwApJoAqpeLChR1lwCMEpt/nSJi\r\nraDjqUMsYZFcr8xDADt1plCx6nEHjiCSlmXdwlICx9sH/PCf/vimAxlYWqujLkjqelJ7AUIY7e4b\r\nL7GQcbu2RQhNpAunWA2LDaxnk59PX+dDGWJdMt5Pml2DvwB6Y/lQF0VjZQmT7gA52nZxg/8A6qND\r\nPnZcjtCq7oLhlc9ccg/hQWnceLi5hH76Dev96P8AwoQyWC6hmyFcZz0PBpgSy48l9xwNpzQA5QAg\r\nA6YoAH6D60AOoAjf7yjvmgB2T3oAQ/6wfQ0ALnnFICMZDPnvikgJOgqgGp/F9aAIL8/uU/66J/Og\r\nCxnjFK4CMflwfUCmAufmpAD9R9RTAGpMBByw+lNAKT/OgBNwDng0AL5g9/yoAQOuODQAhI42nrSs\r\nA7PHvTArzXDb/JgG6Q9T2X3NACxwLChOS0jcsx6mgCG7tmecSjaeMAHsaCWn0IY4LSOYoQoDL06d\r\n8/1pXHrexaKWocOrKrDuKYyTeO0oxSuBzEVprJtIrSR45YEAGVyv5mvPxFHFVY+zhNRT69S04rVm\r\nna2Yt4BbjcypzlRgMTzxXZSpeypxprorGbfM9C9HaorAsGLdvatLC5UTCNAceWSfeiw+VEgzjlDR\r\nYZA64csnyMPbg0rEtdUOE7YGY2z9OPzouHMMeOC54kj2v+R/OmNMhkguI4XEc+6Pacq/p9aSbGSr\r\nemLAuImj/wBrqv51QFjzUkQNGwYZ7GgB25v7p/OgBrFsr8vf1oAcWbIG3r70ANJbzRx29aABi2R8\r\noz9aTAQBy5YqMfWmA7L+n60AIhbDHHegCpqO8QRlRn94uc/WgC2SEQGkBWlkWV4+RwwODTAX7aiv\r\nt8tgASM8UrgT796qwB5PSmA47mzxge9JgJ3GPSjoA5sfjRcBEzk/QUwHDvQAxTtGCD+VADcjPBU5\r\nqQK092GYxRMFxw0h6L/9eqAfEUiQJArOTyT6++aQDzHcOcEqi/maVgFMKAjcSxyOSaaAbc24aMug\r\nUFQe1BMr20E8gIFkRAfUY60aha2qH+b/ANMD+lK4c3kKqedgniMdFHeqDcfIAu3AFLYoUEM4J7Ch\r\nagIWPmDaM8UwH5bHI59KAGBhubcMe1ACHG4BODnpigBHUPw689iKTE1cgmBSF1eVhEVILH+H3pJk\r\n6onE8ZIXOR0zjiqK5kRyWETNvTMb/wB5DikMbi9hHVZ0/wC+W/woABeRMVSTdE3o/H69KEBaXk56\r\njsaAGZbz8HGMUwJNvzCgAJoAaS3PAP40ANTft7c+9AFTUx+6iZucSDgD+dAEZndwse8AfSpAZMGU\r\nFd4II9KLjI1BdcHk9yKQjShZ9sQYD65qkATSSpKOQF7e9DAQTMzZCcj1NFwJQ5bcCuMdD60APXgn\r\n8KEAtMCGW4jhUF2wew7n8KQFYRTXXJzDGf8Avo/4UAEdnEsfmKvIPy55pWI1tcvIQ6K2O1MpbETu\r\nxk2RkA4ySRmi4m9bIY0TvlpOCMYwf1oFZvcWMPLuV3+VTjAGM/WmmCu9yx07cUiwxnnFKwCDd2X9\r\naYDJGYbSQMZpgK24+mMetADYwyn7o4GOtACsx3AE9+cUAOAAoAZ1JJ6CgBwyQc8+1AEVyiyW0kcj\r\nbVZCC3pxSaAeYwYSoI9qVrCa0I7e6inG0SKXXhhmrcZJXaMKWJpVG4xkm0WjSOgxNSvUtbgvJMsq\r\nAY+zgDI961pUnUdkefmGPhg4KUtW+g+1kjuLQXFrK0ScllbkA1NSm4SszXBYuGLpe0gJNrEdnH5k\r\n7oyLwXjOf0qVGT2N6lanTspu1yzaapa3sfm288ciH0NDjJWuiIYmlNtKW25cUZXOevNSbjGLHdgn\r\nHNAEMlyYQBtzxmk3YGytPL5wCsxxg9vWpcxXIIQWUdd2cH61Qxzgq5BoAri7gDlfNAIk8sj/AGsZ\r\nx+VFgL8d6hK8j5OpPSmlYBJb+N5IlaRF3NtHucEj9AaGBZU7TUlD1YCUjjDDjnmmiRZbqG33GRwD\r\n2Hc1QFX7Tc3LBIFEan+J+tFxNksdq8Z3na8ndmOTSYtSUySD7yjHt1pXC7Ehzsw2cZ4HtSCOw5Y5\r\nUBVGG3tntVWCzWxJFHsBycseppjSsLL/AKs0DIoi20sMYY8UkrCQ9nZcdKYx2X9qAAyDsCfpQAxi\r\nX+UqR65FACDHTHSgByjrQA2XIx60ABYsduMUAJklTgDC9aAHsSBuHegCvcp9ot5E3r8ykZpANkvI\r\nkuFiYsrN907Dg/j0oAxr/Q5/tDT2UgV2Oducc11Rrq1pHzOMySp7X2uGla/yM6PWNT0+ZkvUkO08\r\no/ceoNX7KFVe6cTxuNy+vyVnzL8/QyI7e5uNQubwW0shmJO3BIWtYUlSW+pnicbUx0lL2TcV6/mX\r\n7CfURbHToYSJXbcQUPT8egpz5LqUjKhPGJOhh4tJu/8ATGS6HqplaP7MWGcnbjbThWpJXTJr5fmE\r\n6lpxcmuvQWLw/qUZ2xWrIPZxSVamuonlePk7uDNHTL6eK7+x3tw6EHaDkcH0NYVKSl70T1cuzSpS\r\nq/VsT00v2OkaG6VfluFYH+8n+BrjZ9UVpYL1mBLKeMfIMfzNS7MBj24VVaT7Rj2A4/IUWQWIjG6F\r\nmgldgxyQ6ZNPQBrLdYycdM8qRQBRe0Dl5DEpYHefm707jLS2ly8RPl5U8nnAz60CEXTGkEbm1BCO\r\nHT5jwQCM9Pc0XA02e8Bx5SD6DNICrdtLFE0s06RxryTjB/DrTim3ZE1KkacXKbskY/8AbtmpDQwS\r\nySYBJl4A/wDr1usNJv3jw8Vn1CnH9z7zOhsL1L9I5IwBgZYZ6H0rOdPklY9DBYyOLpqpH5mpUncN\r\ncfKcdaVgIlUnHFRZiJGYque+KsYqDCimAknKGgCEHEnkYIHUEelBKdnYlKgFfrQUPoAZwoAJ6UAB\r\nIwCDnBoAhORIxxxnmkBIDnPUc0wFYZIIFADdo3Y6elACnCnAHbkUARsx28AkAdutIDLtrcf6SqyO\r\nxlQ53Y+T26CgBzrnUkJ8ksCBgj5ugoGbBAGT3NMRDJHFIQSis3YkZxTUmtjOdKE/jSY4IEYBcL9K\r\nRailoiX5/QfWgY1M7yCfekgJaYGHqugxX7GeJvLnx+DfWt6dZxVmeJmOTQxLdSDtL8GYUGs6np7G\r\nCdC4j4+ZM4/Guh0adT3l1PEhmWOwb9lNX5dNV+pt2PiS0niY3DLE6jJ9D9KwlhpL4T2MJntGpF+2\r\n91o0oby3vYBLBIHTdjisKkHB2keth8TSxMOek7onJQ9SAPrUWubOSW7IbhcorKC2DwF60crDm0ut\r\nTjbnXbuG5eD7OqsQQynjIrteHpqHNc+Tr8QVqNVRnCyW6N211NZba3lLvhhwgGa5vZy5uU+hjj6U\r\nqMa0dUyy2vaejYN1yOCNvQ1caE5K6RnXzXC0Jcs5amXfeJWdzFYpuHTzCP5CtlhktZHjYvP3J8mG\r\nXz/4BhXV9cX2xZpSViPKtxk+4q1TjDVLXyPGxGY4qrD2VV6GtpOkpdlLi5KiLGRGP4setZOSo+6n\r\nd/lc9DK8reIarVfh7dzpba3jtyFt4ljiHYDrXPKTk7s+soYenQjy01ZF2kbkXzuOoA+lADvmA6r+\r\nVAEbl2VgNpGOaQD1D4HzfpTAHDBD836UAV1KidnZtp6EnvQTpe5Ywdy/NmgofQAzhs0AIAd3XAoA\r\nMfM3vQAxSNzKOef0pASLgcUwAr8nHUUAIo3Lk9TQA11K9OABSAzbVGfzkX5WeMkEn7xz1oQxx+zD\r\nVNpYmXOSo6dOtAGm30zTENGQNxHJ6UgBh8w/vdaYD94xxQAhHIOcNQAu1v736UAIq5HJ70mgOf1u\r\n+1C2dYYLOORZTgPwSB9K2pqN0rnm4p1lSqPlT7HKi2AuAtyrR5BP1NdeKq1YU70Vd3X3HwsKS5/3\r\n2m5dtlv7E26QzrELiQKqE88gnOPwpVqlO9pq7PZyzBY7k56UuVP8Tdj8OSON13fSsWOSFOBWTxVt\r\nIxPRjkcp+9Wqtt9ijdLJoc32q2vBLAjANEz8/StVKNRcs1ZnHPD18FP2uGlzxW6ILmA+IdUWVImi\r\niIC7mHfFUpRow5Xqc9TDzzXFOcI8sdNy1P4cmtoVS2uHJJxtPFZrEQk/fR2TyXEUI/7PU17F7SvD\r\n8NkGkulE0zdyMgCoq4ly0jojsy/JYUbzr+9I1ltLbnbCqn/dxXM5SfU9eOGoxd4xRnjw7p8TmRYN\r\n0jNkl2z1q41pxVkzCtl+Gqy55QTZoxwxxYjjUDbWT1d2dcKcYRUYqyHt+727m79BRYscZvRG/KmA\r\nkbMQBwKAHFeeSSKAFYAI2PSgBVPHNACSfcoAimC7ANoLMcCgmRJjGwZoKH0AM4UY9aAGjcR2/GgA\r\n+bOcj0xigBFyGY4HbqaAFG/HRaAAFypAwMcdKAAbgMcUAJlunBzQBmW6O/2pFwrsCEPA4/M96SAJ\r\nYt+rBgu5lwCckgcemMD86BmpnjDA59qYh6kHt07GgBGH7wH2oAQY2dfegB+MigBCSKAGopOTuI56\r\nUAch4m0+1k1FblnuDchPlwRsA+h6VpBQhapN6HhZxjeSLw8U7tXujDX5Z0WUtnjnPbvXocymuaOq\r\nPi1pL3jso/D2mfb4tSEbNOAuws5IUY7CvNnJtu5+lUIQVOPJtZWNwgEEZ61Js1dWM9NG0+Nw4to2\r\nfOd7DJqpVJT3MKGFpYdNU1a5NMgS5tgowMnj8Kk3tbYnjO8l8cds0CWupIRmgogk3eeACQpHUUCY\r\nvk7AWLsWz1oCwpXn5ScnqaBjlQLz1PqaAA8t16dqAEjB2+hoAfigBsnKEA9qAHKOKAEk+7+IoAgl\r\nO9fubiDlQOOamLbJkPwTsBOG71VxoXleNzUrjBQd3JoAcQDTAApHIpAIBhyD3FMB205zQAL1b60A\r\nOJFK4EcgyOOtMDOtkcs2VZSQyrufpz6UgFLNBcDzGkPyqWCnAHbn1oGanbNMRHy7bhkDFACMSjDP\r\nIz1oAXJViAMjrQA7f0BBGaAHZoAYv3m+tAFLUtNh1G3Ksq+YB8jntWlOo4+h52YZfDFw/vdGcxo9\r\nrEdamtr6ONivTPTIrrk3GkuRny+W4el9clSxCTt+Z2RCbRjBwQK4H5n28Wre6SbF9BQURSeWm3IH\r\nWgVyC4Aa6t1Vccnn8KALXloo6cChjFCKRnmgCN4gz9SCB1oE0NXDDyyx3DrzQCJFwCVzx2oGOBBH\r\nWgAHXmgBqHAP1oAepz1FADX4U/SgBwyOTQBG53L+NADJE3OqKcA8mklYl66DiD5inNK2tyiUdORz\r\nTQEYBCgn15pgOAJyP1oAB93FJgNUtv6ZOKUQHF2zjb+tUA0F9+cDmgAO/PK8expNXAcHJyNvSmBQ\r\nSGVNSaTy28sjg5H/AOukBUvROotyYiWHDHB9e5oA2FlJQZXHHemAqFtg+X9aAByxXlf1oAUAjov6\r\n0AI24gEL096AAFmGeBQAmxievX2oAVVYk/N0PpQBi6j4eS9Z54ZTHOTnPY100sQ46M8HH5JCvJ1a\r\nbtJlfw27xx3NpcOfPSUfK55x7VWK1aktiMhvCNSlN+8nsdAAxZlVsAH0rkPf1YpVVKZHOetFx2Ip\r\n3BurcDnDHp9KBlj5j1wBQAY/2jQA0KDJ68UAQoN08nAAxjHrQT1JWBx06dMUFCAALk9+gpAPHB6U\r\nwGgEE+oNADvcmkAjKChOT0oAbsJXqTS1AGQBOnJqgEKBZg3YjB9qCXuOdVJWkyh4QY6UAGPkH0pg\r\nL3I9aAEwFbPap2AapAl+opoBTy54zxTAQDn5VpAOz60wETG5vrQA+gCtEH2KJM7snr9eKALI6UAF\r\nADX+7QApbAyaADPFADUwVFADxQBQuNW06zleO4vYI5ANxRpAGx9OtF+gXM288TWotEmsZoZS3OH3\r\nDj8BWsKE5q6R5+JzTC4eXLUlr2ONS+urrxDa3d20aSNdKRt6KuMAV0TpSjR16Hk4XF0q2Z89LZx/\r\nE9KEqh2U4znOR3riPpVuPbD7dxyM9KBkUuPttuoUADcf5UAWWYAUAMyMdDmgAI4zyGxSAZExYliM\r\nZ4pkrXUmAI4FBQxcB2yOQe1IBQctmhMBSFP3gM0wBMbBQA3PyuM9qmIDgwC9aoBruu3qDSAbKybd\r\npw244ApoUh5KgpyOPegY/cv94fnQAxtwXO4flQA8dMmgBGOeMGkBEFPmDjjHehKwEnO7Ix0pgA3+\r\n1AC/P6CgBq5DNx+VAD8juaAK8LM0GJM78n+fFAEwyO1IB+RTAqXt7DaRBpHHJAxTSuTKSW5Smnu5\r\nZzFGdo3gg44K9evvT0RLbuUHs75IWVNSIRcli/v3p8y7E2l0ZqWNxC1vDE93G0pTOQevvUs1W2pV\r\nudUu49RlS3gFxawRhpSrfMM56evApDOQtfDreJddvrx5Y/7P+1+YGKnewA4APpXDLBqWKWI5notu\r\nhyywylWVW/yNy98IJKLhrWcoGB2Kw4B+vpXsU8S4Q5LHnYnJoVsV9YuW5/DNrcpazuWS6iijAKHg\r\nFe+O/NYqrNJxT0Z6f1WjzKfKro2ijtcJwDtHJrM2d7llhxxQUVLg7bmCUn5RlSfTNAFtsY680AR5\r\n4wB+NIB7DOOM0wI0yjsmQSTke1BK0ZN0OTQURZJdjtNJgOwMjI5NHUCTHNMBiqNvSgBsiDacDHFJ\r\noBwUYHyimASABDxQBHMANhI/iHagmQ9hyvAoKFx7ClqAZBBFMBSfloAXtQA1vvj6UmAvQZoQC0wA\r\nsAaTYDA2Sfc0XAQ/6wZHGKAG2pZoAXGGyc8YpgV9QvxZQkhd7/3c/qfamlcmUrIyhLqWoTHeVtYS\r\nMKOck8d6rRGd5PfQsDS4nbfIZJXJHLDj60rj5S+qgzCIjITjHtUjW9h81tbvIjugLD/PSguyKv8A\r\nYtjukka2DF2ycscj6UBYtW9rDAhSGIImfuigZMkUcSYVFUDsBgUAOUjB6daAGMV2ELj8KAEhAy57\r\n55oJRKTxjNBRHcIHgkUjqpoAjtj5lujt/doAlYg4C0AObIHBoAgkwm2RuoPU9qETLuThSeTQUJgF\r\nzn60AKeucigB2fagBi5xx60ADZIIPcUAKpAUcjNACSfdNAEc0i7McnkdqBPYfvXIwTx14oGL5q+/\r\n5UAKeB0oATGSB2FADuozSQDf+Wn4UwH4oAaTgdKAAdeRQA0AZPODmpdgFA+bPYcVQFCdZbnTyoYi\r\nXOfTOD0oWhMldFO1s40ffMTJJ/CDztP1qmyEjUCAD5mLYXABHSpLUe5KsQCBVc4oGlYjhVRK+Gw5\r\nPPFAla5KOSTnI6ZNBQ4DJoAaM5ZR0oAUc5z60ANQDc3GeaQEcjsvyheWpJCbJVQJFjP1NUCVgGSM\r\nDg9qBjsMB97NAFWEeRO9v/ARvX29qALB6gAd6AHEHHFAEUqhtisc5PSgT10JeSODQMa64weeKAFI\r\nwOAKAHc9qAGrnn60ALg4JPpQA3YCBSsgFb7p9KYDZFzGcHihCewqYGR70DI8nJ4PWgCxQA3GKAFB\r\n6UkAn/LT8KYDqACgBDQBGFDbvmxzSauAmNrbd/vTAqxEzLE+7k5GB/OkQ9WWo41jBB5+tMpKwpQe\r\nVyKBjsIOOlAEBKm4QA46/wAqCXuixkY60FAM/hQAhOC2OpxQAv3RjFADUyM49aAIbtwFQHgluKCZ\r\ndCxjPOaChOS3TigAGSfQCgCvJkX0eMH5DQBMC5IO3j60ADPk42nIoAjBLTqNp+UZoF1Jd+GxtOaB\r\ngXLAjYaAG7yeNpz0oAeH/wBk0AND8Y2nOaAHM5242mgBoZsAbTmgAcnYRtNACHcUKHhscCkhPYVH\r\n/gIwwFME+ghR89aBkm1v77fpQAxg2R856+1ADgh/vt+lKwCbT5g+duntTAdtb++36UAIAdxG9v0o\r\nANvH3moAhkWSPGwgjPO6gTbG/ZXkYu8hU9tp6UCs2NtIgYhKTtPIwOKQ1FIsIAvzNzTGOdgUODQA\r\ngwCT1NICHYDd+YTjC0ybe9cm6dB9aCh4JxyMUAMTLEsemaAFBy1AAnVvrQBFcpvRcDJB69xQTJEq\r\nt+7B7YoKFyGoACPloArT5jljnCllUEMAO3rQBYDh1VlOVPINADdv70k9MUkALgTN0yRTF1FH+tag\r\nY4Z9RxQA1R87E0AOWgBBwp+tADjzSAF6ZpgNP3CaAFOM+9ADXXGH5ytAn3HhsjNAyP5ieDUWdwHE\r\nYC+xqkA7vTAQn51/GgB1ADBnzD9KQCSSpHgHqelMTdhkUatliSxz1oEl1JQ3OAKCiCKUyxK5XHJG\r\nPxpATAkDkUwGvllAxjmgAAC9etICNPnnY5+7wBTJ6k6juTmgoGHymgBOi5z1oAVRgUAM34LAA9aA\r\nGyFzE21SDg80CewkIby14GB60AtiYbz6UDEYOR1FACDdgrwRQBXsTm2Cjs7D/wAeNAFk44PekBGw\r\nKSI/vtNMT3uSAHJJ4oGL3yO9ADWB3+gNADlHy4FADF3ZPQ4NIBS24DoM0wHHheOKAEb/AFZFAAfp\r\nSYBuByMdqSYEGZU+VM7e1VcjUnHB60FiO3yj60ADSKn3s57CgVxHlVNrswC56mgLirIGJHQ+hoC4\r\n3zkLjDjkce9AXQwbpZGX5flbr6CgnVsnPy4AGB7UFjBnfz+FIBsLh4d+3HzHgfWmA5SScngH1oAV\r\njwuPWgBcd8fnQBHGB5kmBjnn60Erck3cZoKF3ZyO9AADhcHtQAu7igBi4JY4zzQASNtjPbigTCJS\r\nsSg9ccmgEKSW4GfrikMAMA5/KgAB+bGOKAK1kCYGXt5j8/8AAjTAtDG32FAEUzZQkdByTQKWxMME\r\ncUDAdKAGv0HPcUAOHU0ANjHX60ALtAPSgB2KAGt9xvpQAuMn6UARj7xHrULcBQcZHvVWAifJK4Un\r\nPBHtTJY4x4GAZPxPSgdhQkavu2sWPrzQFkMaAMu07ivXaRxQLlJCsbAK8efQEZoHZEZjiVvlQjjp\r\nQHKhYwwkJ2gKQMetAluTZNBQw9Sx/ACkAyFxJDuVdoyRj8aYD8EfMTk9qAFbBK9e9ACNllO00gCF\r\nFEYA/GmJEmKBjSQgz+lADSxI4XrQAgQYx5eD7UACbl3ADv3NAEU5c7QDznoBQTIsgZUUFC7qAEYj\r\nGD1pMBuQvGCKEgK8DeTcPA33XJZD/MUwLeAKAIiC+RnAoAdCv7lAewxQJbCnJYgNikMZtJcgt0NF\r\ntQHjcD979KYCIG2/e/SgAbdtzu/SkwFG/AO7r7UwAhjkbhz7UAB3g43D8qQEbhgc5qZAOBYDr156\r\nU7gJCi5DDOfeqJS6kxOBQURscbWPY0ABfJoAUnDKfY0ARSShsquN3agTY+NcIueTjrQCVkPYgdTQ\r\nMapLHJ49KQDbdkaHKDAyRj8aYCnLtjsB2pAK2CVJpgKxAGKAI4PvOB03cUEomBOfagoacGX6CgAy\r\nCaAGyMxACdT39KBMjHnYYADPrQLUk27I+euOfrQNDhyuM0DFOAooAMHnHWgBOQeQTQBFcw+eoX7r\r\nDlW9DQAQTmSMhxiReHX3oAlUZzxgelACRE7nU9jxQJDsYbNKwxF+831pgL0PFAAn3KAA9D70rAKP\r\nuj6UwAdaAAgE5pWAQgHg0NXAMBeKLAH8YGe1MBCvzZ3nPvQA1juOM8DqaAHLt28UAVmzLMQDt28H\r\nigl6uyJlVVYKo9yaB2HK2Bt9DQMcFDc/rmgBrKcHB60AR25Ro8IhVQxHPrnmgCR+mOg9AOtIBzAb\r\nDjtTAYMY560AJDjZxxg+lAkS5PpQMZuyxII9M0AL7sc0AMOXlXaOF60Ce5IMAmgYjnK8frSYDUXK\r\ngliRTAeDk+3agA5yecUADZwBnqaAGsmGXk/nQBWuUaGUXEeSQPnHqKAJwVaNWRiQ3IOalsByKCM5\r\nOfrTTAGU7T8xoYCRqSD85600ApQgj52oAQL8oO9sUAKyfu87m6UAG07RhjSdwFK453t+lMA2H++3\r\n6UANdenzt19qAHbT/fb9KABV29epoATCA5JyfegBpwWOBn0pAOwQOvbrTAh4F4B3284oJe5MRjJ9\r\naRQx2xKQM9MmgBQx2n5ePrTAX5yuScegFADINuwmMlVDNnPrnmgB6tz8x+lADm/1bfSgBm7Yvcn2\r\npAJCpAYk8k5xTEkSklVJNAxoCgDIoASRxGhbFAm7IWJWEZ3HJPNAIcmOaBiMMrn0pMAjztFMB/eg\r\nBCOKAGsMqOe9AC7ADn0oARvvjPpQBUA+zXAQ/wCqkPyex9KTQF0cDimAdcigBsYxuHvQA49KAGKf\r\nkWgB7/6tvpQAingCgBWAxQAueKAGt1X60AGD60Af/9k=</Data></Thumbnail></Binary></metadata>\r\n"
+    },
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=SelectionSet/56a46e6e95c1a603351043391bb018b6.dat",
+      "data" : "CgMxLjAQARoHCgUxMTI1Mw=="
     }
   ]
 }

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/stage_based_catfim.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/stage_based_catfim.mapx
@@ -36,10 +36,10 @@
     "defaultViewingMode" : "Map",
     "mapType" : "Map",
     "defaultExtent" : {
-      "xmin" : -9393552.88432426378,
-      "ymin" : 4843752.00193005614,
-      "xmax" : -9374585.37919515744,
-      "ymax" : 4857147.25612837821,
+      "xmin" : -9175887.30386825278,
+      "ymin" : 4870907.1256162459,
+      "xmax" : -9170790.87684677914,
+      "ymax" : 4874506.33041367028,
       "spatialReference" : {
         "wkid" : 102100,
         "latestWkid" : 3857
@@ -1658,6 +1658,15 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
+        "definitionExpression" : "interval_stage <> 0",
+        "definitionExpressionName" : "Query 1",
+        "definitionFilterChoices" : [
+          {
+            "type" : "CIMDefinitionFilter",
+            "name" : "Query 1",
+            "definitionExpression" : "interval_stage <> 0"
+          }
+        ],
         "displayField" : "name",
         "editable" : true,
         "fieldDescriptions" : [
@@ -1742,7 +1751,7 @@
           {
             "type" : "CIMFieldDescription",
             "alias" : "Stage",
-            "fieldName" : "stage",
+            "fieldName" : "interval_stage",
             "numberFormat" : {
               "type" : "CIMNumericFormat",
               "alignmentOption" : "esriAlignRight",
@@ -1751,6 +1760,20 @@
               "roundingValue" : 2
             },
             "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Stage",
+            "fieldName" : "stage",
+            "numberFormat" : {
+              "type" : "CIMNumericFormat",
+              "alignmentOption" : "esriAlignRight",
+              "alignmentWidth" : 0,
+              "roundingOption" : "esriRoundNumberOfSignificantDigits",
+              "roundingValue" : 2
+            },
+            "visible" : false,
             "searchMode" : "Exact"
           },
           {
@@ -1778,20 +1801,6 @@
             "type" : "CIMFieldDescription",
             "alias" : "geom",
             "fieldName" : "geom",
-            "visible" : false,
-            "searchMode" : "Exact"
-          },
-          {
-            "type" : "CIMFieldDescription",
-            "alias" : "interval_stage",
-            "fieldName" : "interval_stage",
-            "numberFormat" : {
-              "type" : "CIMNumericFormat",
-              "alignmentOption" : "esriAlignRight",
-              "alignmentWidth" : 0,
-              "roundingOption" : "esriRoundNumberOfSignificantDigits",
-              "roundingValue" : 2
-            },
             "visible" : false,
             "searchMode" : "Exact"
           }
@@ -2213,7 +2222,7 @@
       "layerType" : "Operational",
       "minScale" : 750000,
       "showLegends" : true,
-      "visibility" : true,
+      "visibility" : false,
       "displayCacheType" : "Permanent",
       "maxDisplayCacheAge" : 5,
       "showPopups" : true,
@@ -2889,7 +2898,7 @@
       "layerType" : "Operational",
       "minScale" : 750000,
       "showLegends" : true,
-      "visibility" : true,
+      "visibility" : false,
       "displayCacheType" : "Permanent",
       "maxDisplayCacheAge" : 5,
       "showPopups" : true,
@@ -3565,7 +3574,7 @@
       "layerType" : "Operational",
       "minScale" : 750000,
       "showLegends" : true,
-      "visibility" : true,
+      "visibility" : false,
       "displayCacheType" : "Permanent",
       "maxDisplayCacheAge" : 5,
       "showPopups" : true,
@@ -4241,7 +4250,7 @@
       "layerType" : "Operational",
       "minScale" : 750000,
       "showLegends" : true,
-      "visibility" : true,
+      "visibility" : false,
       "displayCacheType" : "Permanent",
       "maxDisplayCacheAge" : 5,
       "showPopups" : true,
@@ -4917,7 +4926,7 @@
       "layerType" : "Operational",
       "minScale" : 750000,
       "showLegends" : true,
-      "visibility" : true,
+      "visibility" : false,
       "displayCacheType" : "Permanent",
       "maxDisplayCacheAge" : 5,
       "showPopups" : true,

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/stage_based_catfim.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/stage_based_catfim.mapx
@@ -26,6 +26,7 @@
     },
     "layers" : [
       "CIMPATH=map/hydrovis_reference_nws_flood_categorical_hand_fim_sites.xml",
+      "CIMPATH=map/stage_based_catfim__action.xml",
       "CIMPATH=map/stage_based_catfim4.xml",
       "CIMPATH=map/stage_based_catfim3.xml",
       "CIMPATH=map/stage_based_catfim2.xml",
@@ -35,10 +36,10 @@
     "defaultViewingMode" : "Map",
     "mapType" : "Map",
     "defaultExtent" : {
-      "xmin" : -9389142.88613675535,
-      "ymin" : 4828322.49227744155,
-      "xmax" : -9346431.49694715813,
-      "ymax" : 4861506.87994208746,
+      "xmin" : -9393552.88432426378,
+      "ymin" : 4843752.00193005614,
+      "xmax" : -9374585.37919515744,
+      "ymax" : 4857147.25612837821,
       "spatialReference" : {
         "wkid" : 102100,
         "latestWkid" : 3857
@@ -1625,6 +1626,573 @@
       },
       "scaleSymbols" : true,
       "snappable" : true
+    },
+    {
+      "type" : "CIMFeatureLayer",
+      "name" : "Stage-Based CatFIM: 1ft Intervals",
+      "uRI" : "CIMPATH=map/stage_based_catfim__action.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant",
+        "start" : 978307200000
+      },
+      "metadataURI" : "CIMPATH=Metadata/2daef7e5de38aaa23c7db4cfd117aca3.xml",
+      "useSourceMetadata" : true,
+      "description" : "hydrovis.reference.nws_flood_categorical_hand_fim",
+      "layerElevation" : {
+        "type" : "CIMLayerElevationSurface",
+        "mapElevationID" : "{2040A0DA-3625-405D-8B32-E14FA806A248}"
+      },
+      "expanded" : true,
+      "layerType" : "Operational",
+      "minScale" : 82589.936619314918,
+      "showLegends" : true,
+      "visibility" : true,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "autoGenerateFeatureTemplates" : true,
+      "featureElevationExpression" : "0",
+      "featureTable" : {
+        "type" : "CIMFeatureTable",
+        "displayField" : "name",
+        "editable" : true,
+        "fieldDescriptions" : [
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "oid",
+            "fieldName" : "oid",
+            "numberFormat" : {
+              "type" : "CIMNumericFormat",
+              "alignmentOption" : "esriAlignRight",
+              "alignmentWidth" : 0,
+              "roundingOption" : "esriRoundNumberOfDecimals",
+              "roundingValue" : 0
+            },
+            "readOnly" : true,
+            "visible" : false,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "NWS LID",
+            "fieldName" : "ahps_lid",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Name",
+            "fieldName" : "name",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "USGS HUC8",
+            "fieldName" : "huc8",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "WFO",
+            "fieldName" : "wfo",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "RFC",
+            "fieldName" : "rfc",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "State",
+            "fieldName" : "state",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "County",
+            "fieldName" : "county",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "FIM Version",
+            "fieldName" : "version",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Magnitude",
+            "fieldName" : "magnitude",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Stage",
+            "fieldName" : "stage",
+            "numberFormat" : {
+              "type" : "CIMNumericFormat",
+              "alignmentOption" : "esriAlignRight",
+              "alignmentWidth" : 0,
+              "roundingOption" : "esriRoundNumberOfSignificantDigits",
+              "roundingValue" : 2
+            },
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Stage Units",
+            "fieldName" : "stage_uni",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Stage Source",
+            "fieldName" : "s_src",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "Viz",
+            "fieldName" : "viz",
+            "visible" : false,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "geom",
+            "fieldName" : "geom",
+            "visible" : false,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
+            "alias" : "interval_stage",
+            "fieldName" : "interval_stage",
+            "numberFormat" : {
+              "type" : "CIMNumericFormat",
+              "alignmentOption" : "esriAlignRight",
+              "alignmentWidth" : 0,
+              "roundingOption" : "esriRoundNumberOfSignificantDigits",
+              "roundingValue" : 2
+            },
+            "visible" : false,
+            "searchMode" : "Exact"
+          }
+        ],
+        "dataConnection" : {
+          "type" : "CIMSqlQueryDataConnection",
+          "workspaceConnectionString" : "ENCRYPTED_PASSWORD=00022e6879663255762b434e664e5a785855566c644d746b6f6c7a4d54515449774d564d504b6974473670574e43453d2a00;SERVER=hv-ti-egis-rds-pg-egdb.c4vzypepnkx3.us-east-1.rds.amazonaws.com;INSTANCE=sde:postgresql:hv-ti-egis-rds-pg-egdb.c4vzypepnkx3.us-east-1.rds.amazonaws.com;DBCLIENT=postgresql;DB_CONNECTION_PROPERTIES=hv-ti-egis-rds-pg-egdb.c4vzypepnkx3.us-east-1.rds.amazonaws.com;DATABASE=hydrovis;USER=hydrovis;AUTHENTICATION_MODE=DBMS",
+          "workspaceFactory" : "SDE",
+          "dataset" : "hydrovis.reference.%nws_flood_categorical_hand_fim_1_3_3",
+          "datasetType" : "esriDTFeatureClass",
+          "sqlQuery" : "select oid,ahps_lid,magnitude,version,huc8,interval_stage,name,wfo,rfc,state,county,stage,stage_uni,s_src,viz,geom from hydrovis.reference.stage_based_catfim",
+          "srid" : "3857",
+          "spatialReference" : {
+            "wkid" : 102100,
+            "latestWkid" : 3857
+          },
+          "oIDFields" : "oid",
+          "geometryType" : "esriGeometryPolygon",
+          "extent" : {
+            "xmin" : -20037700,
+            "ymin" : -30241100,
+            "xmax" : 900699887774.099,
+            "ymax" : 900689684374.099,
+            "spatialReference" : {
+              "wkid" : 102100,
+              "latestWkid" : 3857
+            }
+          },
+          "queryFields" : [
+            {
+              "name" : "oid",
+              "type" : "esriFieldTypeInteger",
+              "alias" : "oid"
+            },
+            {
+              "name" : "ahps_lid",
+              "type" : "esriFieldTypeString",
+              "alias" : "ahps_lid",
+              "length" : 60000
+            },
+            {
+              "name" : "magnitude",
+              "type" : "esriFieldTypeString",
+              "alias" : "magnitude",
+              "length" : 60000
+            },
+            {
+              "name" : "version",
+              "type" : "esriFieldTypeString",
+              "alias" : "version",
+              "length" : 60000
+            },
+            {
+              "name" : "huc8",
+              "type" : "esriFieldTypeString",
+              "alias" : "huc8",
+              "length" : 60000
+            },
+            {
+              "name" : "interval_stage",
+              "type" : "esriFieldTypeDouble",
+              "alias" : "interval_stage"
+            },
+            {
+              "name" : "name",
+              "type" : "esriFieldTypeString",
+              "alias" : "name",
+              "length" : 60000
+            },
+            {
+              "name" : "wfo",
+              "type" : "esriFieldTypeString",
+              "alias" : "wfo",
+              "length" : 60000
+            },
+            {
+              "name" : "rfc",
+              "type" : "esriFieldTypeString",
+              "alias" : "rfc",
+              "length" : 60000
+            },
+            {
+              "name" : "state",
+              "type" : "esriFieldTypeString",
+              "alias" : "state",
+              "length" : 60000
+            },
+            {
+              "name" : "county",
+              "type" : "esriFieldTypeString",
+              "alias" : "county",
+              "length" : 60000
+            },
+            {
+              "name" : "stage",
+              "type" : "esriFieldTypeDouble",
+              "alias" : "stage"
+            },
+            {
+              "name" : "stage_uni",
+              "type" : "esriFieldTypeString",
+              "alias" : "stage_uni",
+              "length" : 60000
+            },
+            {
+              "name" : "s_src",
+              "type" : "esriFieldTypeString",
+              "alias" : "s_src",
+              "length" : 60000
+            },
+            {
+              "name" : "viz",
+              "type" : "esriFieldTypeString",
+              "alias" : "viz",
+              "length" : 60000
+            },
+            {
+              "name" : "geom",
+              "type" : "esriFieldTypeGeometry",
+              "alias" : "geom",
+              "geometryDef" : {
+                "avgNumPoints" : 0,
+                "geometryType" : "esriGeometryPolygon",
+                "hasM" : false,
+                "hasZ" : false,
+                "spatialReference" : {
+                  "wkid" : 102100,
+                  "latestWkid" : 3857
+                }
+              }
+            }
+          ],
+          "spatialStorageType" : 8
+        },
+        "studyAreaSpatialRel" : "esriSpatialRelUndefined",
+        "searchOrder" : "esriSearchOrderSpatial"
+      },
+      "htmlPopupEnabled" : true,
+      "selectable" : true,
+      "featureCacheType" : "Session",
+      "displayFiltersType" : "ByScale",
+      "featureBlendingMode" : "Alpha",
+      "labelClasses" : [
+        {
+          "type" : "CIMLabelClass",
+          "expression" : "$feature.name",
+          "expressionEngine" : "Arcade",
+          "featuresToLabel" : "AllVisibleFeatures",
+          "maplexLabelPlacementProperties" : {
+            "type" : "CIMMaplexLabelPlacementProperties",
+            "featureType" : "Polygon",
+            "avoidPolygonHoles" : true,
+            "canOverrunFeature" : true,
+            "canPlaceLabelOutsidePolygon" : true,
+            "canRemoveOverlappingLabel" : true,
+            "canStackLabel" : true,
+            "connectionType" : "Unambiguous",
+            "constrainOffset" : "NoConstraint",
+            "contourAlignmentType" : "Page",
+            "contourLadderType" : "Straight",
+            "contourMaximumAngle" : 90,
+            "enableConnection" : true,
+            "featureWeight" : 0,
+            "fontHeightReductionLimit" : 4,
+            "fontHeightReductionStep" : 0.5,
+            "fontWidthReductionLimit" : 90,
+            "fontWidthReductionStep" : 5,
+            "graticuleAlignmentType" : "Straight",
+            "keyNumberGroupName" : "Default",
+            "labelBuffer" : 15,
+            "labelLargestPolygon" : true,
+            "labelPriority" : -1,
+            "labelStackingProperties" : {
+              "type" : "CIMMaplexLabelStackingProperties",
+              "stackAlignment" : "ChooseBest",
+              "maximumNumberOfLines" : 3,
+              "minimumNumberOfCharsPerLine" : 3,
+              "maximumNumberOfCharsPerLine" : 24,
+              "separators" : [
+                {
+                  "type" : "CIMMaplexStackingSeparator",
+                  "separator" : " ",
+                  "splitAfter" : true
+                },
+                {
+                  "type" : "CIMMaplexStackingSeparator",
+                  "separator" : ",",
+                  "visible" : true,
+                  "splitAfter" : true
+                }
+              ]
+            },
+            "lineFeatureType" : "General",
+            "linePlacementMethod" : "OffsetCurvedFromLine",
+            "maximumLabelOverrun" : 80,
+            "maximumLabelOverrunUnit" : "Point",
+            "minimumFeatureSizeUnit" : "Map",
+            "multiPartOption" : "OneLabelPerPart",
+            "offsetAlongLineProperties" : {
+              "type" : "CIMMaplexOffsetAlongLineProperties",
+              "placementMethod" : "BestPositionAlongLine",
+              "labelAnchorPoint" : "CenterOfLabel",
+              "distanceUnit" : "Percentage",
+              "useLineDirection" : true
+            },
+            "pointExternalZonePriorities" : {
+              "type" : "CIMMaplexExternalZonePriorities",
+              "aboveLeft" : 4,
+              "aboveCenter" : 2,
+              "aboveRight" : 1,
+              "centerRight" : 3,
+              "belowRight" : 5,
+              "belowCenter" : 7,
+              "belowLeft" : 8,
+              "centerLeft" : 6
+            },
+            "pointPlacementMethod" : "AroundPoint",
+            "polygonAnchorPointType" : "GeometricCenter",
+            "polygonBoundaryWeight" : 0,
+            "polygonExternalZones" : {
+              "type" : "CIMMaplexExternalZonePriorities",
+              "aboveLeft" : 4,
+              "aboveCenter" : 2,
+              "aboveRight" : 1,
+              "centerRight" : 3,
+              "belowRight" : 5,
+              "belowCenter" : 7,
+              "belowLeft" : 8,
+              "centerLeft" : 6
+            },
+            "polygonFeatureType" : "General",
+            "polygonInternalZones" : {
+              "type" : "CIMMaplexInternalZonePriorities",
+              "center" : 1
+            },
+            "polygonPlacementMethod" : "HorizontalInPolygon",
+            "primaryOffset" : 1,
+            "primaryOffsetUnit" : "Point",
+            "removeExtraWhiteSpace" : true,
+            "repetitionIntervalUnit" : "Point",
+            "rotationProperties" : {
+              "type" : "CIMMaplexRotationProperties",
+              "rotationType" : "Arithmetic",
+              "alignmentType" : "Straight"
+            },
+            "secondaryOffset" : 100,
+            "strategyPriorities" : {
+              "type" : "CIMMaplexStrategyPriorities",
+              "stacking" : 1,
+              "overrun" : 2,
+              "fontCompression" : 3,
+              "fontReduction" : 4,
+              "abbreviation" : 5
+            },
+            "thinningDistanceUnit" : "Point",
+            "truncationMarkerCharacter" : ".",
+            "truncationMinimumLength" : 1,
+            "truncationPreferredCharacters" : "aeiou",
+            "truncationExcludedCharacters" : "0123456789",
+            "polygonAnchorPointPerimeterInsetUnit" : "Point"
+          },
+          "name" : "Class 1",
+          "priority" : -1,
+          "standardLabelPlacementProperties" : {
+            "type" : "CIMStandardLabelPlacementProperties",
+            "featureType" : "Line",
+            "featureWeight" : "None",
+            "labelWeight" : "High",
+            "numLabelsOption" : "OneLabelPerName",
+            "lineLabelPosition" : {
+              "type" : "CIMStandardLineLabelPosition",
+              "above" : true,
+              "inLine" : true,
+              "parallel" : true
+            },
+            "lineLabelPriorities" : {
+              "type" : "CIMStandardLineLabelPriorities",
+              "aboveStart" : 3,
+              "aboveAlong" : 3,
+              "aboveEnd" : 3,
+              "centerStart" : 3,
+              "centerAlong" : 3,
+              "centerEnd" : 3,
+              "belowStart" : 3,
+              "belowAlong" : 3,
+              "belowEnd" : 3
+            },
+            "pointPlacementMethod" : "AroundPoint",
+            "pointPlacementPriorities" : {
+              "type" : "CIMStandardPointPlacementPriorities",
+              "aboveLeft" : 2,
+              "aboveCenter" : 2,
+              "aboveRight" : 1,
+              "centerLeft" : 3,
+              "centerRight" : 2,
+              "belowLeft" : 3,
+              "belowCenter" : 3,
+              "belowRight" : 2
+            },
+            "rotationType" : "Arithmetic",
+            "polygonPlacementMethod" : "AlwaysHorizontal"
+          },
+          "textSymbol" : {
+            "type" : "CIMSymbolReference",
+            "symbol" : {
+              "type" : "CIMTextSymbol",
+              "blockProgression" : "TTB",
+              "depth3D" : 1,
+              "extrapolateBaselines" : true,
+              "fontEffects" : "Normal",
+              "fontEncoding" : "Unicode",
+              "fontFamilyName" : "Tahoma",
+              "fontStyleName" : "Regular",
+              "fontType" : "Unspecified",
+              "haloSize" : 1,
+              "height" : 10,
+              "hinting" : "Default",
+              "horizontalAlignment" : "Left",
+              "kerning" : true,
+              "letterWidth" : 100,
+              "ligatures" : true,
+              "lineGapType" : "ExtraLeading",
+              "symbol" : {
+                "type" : "CIMPolygonSymbol",
+                "symbolLayers" : [
+                  {
+                    "type" : "CIMSolidFill",
+                    "enable" : true,
+                    "color" : {
+                      "type" : "CIMRGBColor",
+                      "values" : [
+                        0,
+                        0,
+                        0,
+                        100
+                      ]
+                    }
+                  }
+                ]
+              },
+              "textCase" : "Normal",
+              "textDirection" : "LTR",
+              "verticalAlignment" : "Bottom",
+              "verticalGlyphOrientation" : "Right",
+              "wordSpacing" : 100,
+              "billboardMode3D" : "FaceNearPlane"
+            }
+          },
+          "useCodedValue" : true,
+          "visibility" : true,
+          "iD" : -1
+        }
+      ],
+      "renderer" : {
+        "type" : "CIMSimpleRenderer",
+        "patch" : "Default",
+        "symbol" : {
+          "type" : "CIMSymbolReference",
+          "symbol" : {
+            "type" : "CIMPolygonSymbol",
+            "symbolLayers" : [
+              {
+                "type" : "CIMSolidStroke",
+                "enable" : true,
+                "capStyle" : "Round",
+                "joinStyle" : "Round",
+                "lineStyle3D" : "Strip",
+                "miterLimit" : 10,
+                "width" : 0.5,
+                "color" : {
+                  "type" : "CIMRGBColor",
+                  "values" : [
+                    130,
+                    130,
+                    130,
+                    100
+                  ]
+                }
+              },
+              {
+                "type" : "CIMSolidFill",
+                "enable" : true,
+                "color" : {
+                  "type" : "CIMRGBColor",
+                  "values" : [
+                    130,
+                    130,
+                    130,
+                    0
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      },
+      "scaleSymbols" : true,
+      "snappable" : true,
+      "symbolLayerDrawing" : {
+        "type" : "CIMSymbolLayerDrawing"
+      }
     },
     {
       "type" : "CIMFeatureLayer",

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/stage_based_catfim.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/stage_based_catfim.mapx
@@ -36,9 +36,9 @@
     "mapType" : "Map",
     "defaultExtent" : {
       "xmin" : -10042414.0540662669,
-      "ymin" : 3795213.49250532547,
+      "ymin" : 3794700.82092288323,
       "xmax" : -10037550.6777432077,
-      "ymax" : 3797622.76879439736,
+      "ymax" : 3798135.4403768396,
       "spatialReference" : {
         "wkid" : 102100,
         "latestWkid" : 3857
@@ -2363,18 +2363,13 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "definitionExpression" : "interval_stage = 0",
+        "definitionExpression" : "interval_stage = 0 AND magnitude = 'action'",
         "definitionExpressionName" : "Query 1",
         "definitionFilterChoices" : [
           {
             "type" : "CIMDefinitionFilter",
             "name" : "Query 1",
-            "definitionExpression" : "interval_stage = 0"
-          },
-          {
-            "type" : "CIMDefinitionFilter",
-            "name" : "Query 2",
-            "definitionExpression" : "magnitude = 'action'"
+            "definitionExpression" : "interval_stage = 0 AND magnitude = 'action'"
           }
         ],
         "displayField" : "name",
@@ -3724,18 +3719,13 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "definitionExpression" : "interval_stage = 0",
+        "definitionExpression" : "interval_stage = 0 AND magnitude = 'minor'",
         "definitionExpressionName" : "Query 1",
         "definitionFilterChoices" : [
           {
             "type" : "CIMDefinitionFilter",
             "name" : "Query 1",
-            "definitionExpression" : "interval_stage = 0"
-          },
-          {
-            "type" : "CIMDefinitionFilter",
-            "name" : "Query 2",
-            "definitionExpression" : "magnitude = 'minor'"
+            "definitionExpression" : "interval_stage = 0 AND magnitude = 'minor'"
           }
         ],
         "displayField" : "name",
@@ -5086,18 +5076,13 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "definitionExpression" : "interval_stage = 0",
+        "definitionExpression" : "interval_stage = 0 AND magnitude = 'moderate'",
         "definitionExpressionName" : "Query 1",
         "definitionFilterChoices" : [
           {
             "type" : "CIMDefinitionFilter",
             "name" : "Query 1",
-            "definitionExpression" : "interval_stage = 0"
-          },
-          {
-            "type" : "CIMDefinitionFilter",
-            "name" : "Query 2",
-            "definitionExpression" : "magnitude = 'moderate'"
+            "definitionExpression" : "interval_stage = 0 AND magnitude = 'moderate'"
           }
         ],
         "displayField" : "name",
@@ -6448,18 +6433,13 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "definitionExpression" : "interval_stage = 0",
+        "definitionExpression" : "interval_stage = 0 AND magnitude = 'major'",
         "definitionExpressionName" : "Query 1",
         "definitionFilterChoices" : [
           {
             "type" : "CIMDefinitionFilter",
             "name" : "Query 1",
-            "definitionExpression" : "interval_stage = 0"
-          },
-          {
-            "type" : "CIMDefinitionFilter",
-            "name" : "Query 2",
-            "definitionExpression" : "magnitude = 'major'"
+            "definitionExpression" : "interval_stage = 0 AND magnitude = 'major'"
           }
         ],
         "displayField" : "name",
@@ -7137,7 +7117,6 @@
         "type" : "CIMLayerElevationSurface",
         "mapElevationID" : "{019DF820-BDA4-4783-84EF-8DA6118FA665}"
       },
-      "expanded" : true,
       "layerType" : "Operational",
       "minScale" : 750000,
       "showLegends" : true,


### PR DESCRIPTION
This merge activates the 1ft intervals for Stage-Based CatFIM. Intervals begin at Action stage and increment by 1 ft until the Major stage + 5ft is reached. Sublayers are created for each category. Each category has an intervals layer and the threshold layer.

## Changes
- `/hydrovis/Core/VIZ/EC2/code/aws_loos/pro_projects/db_pipeline/stage_based_catfim.mapx`


## Screenshots
![image](https://user-images.githubusercontent.com/69594899/230177671-1400ed9c-c7ae-4ddf-b4d0-22d9b96f906c.png)

