### PR TITLE
Fixes regex matching bug

### DIFF
--- a/Core/LAMBDA/viz_functions/viz_initialize_pipeline/lambda_function.py
+++ b/Core/LAMBDA/viz_functions/viz_initialize_pipeline/lambda_function.py
@@ -327,7 +327,7 @@ class configuration:
             configuration_name = "rfc"
             reference_time = datetime.datetime.strptime(f"{date[:4]}-{date[-4:][:2]}-{date[-2:]} {hour[-2:]}:{minute[-2:]}:00", '%Y-%m-%d %H:%M:%S')
         elif 'replace_route' in filename:
-            matches = re.findall(r"(.*)/(\d{8})/wrf_hydro/wrf_hydro.t(\d{2})z.medium_range.channel_rt.f(\d{3,5}).(.*)\.nc", filename)[0]
+            matches = re.findall(r"(.*)/(\d{8})/wrf_hydro/replace_route.t(\d{2})z.medium_range.channel_rt.f(\d{3,5}).(.*)\.nc", filename)[0]
             configuration_name = 'replace_route'
             date = matches[1]
             hour = matches[2]


### PR DESCRIPTION
The replace and route execution of the `initialize_pipeline` lambda began failing in TI a few days ago. I'm guessing I must have had a hard-coded in-place change directly on TI from back when I was developing and testing the replace and route code. Again as my guess, it's likely that TI was just redeployed a couple of days ago with the rnr code that had been recently merged into it.

Anyhow, this small change will fix the issue.