### PR TITLE
Fixed mapx files for raster services

### DIFF
--- a/Core/LAMBDA/viz_functions/image_based/viz_raster_processing/services/ana_snow_depth.py
+++ b/Core/LAMBDA/viz_functions/image_based/viz_raster_processing/services/ana_snow_depth.py
@@ -13,7 +13,7 @@ def main(service_data, reference_time):
     variable = "SNOWH"
     data_temp, crs = open_raster(bucket, input_files[0], variable)
     data_nan = data_temp.where(data_temp != -99990000)
-    data = (data_nan * 39.3701)/1000  #Convert m to in
+    data = (data_nan * 39.3701)/10000  #Convert m to in
     data = data.round(2)
 
     local_raster = create_raster(data, crs)

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_24hr_snow_melt.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_24hr_snow_melt.mapx
@@ -179,9 +179,9 @@
       "dataConnection" : {
         "type" : "CIMStandardDataConnection",
         "workspaceConnectionString" : "DATABASE=\\\\10.26.150.30\\viz\\published\\connection_files\\HydroVis_S3_processing_outputs.acs\\ana_24hr_snow_melt\\published",
-        "workspaceFactory" : "FileGDB",
+        "workspaceFactory" : "Raster",
         "dataset" : "ana_24hr_snow_melt.mrf",
-        "datasetType" : "esriDTRasterDataset"
+        "datasetType" : "esriDTAny"
       },
       "colorizer" : {
         "type" : "CIMRasterClassifyColorizer",

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_24hr_snow_melt.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_24hr_snow_melt.mapx
@@ -488,7 +488,7 @@
   "tableDefinitions" : [
     {
       "type" : "CIMStandaloneTable",
-      "name" : "ana 24hr snow melt - Service Metadata",
+      "name" : "Service Metadata",
       "uRI" : "CIMPATH=past_24_hour_snow_melt/vizprocessing_publish_ana_24hr_snow_melt.xml",
       "sourceModifiedTime" : {
         "type" : "TimeInstant"

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_72hr_snow_water_equiv_change.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_72hr_snow_water_equiv_change.mapx
@@ -147,7 +147,7 @@
       "blendingMode" : "Alpha",
       "dataConnection" : {
         "type" : "CIMStandardDataConnection",
-        "workspaceConnectionString" : "DATABASE=\\\\10.26.150.30\\viz\\published\\connection_files\\HydroVis_S3_processing_outputs.acs\\ana_72hr_snow_water_equiv_change\\published"",
+        "workspaceConnectionString" : "DATABASE=\\\\10.26.150.30\\viz\\published\\connection_files\\HydroVis_S3_processing_outputs.acs\\ana_72hr_snow_water_equiv_change\\published",
         "workspaceFactory" : "Raster",
         "dataset" : "ana_24hr_snow_water_equiv_change.mrf",
         "datasetType" : "esriDTAny"

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_snow_depth.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_snow_depth.mapx
@@ -33,9 +33,9 @@
       "CIMPATH=ana_snow_depth/vizprocessing_publish_ana_snow_depth.xml"
     ],
     "defaultExtent" : {
-      "xmin" : -14258754.8954144157,
+      "xmin" : -14513932.120643612,
       "ymin" : 2760395.72370361257,
-      "xmax" : -7039502.526796178,
+      "xmax" : -6784325.30156698078,
       "ymax" : 7870319.2109560268,
       "spatialReference" : {
         "wkid" : 102100,
@@ -176,13 +176,13 @@
           {
             "type" : "CIMRasterClassBreak",
             "upperBound" : 2,
-            "label" : "< 2 inches",
+            "label" : "< 2\"",
             "color" : {
               "type" : "CIMRGBColor",
               "values" : [
-                182,
-                98,
-                100,
+                209,
+                243,
+                243.99610900878906,
                 100
               ]
             }
@@ -190,13 +190,13 @@
           {
             "type" : "CIMRasterClassBreak",
             "upperBound" : 4,
-            "label" : "2 - 4 inches",
+            "label" : "2 - 4\"",
             "color" : {
               "type" : "CIMRGBColor",
               "values" : [
-                193,
-                63,
-                107,
+                119,
+                242,
+                246,
                 100
               ]
             }
@@ -204,13 +204,13 @@
           {
             "type" : "CIMRasterClassBreak",
             "upperBound" : 10,
-            "label" : "4 - 10 inches",
+            "label" : "4 - 10\"",
             "color" : {
               "type" : "CIMRGBColor",
               "values" : [
-                210,
-                30,
-                152,
+                117,
+                200,
+                241,
                 100
               ]
             }
@@ -218,13 +218,13 @@
           {
             "type" : "CIMRasterClassBreak",
             "upperBound" : 20,
-            "label" : "10 - 20 inches",
+            "label" : "10 - 20\"",
             "color" : {
               "type" : "CIMRGBColor",
               "values" : [
-                216,
-                15,
-                213,
+                97,
+                144,
+                238,
                 100
               ]
             }
@@ -232,13 +232,13 @@
           {
             "type" : "CIMRasterClassBreak",
             "upperBound" : 40,
-            "label" : "20 - 40 inches",
+            "label" : "20 - 40\"",
             "color" : {
               "type" : "CIMRGBColor",
               "values" : [
-                148,
-                9,
-                222,
+                84,
+                81,
+                227,
                 100
               ]
             }
@@ -246,7 +246,7 @@
           {
             "type" : "CIMRasterClassBreak",
             "upperBound" : 60,
-            "label" : "40 - 60 inches",
+            "label" : "40 - 60\"",
             "color" : {
               "type" : "CIMRGBColor",
               "values" : [
@@ -260,13 +260,13 @@
           {
             "type" : "CIMRasterClassBreak",
             "upperBound" : 100,
-            "label" : "60 - 100 inches",
+            "label" : "60 - 100\"",
             "color" : {
               "type" : "CIMRGBColor",
               "values" : [
-                84,
-                81,
-                227,
+                148,
+                9,
+                222,
                 100
               ]
             }
@@ -274,13 +274,13 @@
           {
             "type" : "CIMRasterClassBreak",
             "upperBound" : 200,
-            "label" : "100 - 200 inches",
+            "label" : "100 - 200\"",
             "color" : {
               "type" : "CIMRGBColor",
               "values" : [
-                97,
-                144,
-                238,
+                216,
+                15,
+                213,
                 100
               ]
             }
@@ -288,13 +288,13 @@
           {
             "type" : "CIMRasterClassBreak",
             "upperBound" : 300,
-            "label" : "200 - 300 inches",
+            "label" : "200 - 300\"",
             "color" : {
               "type" : "CIMRGBColor",
               "values" : [
-                117,
-                200,
-                241,
+                210,
+                30,
+                152,
                 100
               ]
             }
@@ -302,13 +302,13 @@
           {
             "type" : "CIMRasterClassBreak",
             "upperBound" : 400,
-            "label" : "300 - 400 inches",
+            "label" : "300 - 400\"",
             "color" : {
               "type" : "CIMRGBColor",
               "values" : [
-                119,
-                242,
-                246,
+                193,
+                63,
+                107,
                 100
               ]
             }
@@ -320,9 +320,9 @@
             "color" : {
               "type" : "CIMRGBColor",
               "values" : [
-                209,
-                243,
-                243.99610900878906,
+                182,
+                98,
+                100,
                 100
               ]
             }
@@ -357,7 +357,7 @@
         "field" : "Value",
         "hillshadeZFactor" : 1,
         "minimumBreak" : 0.0039370097219944,
-        "showInAscendingOrder" : false,
+        "showInAscendingOrder" : true,
         "numberFormat" : {
           "type" : "CIMNumericFormat",
           "alignmentOption" : "esriAlignRight",

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_snow_water_equiv.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_snow_water_equiv.mapx
@@ -26,7 +26,7 @@
       "enableEyeDomeLighting" : true
     },
     "layers" : [
-      "CIMPATH=nwm_snow_water_equivalent_analysis/ana_snow_water_equivalent_tif.xml"
+      "CIMPATH=nwm_snow_water_equivalent_analysis/ana_snow_water_equiv_mrf.xml"
     ],
     "defaultViewingMode" : "Map",
     "mapType" : "Map",
@@ -35,9 +35,9 @@
     ],
     "defaultExtent" : {
       "xmin" : -2474308.0471614236,
-      "ymin" : 76778.1986261385027,
-      "xmax" : 763712.968040505657,
-      "ymax" : 2216184.94081312791,
+      "ymin" : 76178.7700376557186,
+      "xmax" : 763712.968040505541,
+      "ymax" : 2216784.36940161046,
       "spatialReference" : {
         "wkt" : "PROJCS[\"Lambert_Conformal_Conic_2SP\",GEOGCS[\"GCS_unknown\",DATUM[\"D_unknown\",SPHEROID[\"unknown\",6370000.0,0.0]],PRIMEM[\"Greenwich\",0.0],UNIT[\"Degree\",0.0174532925199433]],PROJECTION[\"Lambert_Conformal_Conic\"],PARAMETER[\"false_easting\",0.0],PARAMETER[\"false_northing\",0.0],PARAMETER[\"central_meridian\",-97.0],PARAMETER[\"standard_parallel_1\",30.0],PARAMETER[\"standard_parallel_2\",60.0],PARAMETER[\"latitude_of_origin\",40.0],UNIT[\"Meter\",1.0]]"
       }
@@ -122,12 +122,12 @@
     {
       "type" : "CIMRasterLayer",
       "name" : "NWM Snow Water Equivalent Analysis",
-      "uRI" : "CIMPATH=nwm_snow_water_equivalent_analysis/ana_snow_water_equivalent_tif.xml",
+      "uRI" : "CIMPATH=nwm_snow_water_equivalent_analysis/ana_snow_water_equiv_mrf.xml",
       "sourceModifiedTime" : {
         "type" : "TimeInstant"
       },
       "useSourceMetadata" : true,
-      "description" : "ana_snow_water_equivalent.tif",
+      "description" : "ana_snow_water_equiv.mrf",
       "layerElevation" : {
         "type" : "CIMLayerElevationSurface",
         "mapElevationID" : "{517BE08B-79DE-4E79-AEBB-C481AE488E6B}"
@@ -171,9 +171,9 @@
             "color" : {
               "type" : "CIMRGBColor",
               "values" : [
-                242,
-                217,
-                210,
+                202,
+                247,
+                251,
                 100
               ]
             }
@@ -182,132 +182,6 @@
             "type" : "CIMRasterClassBreak",
             "upperBound" : 0.20000000000000001,
             "label" : "0.05 - 0.2\"",
-            "color" : {
-              "type" : "CIMRGBColor",
-              "values" : [
-                253,
-                185,
-                192,
-                100
-              ]
-            }
-          },
-          {
-            "type" : "CIMRasterClassBreak",
-            "upperBound" : 0.40000000000000002,
-            "label" : "0.2 - 0.4\"",
-            "color" : {
-              "type" : "CIMRGBColor",
-              "values" : [
-                244,
-                149,
-                184,
-                100
-              ]
-            }
-          },
-          {
-            "type" : "CIMRasterClassBreak",
-            "upperBound" : 1,
-            "label" : "0.4 - 1\"",
-            "color" : {
-              "type" : "CIMRGBColor",
-              "values" : [
-                237,
-                114,
-                193,
-                100
-              ]
-            }
-          },
-          {
-            "type" : "CIMRasterClassBreak",
-            "upperBound" : 2,
-            "label" : "1 - 2\"",
-            "color" : {
-              "type" : "CIMRGBColor",
-              "values" : [
-                225,
-                80,
-                218,
-                100
-              ]
-            }
-          },
-          {
-            "type" : "CIMRasterClassBreak",
-            "upperBound" : 4,
-            "label" : "2 - 4\"",
-            "color" : {
-              "type" : "CIMRGBColor",
-              "values" : [
-                175,
-                46,
-                212,
-                100
-              ]
-            }
-          },
-          {
-            "type" : "CIMRasterClassBreak",
-            "upperBound" : 6,
-            "label" : "4 - 6\"",
-            "color" : {
-              "type" : "CIMRGBColor",
-              "values" : [
-                118,
-                27,
-                202,
-                100
-              ]
-            }
-          },
-          {
-            "type" : "CIMRasterClassBreak",
-            "upperBound" : 10,
-            "label" : "6 - 10\"",
-            "color" : {
-              "type" : "CIMRGBColor",
-              "values" : [
-                92,
-                62,
-                204,
-                100
-              ]
-            }
-          },
-          {
-            "type" : "CIMRasterClassBreak",
-            "upperBound" : 20,
-            "label" : "10 - 20\"",
-            "color" : {
-              "type" : "CIMRGBColor",
-              "values" : [
-                99,
-                100,
-                220,
-                100
-              ]
-            }
-          },
-          {
-            "type" : "CIMRasterClassBreak",
-            "upperBound" : 30,
-            "label" : "20 - 30\"",
-            "color" : {
-              "type" : "CIMRGBColor",
-              "values" : [
-                127,
-                162,
-                242,
-                100
-              ]
-            }
-          },
-          {
-            "type" : "CIMRasterClassBreak",
-            "upperBound" : 40,
-            "label" : "30 - 40\"",
             "color" : {
               "type" : "CIMRGBColor",
               "values" : [
@@ -320,14 +194,140 @@
           },
           {
             "type" : "CIMRasterClassBreak",
+            "upperBound" : 0.40000000000000002,
+            "label" : "0.2 - 0.4\"",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                127,
+                162,
+                242,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 1,
+            "label" : "0.4 - 1\"",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                99,
+                100,
+                220,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 2,
+            "label" : "1 - 2\"",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                92,
+                62,
+                204,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 4,
+            "label" : "2 - 4\"",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                118,
+                27,
+                202,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 6,
+            "label" : "4 - 6\"",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                175,
+                46,
+                212,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 10,
+            "label" : "6 - 10\"",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                225,
+                80,
+                218,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 20,
+            "label" : "10 - 20\"",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                237,
+                114,
+                193,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 30,
+            "label" : "20 - 30\"",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                244,
+                149,
+                184,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 40,
+            "label" : "30 - 40\"",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                253,
+                185,
+                192,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
             "upperBound" : 196.84999999999999,
             "label" : "> 40\"",
             "color" : {
               "type" : "CIMRGBColor",
               "values" : [
-                202,
-                247,
-                251,
+                242,
+                217,
+                210,
                 100
               ]
             }
@@ -362,7 +362,7 @@
         "field" : "Value",
         "hillshadeZFactor" : 1,
         "minimumBreak" : 0.01,
-        "showInAscendingOrder" : false,
+        "showInAscendingOrder" : true,
         "numberFormat" : {
           "type" : "CIMNumericFormat",
           "alignmentOption" : "esriAlignLeft",
@@ -372,7 +372,8 @@
           "useSeparator" : true
         },
         "heading" : "Snow Water Equivalent"
-      }
+      },
+      "autoComputeStatsHistogram" : true
     }
   ],
   "binaryReferences" : [

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_soil_moisture.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_soil_moisture.mapx
@@ -34,9 +34,9 @@
       "CIMPATH=ana_soil_moisture/vizprocessing_publish_ana_soil_moisture.xml"
     ],
     "defaultExtent" : {
-      "xmin" : -15617261.8857680373,
+      "xmin" : -15958762.7505056355,
       "ymin" : 1489604.4249374494,
-      "xmax" : -5955816.10263550375,
+      "xmax" : -5614315.23789790459,
       "ymax" : 8328158.64180492051,
       "spatialReference" : {
         "wkid" : 102100,
@@ -126,8 +126,10 @@
       "name" : "Soil Saturation",
       "uRI" : "CIMPATH=ana_soil_moisture/ana_soil_moisture_tif.xml",
       "sourceModifiedTime" : {
-        "type" : "TimeInstant"
+        "type" : "TimeInstant",
+        "start" : 978307200000
       },
+      "metadataURI" : "CIMPATH=Metadata/0419b74f62fe3bf1fe86d7f06cf0c677.xml",
       "useSourceMetadata" : true,
       "description" : "ana_soil_moisture.tif",
       "layerElevation" : {
@@ -173,9 +175,9 @@
             "color" : {
               "type" : "CIMRGBColor",
               "values" : [
-                5,
-                48,
-                97,
+                103,
+                0,
+                31,
                 100
               ]
             }
@@ -184,104 +186,6 @@
             "type" : "CIMRasterClassBreak",
             "upperBound" : 0.20000000000000001,
             "label" : "10  –  20 %",
-            "color" : {
-              "type" : "CIMRGBColor",
-              "values" : [
-                36.778209686279297,
-                107,
-                174.55641174316406,
-                100
-              ]
-            }
-          },
-          {
-            "type" : "CIMRasterClassBreak",
-            "upperBound" : 0.29999999999999999,
-            "label" : "20  –  30 %",
-            "color" : {
-              "type" : "CIMRGBColor",
-              "values" : [
-                84.556419372558594,
-                158.11283874511719,
-                201,
-                100
-              ]
-            }
-          },
-          {
-            "type" : "CIMRasterClassBreak",
-            "upperBound" : 0.40000000000000002,
-            "label" : "30  –  40 %",
-            "color" : {
-              "type" : "CIMRGBColor",
-              "values" : [
-                167,
-                207.66535949707031,
-                228,
-                100
-              ]
-            }
-          },
-          {
-            "type" : "CIMRasterClassBreak",
-            "upperBound" : 0.5,
-            "label" : "40  –  50 %",
-            "color" : {
-              "type" : "CIMRGBColor",
-              "values" : [
-                225.88716125488281,
-                237,
-                243.11283874511719,
-                100
-              ]
-            }
-          },
-          {
-            "type" : "CIMRasterClassBreak",
-            "upperBound" : 0.59999999999999998,
-            "label" : "50  –  60 %",
-            "color" : {
-              "type" : "CIMRGBColor",
-              "values" : [
-                250.33462524414063,
-                231.44357299804688,
-                220.33462524414063,
-                100
-              ]
-            }
-          },
-          {
-            "type" : "CIMRasterClassBreak",
-            "upperBound" : 0.69999999999999996,
-            "label" : "60  –  70 %",
-            "color" : {
-              "type" : "CIMRGBColor",
-              "values" : [
-                247,
-                183,
-                153,
-                100
-              ]
-            }
-          },
-          {
-            "type" : "CIMRasterClassBreak",
-            "upperBound" : 0.80000000000000004,
-            "label" : "70  –  80 %",
-            "color" : {
-              "type" : "CIMRGBColor",
-              "values" : [
-                220.66537475585938,
-                111.33463287353516,
-                88.778205871582031,
-                100
-              ]
-            }
-          },
-          {
-            "type" : "CIMRasterClassBreak",
-            "upperBound" : 0.90000000000000002,
-            "label" : "80  –  90 %",
             "color" : {
               "type" : "CIMRGBColor",
               "values" : [
@@ -294,14 +198,112 @@
           },
           {
             "type" : "CIMRasterClassBreak",
+            "upperBound" : 0.29999999999999999,
+            "label" : "20  –  30 %",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                220.66537475585938,
+                111.33463287353516,
+                88.778205871582031,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 0.40000000000000002,
+            "label" : "30  –  40 %",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                247,
+                183,
+                153,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 0.5,
+            "label" : "40  –  50 %",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                250.33462524414063,
+                231.44357299804688,
+                220.33462524414063,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 0.59999999999999998,
+            "label" : "50  –  60 %",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                225.88716125488281,
+                237,
+                243.11283874511719,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 0.69999999999999996,
+            "label" : "60  –  70 %",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                167,
+                207.66535949707031,
+                228,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 0.80000000000000004,
+            "label" : "70  –  80 %",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                84.556419372558594,
+                158.11283874511719,
+                201,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 0.90000000000000002,
+            "label" : "80  –  90 %",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                36.778209686279297,
+                107,
+                174.55641174316406,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
             "upperBound" : 1,
             "label" : "90  –  100 %",
             "color" : {
               "type" : "CIMRGBColor",
               "values" : [
-                103,
-                0,
-                31,
+                5,
+                48,
+                97,
                 100
               ]
             }
@@ -662,7 +664,7 @@
         "field" : "Value",
         "hillshadeZFactor" : 1,
         "minimumBreak" : 0.10000000149012001,
-        "showInAscendingOrder" : false,
+        "showInAscendingOrder" : true,
         "numberFormat" : {
           "type" : "CIMNumericFormat",
           "alignmentOption" : "esriAlignRight",
@@ -674,6 +676,11 @@
     }
   ],
   "binaryReferences" : [
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/0419b74f62fe3bf1fe86d7f06cf0c677.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230419</CreaDate><CreaTime>15523500</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri></metadata>\r\n"
+    },
     {
       "type" : "CIMBinaryReference",
       "uRI" : "CIMPATH=Metadata/eb8dce9a80c4a368940b9302a29c82e5.xml",

--- a/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_soil_moisture_ice_content.mapx
+++ b/Core/VIZ/EC2/code/aws_loosa/pro_projects/db_pipeline/ana_soil_moisture_ice_content.mapx
@@ -34,10 +34,10 @@
       "CIMPATH=ana_soil_moisture_ice_content/vizprocessing_publish_ana_soil_moisture_ice_content.xml"
     ],
     "defaultExtent" : {
-      "xmin" : -15459343.5088251643,
-      "ymin" : 1424411.76479305048,
-      "xmax" : -5665145.03554271907,
-      "ymax" : 8356930.84876251873,
+      "xmin" : -15805536.7518568709,
+      "ymin" : 1424411.76479305,
+      "xmax" : -5318951.79251101334,
+      "ymax" : 8356930.84876251966,
       "spatialReference" : {
         "wkid" : 102100,
         "latestWkid" : 3857
@@ -175,9 +175,9 @@
             "color" : {
               "type" : "CIMRGBColor",
               "values" : [
-                220,
                 0,
-                219,
+                227,
+                224,
                 100
               ]
             }
@@ -189,9 +189,9 @@
             "color" : {
               "type" : "CIMRGBColor",
               "values" : [
-                169,
                 0,
-                230,
+                129,
+                215,
                 100
               ]
             }
@@ -217,9 +217,9 @@
             "color" : {
               "type" : "CIMRGBColor",
               "values" : [
+                169,
                 0,
-                129,
-                215,
+                230,
                 100
               ]
             }
@@ -231,9 +231,9 @@
             "color" : {
               "type" : "CIMRGBColor",
               "values" : [
+                220,
                 0,
-                227,
-                224,
+                219,
                 100
               ]
             }
@@ -268,7 +268,7 @@
         "field" : "Value",
         "hillshadeZFactor" : 1,
         "minimumBreak" : 0.01,
-        "showInAscendingOrder" : false,
+        "showInAscendingOrder" : true,
         "numberFormat" : {
           "type" : "CIMNumericFormat",
           "alignmentOption" : "esriAlignLeft",
@@ -296,7 +296,7 @@
   "tableDefinitions" : [
     {
       "type" : "CIMStandaloneTable",
-      "name" : "ana soil moisture ice content - Service Metadata",
+      "name" : "Service Metadata",
       "uRI" : "CIMPATH=ana_soil_moisture_ice_content/vizprocessing_publish_ana_soil_moisture_ice_content.xml",
       "sourceModifiedTime" : {
         "type" : "TimeInstant"


### PR DESCRIPTION
Recently pushed raster services were failing to publish due to some small errors, namely an extra " and the wrong dataset type

## Changes

- Core\VIZ\EC2\code\aws_loosa\pro_projects\db_pipeline\ana_72hr_snow_water_equiv_change.mapx: Removed extra " in the workspace string
- Core\VIZ\EC2\code\aws_loosa\pro_projects\db_pipeline\ana_24hr_snow_melt.mapx: Updated workspaceFactory to be "Raster" and "datasetType" to be "esriDTAny"

