### PR TITLE
fixed oids on raster services

### DIFF
--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim/ana_snow_depth.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim/ana_snow_depth.mapx
@@ -392,16 +392,59 @@
       "useSourceMetadata" : true,
       "displayField" : "reference_time",
       "editable" : true,
+      "fieldDescriptions" : [
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "oid",
+          "fieldName" : "oid",
+          "numberFormat" : {
+            "type" : "CIMNumericFormat",
+            "alignmentOption" : "esriAlignRight",
+            "alignmentWidth" : 0,
+            "roundingOption" : "esriRoundNumberOfDecimals",
+            "roundingValue" : 0
+          },
+          "readOnly" : true,
+          "visible" : false,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Reference Time",
+          "fieldName" : "reference_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Valid Time",
+          "fieldName" : "valid_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Update Time",
+          "fieldName" : "update_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        }
+      ],
       "dataConnection" : {
         "type" : "CIMSqlQueryDataConnection",
         "workspaceConnectionString" : "ENCRYPTED_PASSWORD=00022e6857366675744b576f6b392b6c2f4b4b4966783458536335384e724f65436a59717333384b3131303435576b4c526b332f74426379696f637277393159722f48302a00;SERVER=hydrovis-ti-viz-processing.c4vzypepnkx3.us-east-1.rds.amazonaws.com;INSTANCE=sde:postgresql:hydrovis-ti-viz-processing.c4vzypepnkx3.us-east-1.rds.amazonaws.com;DBCLIENT=postgresql;DB_CONNECTION_PROPERTIES=hydrovis-ti-viz-processing.c4vzypepnkx3.us-east-1.rds.amazonaws.com;DATABASE=vizprocessing;USER=viz_proc_dev_rw_user;AUTHENTICATION_MODE=DBMS",
         "workspaceFactory" : "SDE",
         "dataset" : "vizprocessing.publish.%ana_snow_depth",
         "datasetType" : "esriDTTable",
-        "sqlQuery" : "select reference_time,valid_time,update_time from vizprocessing.publish.ana_snow_depth",
-        "oIDFields" : "reference_time",
+        "sqlQuery" : "select oid,reference_time,valid_time,update_time from vizprocessing.publish.ana_snow_depth",
+        "oIDFields" : "oid",
         "geometryType" : "esriGeometryNull",
         "queryFields" : [
+          {
+            "name" : "oid",
+            "type" : "esriFieldTypeInteger",
+            "alias" : "oid"
+          },
           {
             "name" : "reference_time",
             "type" : "esriFieldTypeString",

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim/ana_soil_moisture.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim/ana_soil_moisture.mapx
@@ -698,16 +698,59 @@
       "useSourceMetadata" : true,
       "displayField" : "reference_time",
       "editable" : true,
+      "fieldDescriptions" : [
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "oid",
+          "fieldName" : "oid",
+          "numberFormat" : {
+            "type" : "CIMNumericFormat",
+            "alignmentOption" : "esriAlignRight",
+            "alignmentWidth" : 0,
+            "roundingOption" : "esriRoundNumberOfDecimals",
+            "roundingValue" : 0
+          },
+          "readOnly" : true,
+          "visible" : false,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Reference Time",
+          "fieldName" : "reference_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Valid Time",
+          "fieldName" : "valid_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Update Time",
+          "fieldName" : "update_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        }
+      ],
       "dataConnection" : {
         "type" : "CIMSqlQueryDataConnection",
         "workspaceConnectionString" : "ENCRYPTED_PASSWORD=00022e6838474c307054577333773964576b7641755473645070746174665764746d645a70624b4373473145437374333639664d6d6e6f426e74715865626c683775736c2a00;SERVER=hydrovis-ti-viz-processing.c4vzypepnkx3.us-east-1.rds.amazonaws.com;INSTANCE=sde:postgresql:hydrovis-ti-viz-processing.c4vzypepnkx3.us-east-1.rds.amazonaws.com;DBCLIENT=postgresql;DB_CONNECTION_PROPERTIES=hydrovis-ti-viz-processing.c4vzypepnkx3.us-east-1.rds.amazonaws.com;DATABASE=vizprocessing;USER=viz_proc_dev_rw_user;AUTHENTICATION_MODE=DBMS",
         "workspaceFactory" : "SDE",
         "dataset" : "vizprocessing.publish.%ana_soil_moisture",
         "datasetType" : "esriDTTable",
-        "sqlQuery" : "select reference_time,valid_time,update_time from vizprocessing.publish.ana_soil_moisture",
-        "oIDFields" : "reference_time",
+        "sqlQuery" : "select oid,reference_time,valid_time,update_time from vizprocessing.publish.ana_soil_moisture",
+        "oIDFields" : "oid",
         "geometryType" : "esriGeometryNull",
         "queryFields" : [
+          {
+            "name" : "oid",
+            "type" : "esriFieldTypeInteger",
+            "alias" : "oid"
+          },
           {
             "name" : "reference_time",
             "type" : "esriFieldTypeString",

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim/ana_soil_moisture_ice_content.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim/ana_soil_moisture_ice_content.mapx
@@ -304,16 +304,59 @@
       "useSourceMetadata" : true,
       "displayField" : "reference_time",
       "editable" : true,
+      "fieldDescriptions" : [
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "oid",
+          "fieldName" : "oid",
+          "numberFormat" : {
+            "type" : "CIMNumericFormat",
+            "alignmentOption" : "esriAlignRight",
+            "alignmentWidth" : 0,
+            "roundingOption" : "esriRoundNumberOfDecimals",
+            "roundingValue" : 0
+          },
+          "readOnly" : true,
+          "visible" : false,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Reference Time",
+          "fieldName" : "reference_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Valid Time",
+          "fieldName" : "valid_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Update Time",
+          "fieldName" : "update_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        }
+      ],
       "dataConnection" : {
         "type" : "CIMSqlQueryDataConnection",
         "workspaceConnectionString" : "ENCRYPTED_PASSWORD=00022e68396e38764e42464b6630642b714a497477752b4132786a394673507231616358624b68512f55464b574d77663665704c344e3663366b667378744550393842592a00;SERVER=hydrovis-ti-viz-processing.c4vzypepnkx3.us-east-1.rds.amazonaws.com;INSTANCE=sde:postgresql:hydrovis-ti-viz-processing.c4vzypepnkx3.us-east-1.rds.amazonaws.com;DBCLIENT=postgresql;DB_CONNECTION_PROPERTIES=hydrovis-ti-viz-processing.c4vzypepnkx3.us-east-1.rds.amazonaws.com;DATABASE=vizprocessing;USER=viz_proc_dev_rw_user;AUTHENTICATION_MODE=DBMS",
         "workspaceFactory" : "SDE",
         "dataset" : "vizprocessing.publish.%ana_soil_moisture_ice_content",
         "datasetType" : "esriDTTable",
-        "sqlQuery" : "select reference_time,valid_time,update_time from vizprocessing.publish.ana_soil_moisture_ice_content",
-        "oIDFields" : "reference_time",
+        "sqlQuery" : "select oid,reference_time,valid_time,update_time from vizprocessing.publish.ana_soil_moisture_ice_content",
+        "oIDFields" : "oid",
         "geometryType" : "esriGeometryNull",
         "queryFields" : [
+          {
+            "name" : "oid",
+            "type" : "esriFieldTypeInteger",
+            "alias" : "oid"
+          },
           {
             "name" : "reference_time",
             "type" : "esriFieldTypeString",


### PR DESCRIPTION
Added oid fields to recently published raster services

## Changes

- Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim/ana_snow_depth.mapx: Added oid field to service metadata table
- Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim/ana_soil_moisture.mapx: Added oid field to service metadata table
- Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim/ana_soil_moisture_ice_content.mapx: Added oid field to service metadata table
