### PR TITLE
Various Small Fixes/Improvements for V2.1.0

### DIFF
--- a/Core/LAMBDA/viz_functions/image_based/viz_schism_fim_processing/requirements.txt
+++ b/Core/LAMBDA/viz_functions/image_based/viz_schism_fim_processing/requirements.txt
@@ -12,4 +12,5 @@ geopandas==0.12.2
 SQLAlchemy==1.4.46
 GeoAlchemy2==0.12.3
 psycopg2-binary==2.9.3
-boto3==1.26.90
+botocore==1.27.59
+boto3==1.24.59

--- a/Core/LAMBDA/viz_functions/image_based/viz_schism_fim_processing/requirements.txt
+++ b/Core/LAMBDA/viz_functions/image_based/viz_schism_fim_processing/requirements.txt
@@ -12,3 +12,4 @@ geopandas==0.12.2
 SQLAlchemy==1.4.46
 GeoAlchemy2==0.12.3
 psycopg2-binary==2.9.3
+boto3==1.26.90

--- a/Core/LAMBDA/viz_functions/viz_fim_data_prep/lambda_function.py
+++ b/Core/LAMBDA/viz_functions/viz_fim_data_prep/lambda_function.py
@@ -103,7 +103,7 @@ def setup_huc_inundation(event):
         
         s3_keys = []
         df_streamflows = df_streamflows.drop_duplicates("huc8_branch")
-        df_streamflows_split = np.array_split(df_streamflows[["huc8_branch", "huc", "data_key"]], 20)
+        df_streamflows_split = [df_split for df_split in np.array_split(df_streamflows[["huc8_branch", "huc", "data_key"]], 20) if not df_split.empty]
         for index, df in enumerate(df_streamflows_split):
             # Key for the csv file that will be stored in S3
             csv_key = f"{PROCESSED_OUTPUT_PREFIX}/{product}/{fim_config_name}/workspace/{date}/{hour}/hucs_to_process_{index}.csv"

--- a/Core/LAMBDA/viz_functions/viz_publish_service/lambda_function.py
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/lambda_function.py
@@ -95,7 +95,7 @@ def lambda_handler(event, context):
                 print(f"---> Updated {service_name} sharing to org in Portal.")
 
             # Ensuring that the description for the service matches the iteminfo
-            matching_service = matching_services[0]
+            matching_service = [service for service in publish_server.services.list(folder=folder) if service.properties['serviceName'] == service_name or service.properties['serviceName'] == service_name_publish][0]
             if not matching_service.properties['description']:
                 print("Updating service property description to match iteminfo")
                 service_properties = matching_service.properties


### PR DESCRIPTION
After pushing V2.1.0 to UAT, there were a few small fixes that needed to be done.

1. Implemented a specific version for botocore and boto3 for the schism lambda. The most recent versions with lambda were throwing dependency errors
2. cleaned up HUC mapping to not run extra HUC runs by removing empty sublist in the HUC run list
3. Fixed wrong variable reference in the publish service code. The old variable was referencing services before publishing the new version. I had to recreate the service list to get the newly created service.