### PR TITLE
Adds resources to reboot rnr machine daily at 2230

### DIFF
--- a/Core/main.tf
+++ b/Core/main.tf
@@ -527,6 +527,7 @@ module "rnr_ec2" {
   nomads_url                     = local.env.rnr_nomads_url
   s3_url                         = local.env.rnr_s3_url
   rnr_versions                   = local.env.rnr_versions
+  iam_role_arn                   = module.iam-roles.role_hydrovis-sync-wrds-location-db.arn
 }
 
 module "egis_license_manager" {


### PR DESCRIPTION
Refs #385

This is to introduce three new AWS resources that will automate the daily reboot of the "hv-*-replace-route" EC2, including a a step function that performs the reboot, and an eventbridge cron an associated trigger that executes the step function daily at 2230. 

Pertinent details from terraform plan:
  \# aws_cloudwatch_event_rule.daily_at_2330 will be created
  \# aws_cloudwatch_event_target.trigger_reboot_rnr_ec2 will be created
  \# aws_sfn_state_machine.reboot_replace_route_ec2_step_function will be created
Plan: 3 to add, 0 to change, 0 to destroy.