### PR TITLE
Public FIM Rendering and DB Foreign Table Fixes

### DIFF
--- a/Core/EC2/RDSBastion/scripts/viz/postgresql_setup.sh.tftpl
+++ b/Core/EC2/RDSBastion/scripts/viz/postgresql_setup.sh.tftpl
@@ -12,6 +12,11 @@ EGISDBHOST="${EGISDBHOST}"
 EGISDBPORT=${EGISDBPORT}
 EGISDBUSERNAME="${EGISDBUSERNAME}"
 EGISDBPASSWORD="${EGISDBPASSWORD}"
+LOCATIONDBNAME="${LOCATIONDBNAME}"
+LOCATIONDBHOST="${LOCATIONDBHOST}"
+LOCATIONDBPORT=${LOCATIONDBPORT}
+LOCATIONDBUSER="${LOCATIONDBUSER}"
+LOCATIONDBPASS="${LOCATIONDBPASS}"
 DEPLOYMENT_BUCKET="${DEPLOYMENT_BUCKET}"
 HOME="${HOME}"
 VIZ_PROC_ADMIN_RW_USER="${VIZ_PROC_ADMIN_RW_USER}"
@@ -126,7 +131,21 @@ psql -h "$${VIZDBHOST}" -U "$${VIZDBUSERNAME}" -p $${VIZDBPORT} -d "$${VIZDBNAME
             GRANT ALL ON ALL TABLES IN SCHEMA dev TO $${VIZ_PROC_DEV_RW_USER};
             ALTER DEFAULT PRIVILEGES IN SCHEMA dev GRANT all ON TABLES TO $${VIZ_PROC_DEV_RW_USER};"
 
-echo "Setting up external.usgs_gage table in the EVIZ GIS DB, ensuring postgres_fdw extension installed, and setting up foreign table wrappers..."
+echo "Setting up wrds location foreign table in the VIZ GIS DB, ensuring postgres_fdw extension installed, and setting up foreign table wrappers..."
+psql -h "$${VIZDBHOST}" -U "$${VIZDBUSERNAME}" -p $${VIZDBPORT} -d "$${VIZDBNAME}" \
+    -tAc "do
+            '
+            declare
+            l_rec record;
+            begin
+            for l_rec in (select foreign_table_schema, foreign_table_name 
+                            from information_schema.foreign_tables
+                            where foreign_table_schema = ''external'') loop
+                execute format(''drop foreign table %I.%I'', l_rec.foreign_table_schema, l_rec.foreign_table_name);
+            end loop;
+            end;
+            '"
+
 psql -h "$${VIZDBHOST}" -U "$${VIZDBUSERNAME}" -p $${VIZDBPORT} -d "$${VIZDBNAME}" \
     -tAc "CREATE EXTENSION IF NOT EXISTS postgres_fdw;
             DROP SERVER IF EXISTS wrds_location CASCADE;
@@ -134,7 +153,7 @@ psql -h "$${VIZDBHOST}" -U "$${VIZDBUSERNAME}" -p $${VIZDBPORT} -d "$${VIZDBNAME
             CREATE USER MAPPING FOR $${VIZDBUSERNAME} SERVER wrds_location OPTIONS (user '$${LOCATIONDBUSER}', password '$${LOCATIONDBPASS}');
             CREATE USER MAPPING FOR $${VIZ_PROC_ADMIN_RW_USER} SERVER wrds_location OPTIONS (user '$${LOCATIONDBUSER}', password '$${LOCATIONDBPASS}');
             IMPORT FOREIGN SCHEMA public FROM SERVER wrds_location INTO external;
