### PR TITLE
FIM Data Prep Fix for Reference Products

### DIFF
--- a/Core/LAMBDA/viz_functions/image_based/main.tf
+++ b/Core/LAMBDA/viz_functions/image_based/main.tf
@@ -354,7 +354,7 @@ data "archive_file" "hand_fim_processing_zip" {
       IMAGE_TAG          = var.ecr_repository_image_tag
       LAMBDA_ROLE_ARN    = var.lambda_role
       FIM_BUCKET         = var.fim_data_bucket
-      FIM_PREFIX         = "fim_${replace(var.fim_version, ".", "_")}"
+      FIM_PREFIX         = "fim_${replace(var.fim_version, ".", "_")}/hand_datasets"
       VIZ_DB_DATABASE    = var.viz_db_name
       VIZ_DB_HOST        = var.viz_db_host
       VIZ_DB_USERNAME    = jsondecode(var.viz_db_user_secret_string)["username"]

--- a/Core/LAMBDA/viz_functions/image_based/viz_hand_fim_processing/lambda_function.py
+++ b/Core/LAMBDA/viz_functions/image_based/viz_hand_fim_processing/lambda_function.py
@@ -7,13 +7,13 @@ import geopandas as gpd
 import os
 import time
 import datetime
-from shapely.geometry import shape
-from shapely.ops import unary_union
+import re
 
 from viz_classes import s3_file, database
 
 FIM_BUCKET = os.environ['FIM_BUCKET']
 FIM_PREFIX = os.environ['FIM_PREFIX']
+FIM_VERSION = re.findall("[/_]?(\d*_\d*_\d*_\d*)/?", FIM_PREFIX)[0]
 
 s3 = boto3.client("s3")
 
@@ -203,19 +203,22 @@ def create_inundation_catchment_boundary(huc8, branch):
     geom = [shape(i['geom']) for i in geoms]
     hydro_ids = [i['hydro_id'] for i in geoms]
     df_final = gpd.GeoDataFrame({'geom':geom, 'hydro_id': hydro_ids}, crs="ESRI:102039", geometry="geom")
-    df_final = df_final.dissolve(by="hydro_id")
+    df_final = df_final.dissolve(by="hydro_id").explode()
     df_final = df_final.to_crs(3857)
     df_final = df_final.set_crs('epsg:3857')
-    print("dropping duplicates")
+    
     if df_final.index.has_duplicates:
+        print("dropping duplicates")
         df_final = df_final.drop_duplicates()
     
     print("Adding additional metadata columns")
     df_final = df_final.reset_index()
     df_final = df_final.rename(columns={"index": "hydro_id"})
-    df_final['fim_version'] = FIM_PREFIX.split("fim_")[-1]
+    df_final['fim_version'] = FIM_VERSION
     df_final['huc8'] = huc8
     df_final['branch'] = branch
+
+    df_final = df_final.drop(columns=["level_1"])
                 
     return df_final
     
@@ -392,19 +395,21 @@ def create_inundation_output(huc8, branch, stage_lookup, reference_time):
     geom = [shape(i['geom']) for i in geoms]
     hydro_ids = [i['hydro_id'] for i in geoms]
     df_final = gpd.GeoDataFrame({'geom':geom, 'hydro_id': hydro_ids}, crs="ESRI:102039", geometry="geom")
-    df_final = df_final.dissolve(by="hydro_id")
+    df_final = df_final.dissolve(by="hydro_id").explode()
     df_final['geom'] = df_final['geom'].simplify(5) #Simplifying polygons to ~5m to clean up problematic geometries
     df_final = df_final.to_crs(3857)
     df_final = df_final.set_crs('epsg:3857')
         
     df_final = df_final.join(stage_lookup).dropna()
     
-    df_final = df_final.drop_duplicates()
+    if df_final.index.has_duplicates:
+        print("dropping duplicates")
+        df_final = df_final.drop_duplicates()
     
     print("Adding additional metadata columns")
     df_final = df_final.reset_index()
     df_final = df_final.rename(columns={"index": "hydro_id"})
-    df_final['fim_version'] = FIM_PREFIX.split("fim_")[-1]
+    df_final['fim_version'] = FIM_VERSION
     df_final['reference_time'] = reference_time
     df_final['huc8'] = huc8
     df_final['branch'] = branch
@@ -416,7 +421,7 @@ def create_inundation_output(huc8, branch, stage_lookup, reference_time):
     df_final['hydro_id_str'] = df_final['hydro_id'].astype(str)
     df_final['feature_id_str'] = df_final['feature_id'].astype(str)
 
-    df_final = df_final.drop(columns=["hand_stage_m", "max_rc_stage_m", "streamflow_cms", "max_rc_discharge_cms"])
+    df_final = df_final.drop(columns=["hand_stage_m", "max_rc_stage_m", "streamflow_cms", "max_rc_discharge_cms", "level_1"])
                 
     return df_final
 

--- a/Core/LAMBDA/viz_functions/viz_fim_data_prep/lambda_function.py
+++ b/Core/LAMBDA/viz_functions/viz_fim_data_prep/lambda_function.py
@@ -57,7 +57,7 @@ def setup_huc_inundation(event):
     # Checks if all tables references in sql file exist and are updated (if applicable)
     # Raises a custom RequiredTableNotUpdated if not, which will be caught by viz_pipline
     # and invoke a retry
-    process_db.check_required_tables_updated(sql_path, sql_replace, reference_time, raise_if_false=True)
+    viz_db.check_required_tables_updated(sql_path, sql_replace, reference_time, raise_if_false=True)
 
     sql = open(sql_path, 'r').read().lower()
 


### PR DESCRIPTION
For the FIM data prep lambda, the EGIS DB is being used to check required tables when a reference product is being ran. I hardcoded the check to occur on the viz DB instead because we will never use the EGIS DB to grab data to process from.