### PR TITLE
Hawaii and Puerto Rico HAND and SCHISM FIM Fixes

### DIFF
--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/ana_inundation_hi.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/ana_inundation_hi.sql
@@ -1,3 +1,8 @@
+--Add an empty row so that service monitor will pick up a reference and update time in the event of no fim features
+INSERT INTO ingest.ana_inundation_hi(
+	hydro_id, hydro_id_str, geom, branch, feature_id, feature_id_str, streamflow_cfs, hand_stage_ft, max_rc_stage_ft, max_rc_discharge_cfs, fim_version, reference_time, huc8)
+	VALUES (-9999, '-9999', NULL, 'NA', -9999, '-9999', -9999, -9999, -9999, -9999, 'NA', to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), '-9999');
+
 DROP TABLE IF EXISTS publish.ana_inundation_hi;
 
 SELECT  
@@ -22,7 +27,3 @@ SELECT
 INTO publish.ana_inundation_hi
 FROM ingest.ana_inundation_hi as inun 
 left join derived.channels_hi AS channels ON channels.feature_id = inun.feature_id_str
---Add an empty row so that service monitor will pick up a reference and update time in the event of no fim features.
-UNION SELECT -9999, '-9999', 'NA', -9999, '-9999', -9999, -9999, -9999, -9999, 'NA', to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), 
-to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), '-9999', NULL,
-to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS update_time, -9999, NULL, 'HI';

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/ana_inundation_prvi.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/ana_inundation_prvi.sql
@@ -1,3 +1,8 @@
+--Add an empty row so that service monitor will pick up a reference and update time in the event of no fim features
+INSERT INTO ingest.ana_inundation_prvi(
+	hydro_id, hydro_id_str, geom, branch, feature_id, feature_id_str, streamflow_cfs, hand_stage_ft, max_rc_stage_ft, max_rc_discharge_cfs, fim_version, reference_time, huc8)
+	VALUES (-9999, '-9999', NULL, 'NA', -9999, '-9999', -9999, -9999, -9999, -9999, 'NA', to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), '-9999');
+
 DROP TABLE IF EXISTS publish.ana_inundation_prvi;
 
 SELECT  
@@ -22,7 +27,3 @@ SELECT
 INTO publish.ana_inundation_prvi
 FROM ingest.ana_inundation_prvi as inun 
 left join derived.channels_prvi as channels ON channels.feature_id = inun.feature_id
---Add an empty row so that service monitor will pick up a reference and update time in the event of no fim features.
-UNION SELECT -9999, '-9999', 'NA', -9999, '-9999', -9999, -9999, -9999, -9999, 'NA', to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), 
-to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), '-9999', NULL,
-to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS update_time, -9999, NULL, 'PRVI';

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/srf_48hr_max_inundation_hi.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/srf_48hr_max_inundation_hi.sql
@@ -1,3 +1,8 @@
+--Add an empty row so that service monitor will pick up a reference and update time in the event of no fim features
+INSERT INTO ingest.srf_48hr_max_inundation_hi(
+	hydro_id, hydro_id_str, geom, branch, feature_id, feature_id_str, streamflow_cfs, hand_stage_ft, max_rc_stage_ft, max_rc_discharge_cfs, fim_version, reference_time, huc8)
+	VALUES (-9999, '-9999', NULL, 'NA', -9999, '-9999', -9999, -9999, -9999, -9999, 'NA', to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), '-9999');
+
 DROP TABLE IF EXISTS publish.srf_48hr_max_inundation_hi;
 
 SELECT  

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/srf_48hr_max_inundation_prvi.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/srf_48hr_max_inundation_prvi.sql
@@ -1,3 +1,8 @@
+--Add an empty row so that service monitor will pick up a reference and update time in the event of no fim features
+INSERT INTO ingest.srf_48hr_max_inundation_prvi(
+	hydro_id, hydro_id_str, geom, branch, feature_id, feature_id_str, streamflow_cfs, hand_stage_ft, max_rc_stage_ft, max_rc_discharge_cfs, fim_version, reference_time, huc8)
+	VALUES (-9999, '-9999', NULL, 'NA', -9999, '-9999', -9999, -9999, -9999, -9999, 'NA', to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), '-9999');
+
 DROP TABLE IF EXISTS publish.srf_48hr_max_inundation_prvi;
 
 SELECT  


### PR DESCRIPTION
Had to do a few things to get HAND and SCHISM FIM working for Hawaii and Puerto Rico

1.  Update vlab repo to create coastal triggers for AnA and SRF Hawaii and Puerto Rico Coastal datasets
2. Update viz class method to handle new eventbridge inputs. Also simplified function since we have also simplified the eventbridge names to be the configuration name
3. Added null rows to the ingest inundation table before merging and creating the publish table. This helped get past the check required tables function that was failing because the ingest table was empty.