-            ALTER SERVER wrds_location OPTIONS (set fetch_size '150000');"
+            ALTER SERVER wrds_location OPTIONS (fetch_size '150000');"
 
 # Setting up EGIS DB - Part 2
 export PGPASSWORD=$${EGISDBPASSWORD}

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim/ana_inundation_extent.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim/ana_inundation_extent.mapx
@@ -277,7 +277,7 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "displayField" : "feature_id",
+        "displayField" : "streamflow_cfs",
         "editable" : true,
         "fieldDescriptions" : [
           {
@@ -416,35 +416,7 @@
       "htmlPopupEnabled" : true,
       "selectable" : true,
       "featureCacheType" : "Session",
-      "enableDisplayFilters" : true,
-      "displayFilters" : [
-        {
-          "type" : "CIMDisplayFilter",
-          "name" : "Large Streams",
-          "whereClause" : "strm_order >= 4",
-          "maxScale" : 5000000
-        },
-        {
-          "type" : "CIMDisplayFilter",
-          "name" : "Medium Streams",
-          "whereClause" : "strm_order >= 3",
-          "minScale" : 5000000,
-          "maxScale" : 2500000
-        },
-        {
-          "type" : "CIMDisplayFilter",
-          "name" : "Small Streams",
-          "whereClause" : "strm_order >= 2",
-          "minScale" : 2500000,
-          "maxScale" : 500000
-        },
-        {
-          "type" : "CIMDisplayFilter",
-          "name" : "All Streams",
-          "whereClause" : "strm_order >= 1",
-          "minScale" : 500000
-        }
-      ],
+      "displayFilters" : [],
       "displayFiltersType" : "ByScale",
       "featureBlendingMode" : "Alpha",
       "labelClasses" : [

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_mem1/mrf_gfs_5day_max_inundation_extent.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_mem1/mrf_gfs_5day_max_inundation_extent.mapx
@@ -261,10 +261,11 @@
         "type" : "CIMLayerElevationSurface",
         "mapElevationID" : "{84F61CAA-CD53-4C26-BBF2-C7F7CA71C354}"
       },
+      "expanded" : true,
       "layerType" : "Operational",
       "minScale" : 400000,
       "showLegends" : true,
-      "visibility" : false,
+      "visibility" : true,
       "displayCacheType" : "Permanent",
       "maxDisplayCacheAge" : 5,
       "showPopups" : true,
@@ -276,7 +277,7 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "displayField" : "name",
+        "displayField" : "streamflow_cfs",
         "editable" : true,
         "fieldDescriptions" : [
           {
@@ -415,35 +416,7 @@
       "htmlPopupEnabled" : true,
       "selectable" : true,
       "featureCacheType" : "Session",
-      "enableDisplayFilters" : true,
-      "displayFilters" : [
-        {
-          "type" : "CIMDisplayFilter",
-          "name" : "Large Streams",
-          "whereClause" : "strm_order >= 4",
-          "maxScale" : 5000000
-        },
-        {
-          "type" : "CIMDisplayFilter",
-          "name" : "Medium Streams",
-          "whereClause" : "strm_order >= 3",
-          "minScale" : 5000000,
-          "maxScale" : 2500000
-        },
-        {
-          "type" : "CIMDisplayFilter",
-          "name" : "Small Streams",
-          "whereClause" : "strm_order >= 2",
-          "minScale" : 2500000,
-          "maxScale" : 500000
-        },
-        {
-          "type" : "CIMDisplayFilter",
-          "name" : "All Streams",
-          "whereClause" : "strm_order >= 1",
-          "minScale" : 500000
-        }
-      ],
+      "displayFilters" : [],
       "displayFiltersType" : "ByScale",
       "featureBlendingMode" : "Alpha",
       "labelClasses" : [

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/replace_route/rfc_based_5day_max_inundation_extent.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/replace_route/rfc_based_5day_max_inundation_extent.mapx
@@ -277,7 +277,7 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "displayField" : "feature_id",
+        "displayField" : "streamflow_cfs",
         "editable" : true,
         "fieldDescriptions" : [
           {
@@ -416,35 +416,7 @@
       "htmlPopupEnabled" : true,
       "selectable" : true,
       "featureCacheType" : "Session",
-      "enableDisplayFilters" : true,
-      "displayFilters" : [
-        {
-          "type" : "CIMDisplayFilter",
-          "name" : "Large Streams",
-          "whereClause" : "strm_order >= 4",
-          "maxScale" : 5000000
-        },
-        {
-          "type" : "CIMDisplayFilter",
-          "name" : "Medium Streams",
-          "whereClause" : "strm_order >= 3",
-          "minScale" : 5000000,
-          "maxScale" : 2500000
-        },
-        {
-          "type" : "CIMDisplayFilter",
-          "name" : "Small Streams",
-          "whereClause" : "strm_order >= 2",
-          "minScale" : 2500000,
-          "maxScale" : 500000
-        },
-        {
-          "type" : "CIMDisplayFilter",
-          "name" : "All Streams",
-          "whereClause" : "strm_order >= 1",
-          "minScale" : 500000
-        }
-      ],
+      "displayFilters" : [],
       "displayFiltersType" : "ByScale",
       "featureBlendingMode" : "Alpha",
       "labelClasses" : [


### PR DESCRIPTION
This PR will resolve a few issues dealing with Public FIM rendering and data processing.

1. The RDS bastion script was failing when creating a foreign table from the WRDS location DB. This was due to missing variable in the setup script.
2. The RDS bastion script was failing because a foreign table already existed from the dump. I added some postgres logic to loop through the external schema as delete existing foreign tables. This required removing the "set" from the fetch size option
3. Removed the display filters on the public services because strm order is not present and was causing the services to not render