### PR TITLE
Implements coastal fim depth services as vrts

### DIFF
--- a/Core/LAMBDA/viz_functions/image_based/viz_optimize_rasters/Dockerfile
+++ b/Core/LAMBDA/viz_functions/image_based/viz_optimize_rasters/Dockerfile
@@ -1,22 +1,6 @@
-FROM ghcr.io/lambgeo/lambda-gdal:3.5 as gdal
+FROM ghcr.io/lambgeo/lambda-gdal:3.6-python3.9
 
-# We use the official AWS Lambda image
-FROM public.ecr.aws/lambda/python:3.9
-
-ENV PACKAGE_PREFIX=/opt
-
-# Bring C libs from lambgeo/lambda-gdal image
-COPY --from=gdal /opt/lib/ ${PACKAGE_PREFIX}/lib/
-COPY --from=gdal /opt/include/ ${PACKAGE_PREFIX}/include/
-COPY --from=gdal /opt/share/ ${PACKAGE_PREFIX}/share/
-COPY --from=gdal /opt/bin/ ${PACKAGE_PREFIX}/bin/
-
-ENV \
-  GDAL_DATA=${PACKAGE_PREFIX}/share/gdal \
-  PROJ_LIB=${PACKAGE_PREFIX}/share/proj \
-  GDAL_CONFIG=${PACKAGE_PREFIX}/bin/gdal-config \
-  GEOS_CONFIG=${PACKAGE_PREFIX}/bin/geos-config \
-  PATH=${PACKAGE_PREFIX}/bin:$PATH
+RUN python -m pip install gdal==$(gdal-config --version)
 
 # Copy any local files to the package
 COPY lambda_function.py /var/task/lambda_function.py
@@ -24,4 +8,5 @@ COPY logger.py /var/task/logger.py
 COPY OptimizeRasters.py /var/task/OptimizeRasters.py
 COPY TIF_to_MRF.xml /var/task/TIF_to_MRF.xml
 
+ENTRYPOINT [ "/lambda-entrypoint.sh" ]
 CMD [ "lambda_function.lambda_handler" ]

--- a/Core/LAMBDA/viz_functions/image_based/viz_optimize_rasters/lambda_function.py
+++ b/Core/LAMBDA/viz_functions/image_based/viz_optimize_rasters/lambda_function.py
@@ -3,6 +3,8 @@ import shutil
 import boto3
 import OptimizeRasters
 
+from osgeo import gdal
+
 s3 = boto3.client('s3')
 s3_resource = boto3.resource('s3')
 
@@ -18,6 +20,45 @@ def lambda_handler(event, context):
             context(object): Provides methods and properties that provide information about the invocation, function,
                              and runtime environment
     """
+    if 'step' in event and event['step'] == 'create_vrt':
+        run_create_vrt(event)
+    else:
+        run_optimize_raster(event)
+
+def create_optimized_rasters(inundation_raster):
+    args = {
+        'input': os.path.dirname(inundation_raster),    # input path. eg. c:/input/mydata
+        'output': '/tmp/or',  # processed output path. eg. c:/output/mydata
+        'subs': 'false',    # Do we included subfolders?
+        'config': 'TIF_to_MRF.xml'  # eg. r'c:/Image_Mgmt_Workflows/OptimizeRasters/Templates/Imagery_to_MRF_LERC.xml'  # noqa
+    }
+    rpt = OptimizeRasters.Report(OptimizeRasters.Base())
+    writeToPath = '/tmp/or'
+    if not os.path.exists(writeToPath):
+        os.mkdir(writeToPath)
+    ORJobFile = os.path.join(writeToPath, '{}{}'.format(rpt.getUniqueFileName(), rpt.CJOB_EXT))
+    rpt.init(ORJobFile)
+    for key in args.keys():
+        rpt.addHeader(key, args[key])   # add necessary headers.
+    rpt.addFile(inundation_raster)  # eg. c:/input/mydata/readme.txt
+    # please note, when adding files into the job file, it's important that all entries should have the same parent folder. In this case, it's (c:/input/mydata/)  # noqa
+    rpt.write()  # create the OR job/.orjob file.
+    args['input'] = ORJobFile      # input now points to the newly created OptimizeRasters Job file.
+    app = OptimizeRasters.Application(args)  # The args{} can contain any valid cmd-line argument name without the prefix '-'  # noqa
+    # app.registerMessageCallback(messages)   # Optional. If messages need to be brought back onto the caller's side.
+    if (not app.init()):
+        return False
+    app.run()  # Do processing..
+    rpt = app.getReport()   # Get report/log status
+    isSuccess = False
+    if (rpt and
+            not rpt.hasFailures()):  # If log has no failures, consider the processing as successful.
+        isSuccess = True
+    print('Results> {}'.format(str(isSuccess)))
+
+    return writeToPath
+
+def run_optimize_raster(event):
     # Parse the event to get the necessary arguments
     input_raster_bucket = event['output_bucket']
     input_raster_key = event['output_raster']
@@ -62,36 +103,37 @@ def lambda_handler(event, context):
         f"Successfully processed mrf for {input_raster_key}"
     )
 
+def run_create_vrt(event):
+    fim_config = event['args']['fim_config']['name']
+    output_bucket = event['args']['product']['raster_outputs']['output_bucket']
+    output_workspaces = event['args']['product']['raster_outputs']['output_raster_workspaces']
+    output_workspace = next(list(workspace.values())[0] for workspace in output_workspaces if list(workspace.keys())[0] == fim_config)
 
-def create_optimized_rasters(inundation_raster):
-    args = {
-        'input': os.path.dirname(inundation_raster),    # input path. eg. c:/input/mydata
-        'output': '/tmp/or',  # processed output path. eg. c:/output/mydata
-        'subs': 'false',    # Do we included subfolders?
-        'config': 'TIF_to_MRF.xml'  # eg. r'c:/Image_Mgmt_Workflows/OptimizeRasters/Templates/Imagery_to_MRF_LERC.xml'  # noqa
-    }
-    rpt = OptimizeRasters.Report(OptimizeRasters.Base())
-    writeToPath = '/tmp/or'
-    if not os.path.exists(writeToPath):
-        os.mkdir(writeToPath)
-    ORJobFile = os.path.join(writeToPath, '{}{}'.format(rpt.getUniqueFileName(), rpt.CJOB_EXT))
-    rpt.init(ORJobFile)
-    for key in args.keys():
-        rpt.addHeader(key, args[key])   # add necessary headers.
-    rpt.addFile(inundation_raster)  # eg. c:/input/mydata/readme.txt
-    # please note, when adding files into the job file, it's important that all entries should have the same parent folder. In this case, it's (c:/input/mydata/)  # noqa
-    rpt.write()  # create the OR job/.orjob file.
-    args['input'] = ORJobFile      # input now points to the newly created OptimizeRasters Job file.
-    app = OptimizeRasters.Application(args)  # The args{} can contain any valid cmd-line argument name without the prefix '-'  # noqa
-    # app.registerMessageCallback(messages)   # Optional. If messages need to be brought back onto the caller's side.
-    if (not app.init()):
-        return False
-    app.run()  # Do processing..
-    rpt = app.getReport()   # Get report/log status
-    isSuccess = False
-    if (rpt and
-            not rpt.hasFailures()):  # If log has no failures, consider the processing as successful.
-        isSuccess = True
-    print('Results> {}'.format(str(isSuccess)))
+    # We only create two VRTs (one in the mrf folder and another in the tif folder)
+    # because we only want one in the mrf folder, but for it to be moved to the 
+    # publish folder it has to also exist in the tif folder since the tif folder
+    # is used as the basis for what gets copied over in the viz_update_egis_data lambda
+    create_vrt(output_bucket, f'{output_workspace}/tif/', '.tif')
+    create_vrt(output_bucket, f'{output_workspace}/mrf/', '.mrf')
 
-    return writeToPath
+def create_vrt(output_bucket, output_workspace, extension):
+    s3_client = boto3.client('s3')
+    paginator = s3_client.get_paginator('list_objects')
+    operation_parameters = {'Bucket': output_bucket,
+                            'Prefix': output_workspace,
+                            'Delimiter': '/'}
+    page_iterator = paginator.paginate(**operation_parameters)
+    vrt_files = []
+    page_count = 0
+    for page in page_iterator:
+        page_count += 1
+        objects = page['Contents']
+        for obj in objects:
+            key = obj['Key']
+            if key.endswith(extension):
+                vrt_files.append(f'/vsis3/{output_bucket}/{key}')
+
+    out_vrt = f'/vsis3/{output_bucket}/{output_workspace}_dataset.vrt'
+    print(f"Building VRT from {len(vrt_files)} files and writing to {out_vrt}...")
+    vrt_options = gdal.BuildVRTOptions(VRTNodata=0)
+    gdal.BuildVRT(out_vrt, vrt_files, options=vrt_options)

--- a/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/analysis_assim_coastal/ana_coastal_inundation.yml
+++ b/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/analysis_assim_coastal/ana_coastal_inundation.yml
@@ -29,3 +29,4 @@ postprocess_sql:
 
 services:
   - ana_coastal_inundation_extent_noaa
+  - ana_coastal_inundation_depth_noaa

--- a/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/analysis_assim_coastal_hawaii/ana_coastal_inundation_hi.yml
+++ b/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/analysis_assim_coastal_hawaii/ana_coastal_inundation_hi.yml
@@ -19,3 +19,4 @@ fim_configs:
 
 services:
   - ana_coastal_inundation_extent_hi_noaa
+  - ana_coastal_inundation_depth_hi_noaa

--- a/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/analysis_assim_coastal_puertorico/ana_coastal_inundation_prvi.yml
+++ b/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/analysis_assim_coastal_puertorico/ana_coastal_inundation_prvi.yml
@@ -19,3 +19,4 @@ fim_configs:
 
 services:
   - ana_coastal_inundation_extent_prvi_noaa
+  - ana_coastal_inundation_depth_prvi_noaa

--- a/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/medium_range_mem1_coastal/mrf_gfs_10day_max_coastal_inundation.yml
+++ b/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/medium_range_mem1_coastal/mrf_gfs_10day_max_coastal_inundation.yml
@@ -69,3 +69,4 @@ postprocess_sql:
 
 services:
   - mrf_gfs_10day_max_coastal_inundation_extent_noaa
+  - mrf_gfs_10day_max_coastal_inundation_depth_noaa

--- a/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/short_range_coastal/srf_18hr_max_coastal_inundation.yml
+++ b/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/short_range_coastal/srf_18hr_max_coastal_inundation.yml
@@ -29,3 +29,4 @@ postprocess_sql:
 
 services:
   - srf_18hr_max_coastal_inundation_extent_noaa
+  - srf_18hr_max_coastal_inundation_depth_noaa

--- a/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/short_range_coastal_hawaii/srf_48hr_max_coastal_inundation_hi.yml
+++ b/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/short_range_coastal_hawaii/srf_48hr_max_coastal_inundation_hi.yml
@@ -19,3 +19,4 @@ fim_configs:
 
 services:
   - srf_48hr_max_coastal_inundation_extent_hi_noaa
+  - srf_48hr_max_coastal_inundation_depth_hi_noaa

--- a/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/short_range_coastal_puertorico/srf_48hr_max_coastal_inundation_prvi.yml
+++ b/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/short_range_coastal_puertorico/srf_48hr_max_coastal_inundation_prvi.yml
@@ -19,3 +19,4 @@ fim_configs:
 
 services:
   - srf_48hr_max_coastal_inundation_extent_prvi_noaa
+  - srf_48hr_max_coastal_inundation_depth_prvi_noaa

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal/ana_coastal_inundation_depth_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal/ana_coastal_inundation_depth_noaa.mapx
@@ -1,0 +1,453 @@
+{
+  "type" : "CIMMapDocument",
+  "version" : "2.7.0",
+  "build" : 26828,
+  "mapDefinition" : {
+    "type" : "CIMMap",
+    "name" : "NWM Coastal FIM Depth Analysis",
+    "uRI" : "CIMPATH=map/map.xml",
+    "sourceModifiedTime" : {
+      "type" : "TimeInstant"
+    },
+    "metadataURI" : "CIMPATH=Metadata/511a310f06766413e4a9efb971180b16.xml",
+    "useSourceMetadata" : true,
+    "illumination" : {
+      "type" : "CIMIlluminationProperties",
+      "ambientLight" : 75,
+      "sunPositionX" : -0.61237243569579003,
+      "sunPositionY" : 0.61237243569579003,
+      "sunPositionZ" : 0.5,
+      "illuminationSource" : "AbsoluteSunPosition",
+      "sunAzimuth" : 315,
+      "sunAltitude" : 30,
+      "showStars" : true,
+      "enableAmbientOcclusion" : true,
+      "enableEyeDomeLighting" : true
+    },
+    "layers" : [
+      "CIMPATH=map/_dataset_vrt.xml",
+      "CIMPATH=map/_dataset_vrt2.xml"
+    ],
+    "defaultViewingMode" : "Map",
+    "mapType" : "Map",
+    "defaultExtent" : {
+      "xmin" : -125.895685813900741,
+      "ymin" : 14.2068479882217993,
+      "xmax" : -66.3102524994904741,
+      "ymax" : 65.375504847905944,
+      "spatialReference" : {
+        "wkid" : 4326,
+        "latestWkid" : 4326
+      }
+    },
+    "elevationSurfaces" : [
+      {
+        "type" : "CIMMapElevationSurface",
+        "elevationMode" : "BaseGlobeSurface",
+        "name" : "Ground",
+        "verticalExaggeration" : 1,
+        "mapElevationID" : "{898F2553-05D3-4719-B747-5466725BAA27}",
+        "color" : {
+          "type" : "CIMRGBColor",
+          "values" : [
+            255,
+            255,
+            255,
+            100
+          ]
+        },
+        "surfaceTINShadingMode" : "Smooth",
+        "visibility" : true,
+        "expanded" : true
+      }
+    ],
+    "generalPlacementProperties" : {
+      "type" : "CIMMaplexGeneralPlacementProperties",
+      "invertedLabelTolerance" : 2,
+      "unplacedLabelColor" : {
+        "type" : "CIMRGBColor",
+        "values" : [
+          255,
+          0,
+          0,
+          100
+        ]
+      },
+      "keyNumberGroups" : [
+        {
+          "type" : "CIMMaplexKeyNumberGroup",
+          "delimiterCharacter" : ".",
+          "horizontalAlignment" : "Left",
+          "maximumNumberOfLines" : 20,
+          "minimumNumberOfLines" : 2,
+          "name" : "Default",
+          "numberResetType" : "None",
+          "keyNumberMethod" : "PreventUnplacedLabels"
+        }
+      ],
+      "placementQuality" : "High"
+    },
+    "snappingProperties" : {
+      "type" : "CIMSnappingProperties",
+      "xYTolerance" : 10,
+      "xYToleranceUnit" : "SnapXYToleranceUnitPixel",
+      "snapToSketchEnabled" : true,
+      "snapRequestType" : "SnapRequestType_GeometricAndVisualSnapping",
+      "isZSnappingEnabled" : true
+    },
+    "spatialReference" : {
+      "wkid" : 4326,
+      "latestWkid" : 4326
+    },
+    "timeDisplay" : {
+      "type" : "CIMMapTimeDisplay",
+      "defaultTimeIntervalUnits" : "esriTimeUnitsUnknown",
+      "timeValue" : {
+        "type" : "TimeExtent",
+        "start" : null,
+        "end" : null,
+        "empty" : false
+      },
+      "timeRelation" : "esriTimeRelationOverlaps"
+    },
+    "colorModel" : "RGB",
+    "scaleDisplayFormat" : "Value",
+    "clippingMode" : "None",
+    "nearPlaneClipDistanceMode" : "Automatic",
+    "rGBColorProfile" : "sRGB IEC61966-2-1 noBPC",
+    "cMYKColorProfile" : "U.S. Web Coated (SWOP) v2"
+  },
+  "layerDefinitions" : [
+    {
+      "type" : "CIMRasterLayer",
+      "name" : "Atlantic and Gulf Coastal Inundation Depth",
+      "uRI" : "CIMPATH=map/_dataset_vrt.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant",
+        "start" : 978307200000
+      },
+      "metadataURI" : "CIMPATH=Metadata/d37718d89ece7ecbefff4476d478739a.xml",
+      "useSourceMetadata" : true,
+      "description" : "_dataset.vrt",
+      "layerElevation" : {
+        "type" : "CIMLayerElevationSurface",
+        "mapElevationID" : "{898F2553-05D3-4719-B747-5466725BAA27}"
+      },
+      "layerType" : "Operational",
+      "minScale" : 500000,
+      "showLegends" : true,
+      "visibility" : true,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "dataConnection" : {
+        "type" : "CIMStandardDataConnection",
+        "workspaceConnectionString" : "DATABASE=\\\\10.26.150.30\\viz\\published\\raster_connection.acs\\srf_18hr_max_coastal_inundation\\srf_18hr_max_coastal_inundation_atlgulf\\published",
+        "workspaceFactory" : "Raster",
+        "dataset" : "_dataset.vrt",
+        "datasetType" : "esriDTAny"
+      },
+      "colorizer" : {
+        "type" : "CIMRasterClassifyColorizer",
+        "resamplingType" : "NearestNeighbor",
+        "noDataColor" : {
+          "type" : "CIMRGBColor",
+          "values" : [
+            255,
+            255,
+            255,
+            0
+          ]
+        },
+        "normalizationType" : "Nothing",
+        "classBreaks" : [
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 1,
+            "label" : "< 1'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                115,
+                223,
+                255,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 3,
+            "label" : "1' - 3'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                0,
+                112,
+                255,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 6,
+            "label" : "3' - 6'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                255,
+                0,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 9,
+            "label" : "6' - 9'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                170,
+                0,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 999,
+            "label" : "> 9'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                0,
+                0,
+                100
+              ]
+            }
+          }
+        ],
+        "classificationMethod" : "Manual",
+        "colorRamp" : {
+          "type" : "CIMLinearContinuousColorRamp",
+          "colorSpace" : {
+            "type" : "CIMICCColorSpace",
+            "url" : "Default RGB"
+          },
+          "fromColor" : {
+            "type" : "CIMHSVColor",
+            "values" : [
+              60,
+              100,
+              96,
+              100
+            ]
+          },
+          "toColor" : {
+            "type" : "CIMHSVColor",
+            "values" : [
+              0,
+              100,
+              96,
+              100
+            ]
+          }
+        },
+        "field" : "Value",
+        "hillshadeZFactor" : 1,
+        "showInAscendingOrder" : true,
+        "numberFormat" : {
+          "type" : "CIMNumericFormat",
+          "alignmentOption" : "esriAlignLeft",
+          "alignmentWidth" : 12,
+          "roundingOption" : "esriRoundNumberOfDecimals",
+          "roundingValue" : 6,
+          "useSeparator" : true
+        }
+      }
+    },
+    {
+      "type" : "CIMRasterLayer",
+      "name" : "Pacific Coastal Inundation Depth",
+      "uRI" : "CIMPATH=map/_dataset_vrt2.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant",
+        "start" : 978307200000
+      },
+      "metadataURI" : "CIMPATH=Metadata/30bff489edcefad05cb0ccf40b0e4329.xml",
+      "useSourceMetadata" : true,
+      "description" : "_dataset.vrt",
+      "layerElevation" : {
+        "type" : "CIMLayerElevationSurface",
+        "mapElevationID" : "{898F2553-05D3-4719-B747-5466725BAA27}"
+      },
+      "layerType" : "Operational",
+      "minScale" : 500000,
+      "showLegends" : true,
+      "visibility" : true,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "dataConnection" : {
+        "type" : "CIMStandardDataConnection",
+        "workspaceConnectionString" : "DATABASE=\\\\10.26.150.30\\viz\\published\\raster_connection.acs\\ana_coastal_inundation\\ana_coastal_inundation_pacific\\published",
+        "workspaceFactory" : "Raster",
+        "dataset" : "_dataset.vrt",
+        "datasetType" : "esriDTAny"
+      },
+      "colorizer" : {
+        "type" : "CIMRasterClassifyColorizer",
+        "resamplingType" : "NearestNeighbor",
+        "noDataColor" : {
+          "type" : "CIMRGBColor",
+          "values" : [
+            255,
+            255,
+            255,
+            0
+          ]
+        },
+        "normalizationType" : "Nothing",
+        "classBreaks" : [
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 1,
+            "label" : "< 1'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                115,
+                223,
+                255,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 3,
+            "label" : "1' - 3'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                0,
+                112,
+                255,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 6,
+            "label" : "3' - 6'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                255,
+                0,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 9,
+            "label" : "6' - 9'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                170,
+                0,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 999,
+            "label" : "> 9'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                0,
+                0,
+                100
+              ]
+            }
+          }
+        ],
+        "classificationMethod" : "Manual",
+        "colorRamp" : {
+          "type" : "CIMLinearContinuousColorRamp",
+          "colorSpace" : {
+            "type" : "CIMICCColorSpace",
+            "url" : "Default RGB"
+          },
+          "fromColor" : {
+            "type" : "CIMHSVColor",
+            "values" : [
+              60,
+              100,
+              96,
+              100
+            ]
+          },
+          "toColor" : {
+            "type" : "CIMHSVColor",
+            "values" : [
+              0,
+              100,
+              96,
+              100
+            ]
+          }
+        },
+        "field" : "Value",
+        "hillshadeZFactor" : 1,
+        "showInAscendingOrder" : true,
+        "numberFormat" : {
+          "type" : "CIMNumericFormat",
+          "alignmentOption" : "esriAlignLeft",
+          "alignmentWidth" : 12,
+          "roundingOption" : "esriRoundNumberOfDecimals",
+          "roundingValue" : 6,
+          "useSeparator" : true
+        }
+      }
+    }
+  ],
+  "binaryReferences" : [
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/30bff489edcefad05cb0ccf40b0e4329.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>20152100</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri></metadata>\r\n"
+    },
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/511a310f06766413e4a9efb971180b16.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>19525300</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>Map</resTitle></idCitation></dataIdInfo></metadata>\r\n"
+    },
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/d37718d89ece7ecbefff4476d478739a.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>20055700</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri></metadata>\r\n"
+    }
+  ]
+}

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal/ana_coastal_inundation_depth_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal/ana_coastal_inundation_depth_noaa.yml
@@ -1,0 +1,11 @@
+service: ana_coastal_inundation_depth
+summary: Coastal Inundation Depth Analysis
+description: Depicts the inundation depth of the National Water Model (NWM) total water level forecast. 
+  This service is derived from the analysis and assimilation configuration of the NWM over the contiguous U.S. 
+  Updated hourly.
+tags: national water model, nwm, ana, conus, schism, coastal, fim, inundation, depth
+credits: National Water Model, NOAA/NWS National Water Center
+egis_server: server
+egis_folder: nwm
+feature_service: false
+public_service: false

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal_hawaii/ana_coastal_inundation_depth_hi_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal_hawaii/ana_coastal_inundation_depth_hi_noaa.mapx
@@ -1,0 +1,295 @@
+{
+  "type" : "CIMMapDocument",
+  "version" : "2.7.0",
+  "build" : 26828,
+  "mapDefinition" : {
+    "type" : "CIMMap",
+    "name" : "NWM Coastal Inundation Depth Analysis for Hawaii",
+    "uRI" : "CIMPATH=map/map.xml",
+    "sourceModifiedTime" : {
+      "type" : "TimeInstant"
+    },
+    "metadataURI" : "CIMPATH=Metadata/511a310f06766413e4a9efb971180b16.xml",
+    "useSourceMetadata" : true,
+    "illumination" : {
+      "type" : "CIMIlluminationProperties",
+      "ambientLight" : 75,
+      "sunPositionX" : -0.61237243569579003,
+      "sunPositionY" : 0.61237243569579003,
+      "sunPositionZ" : 0.5,
+      "illuminationSource" : "AbsoluteSunPosition",
+      "sunAzimuth" : 315,
+      "sunAltitude" : 30,
+      "showStars" : true,
+      "enableAmbientOcclusion" : true,
+      "enableEyeDomeLighting" : true
+    },
+    "layers" : [
+      "CIMPATH=map/_dataset_vrt.xml"
+    ],
+    "defaultViewingMode" : "Map",
+    "mapType" : "Map",
+    "defaultExtent" : {
+      "xmin" : -125.895685813900741,
+      "ymin" : 14.2068479882217993,
+      "xmax" : -66.3102524994904741,
+      "ymax" : 65.375504847905944,
+      "spatialReference" : {
+        "wkid" : 4326,
+        "latestWkid" : 4326
+      }
+    },
+    "elevationSurfaces" : [
+      {
+        "type" : "CIMMapElevationSurface",
+        "elevationMode" : "BaseGlobeSurface",
+        "name" : "Ground",
+        "verticalExaggeration" : 1,
+        "mapElevationID" : "{898F2553-05D3-4719-B747-5466725BAA27}",
+        "color" : {
+          "type" : "CIMRGBColor",
+          "values" : [
+            255,
+            255,
+            255,
+            100
+          ]
+        },
+        "surfaceTINShadingMode" : "Smooth",
+        "visibility" : true,
+        "expanded" : true
+      }
+    ],
+    "generalPlacementProperties" : {
+      "type" : "CIMMaplexGeneralPlacementProperties",
+      "invertedLabelTolerance" : 2,
+      "unplacedLabelColor" : {
+        "type" : "CIMRGBColor",
+        "values" : [
+          255,
+          0,
+          0,
+          100
+        ]
+      },
+      "keyNumberGroups" : [
+        {
+          "type" : "CIMMaplexKeyNumberGroup",
+          "delimiterCharacter" : ".",
+          "horizontalAlignment" : "Left",
+          "maximumNumberOfLines" : 20,
+          "minimumNumberOfLines" : 2,
+          "name" : "Default",
+          "numberResetType" : "None",
+          "keyNumberMethod" : "PreventUnplacedLabels"
+        }
+      ],
+      "placementQuality" : "High"
+    },
+    "snappingProperties" : {
+      "type" : "CIMSnappingProperties",
+      "xYTolerance" : 10,
+      "xYToleranceUnit" : "SnapXYToleranceUnitPixel",
+      "snapToSketchEnabled" : true,
+      "snapRequestType" : "SnapRequestType_GeometricAndVisualSnapping",
+      "isZSnappingEnabled" : true
+    },
+    "spatialReference" : {
+      "wkid" : 4326,
+      "latestWkid" : 4326
+    },
+    "timeDisplay" : {
+      "type" : "CIMMapTimeDisplay",
+      "defaultTimeIntervalUnits" : "esriTimeUnitsUnknown",
+      "timeValue" : {
+        "type" : "TimeExtent",
+        "start" : null,
+        "end" : null,
+        "empty" : false
+      },
+      "timeRelation" : "esriTimeRelationOverlaps"
+    },
+    "colorModel" : "RGB",
+    "scaleDisplayFormat" : "Value",
+    "clippingMode" : "None",
+    "nearPlaneClipDistanceMode" : "Automatic",
+    "rGBColorProfile" : "sRGB IEC61966-2-1 noBPC",
+    "cMYKColorProfile" : "U.S. Web Coated (SWOP) v2"
+  },
+  "layerDefinitions" : [
+    {
+      "type" : "CIMRasterLayer",
+      "name" : "Coastal Inundation Depth",
+      "uRI" : "CIMPATH=map/_dataset_vrt.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant",
+        "start" : 978307200000
+      },
+      "metadataURI" : "CIMPATH=Metadata/d37718d89ece7ecbefff4476d478739a.xml",
+      "useSourceMetadata" : true,
+      "description" : "_dataset.vrt",
+      "layerElevation" : {
+        "type" : "CIMLayerElevationSurface",
+        "mapElevationID" : "{898F2553-05D3-4719-B747-5466725BAA27}"
+      },
+      "layerType" : "Operational",
+      "minScale" : 500000,
+      "showLegends" : true,
+      "visibility" : true,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "dataConnection" : {
+        "type" : "CIMStandardDataConnection",
+        "workspaceConnectionString" : "DATABASE=\\\\10.26.150.30\\viz\\published\\raster_connection.acs\\ana_coastal_inundation_hi\\ana_coastal_inundation_hi\\published",
+        "workspaceFactory" : "Raster",
+        "dataset" : "_dataset.vrt",
+        "datasetType" : "esriDTAny"
+      },
+      "colorizer" : {
+        "type" : "CIMRasterClassifyColorizer",
+        "resamplingType" : "NearestNeighbor",
+        "noDataColor" : {
+          "type" : "CIMRGBColor",
+          "values" : [
+            255,
+            255,
+            255,
+            0
+          ]
+        },
+        "normalizationType" : "Nothing",
+        "classBreaks" : [
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 1,
+            "label" : "< 1'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                115,
+                223,
+                255,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 3,
+            "label" : "1' - 3'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                0,
+                112,
+                255,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 6,
+            "label" : "3' - 6'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                255,
+                0,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 9,
+            "label" : "6' - 9'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                170,
+                0,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 999,
+            "label" : "> 9'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                0,
+                0,
+                100
+              ]
+            }
+          }
+        ],
+        "classificationMethod" : "Manual",
+        "colorRamp" : {
+          "type" : "CIMLinearContinuousColorRamp",
+          "colorSpace" : {
+            "type" : "CIMICCColorSpace",
+            "url" : "Default RGB"
+          },
+          "fromColor" : {
+            "type" : "CIMHSVColor",
+            "values" : [
+              60,
+              100,
+              96,
+              100
+            ]
+          },
+          "toColor" : {
+            "type" : "CIMHSVColor",
+            "values" : [
+              0,
+              100,
+              96,
+              100
+            ]
+          }
+        },
+        "field" : "Value",
+        "hillshadeZFactor" : 1,
+        "showInAscendingOrder" : true,
+        "numberFormat" : {
+          "type" : "CIMNumericFormat",
+          "alignmentOption" : "esriAlignLeft",
+          "alignmentWidth" : 12,
+          "roundingOption" : "esriRoundNumberOfDecimals",
+          "roundingValue" : 6,
+          "useSeparator" : true
+        }
+      }
+    }
+  ],
+  "binaryReferences" : [
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/30bff489edcefad05cb0ccf40b0e4329.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>20152100</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri></metadata>\r\n"
+    },
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/511a310f06766413e4a9efb971180b16.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>19525300</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>Map</resTitle></idCitation></dataIdInfo></metadata>\r\n"
+    },
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/d37718d89ece7ecbefff4476d478739a.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>20055700</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri></metadata>\r\n"
+    }
+  ]
+}

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal_hawaii/ana_coastal_inundation_depth_hi_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal_hawaii/ana_coastal_inundation_depth_hi_noaa.yml
@@ -1,9 +1,9 @@
 service: ana_coastal_inundation_depth
-summary: Coastal Inundation Analysis Depth
+summary: Coastal Inundation Depth Analysis for Hawaii
 description: Depicts the inundation depth of the National Water Model (NWM) total water level forecast. 
-  This service is derived from the analysis and assimilation configuration of the NWM over the contiguous U.S. 
+  This service is derived from the analysis and assimilation configuration of the NWM over Hawaii.
   Updated hourly.
-tags: national water model, nwm, ana, conus, schism, coastal, fim, inundation, depth
+tags: national water model, nwm, ana, schism, coastal, fim, inundation, depth, hawaii, hi
 credits: National Water Model, NOAA/NWS National Water Center
 egis_server: server
 egis_folder: nwm

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal_puertorico/ana_coastal_inundation_depth_prvi_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal_puertorico/ana_coastal_inundation_depth_prvi_noaa.mapx
@@ -1,0 +1,295 @@
+{
+  "type" : "CIMMapDocument",
+  "version" : "2.7.0",
+  "build" : 26828,
+  "mapDefinition" : {
+    "type" : "CIMMap",
+    "name" : "NWM Coastal Inundation Depth Analysis for Puerto Rico and Virgin Islands",
+    "uRI" : "CIMPATH=map/map.xml",
+    "sourceModifiedTime" : {
+      "type" : "TimeInstant"
+    },
+    "metadataURI" : "CIMPATH=Metadata/511a310f06766413e4a9efb971180b16.xml",
+    "useSourceMetadata" : true,
+    "illumination" : {
+      "type" : "CIMIlluminationProperties",
+      "ambientLight" : 75,
+      "sunPositionX" : -0.61237243569579003,
+      "sunPositionY" : 0.61237243569579003,
+      "sunPositionZ" : 0.5,
+      "illuminationSource" : "AbsoluteSunPosition",
+      "sunAzimuth" : 315,
+      "sunAltitude" : 30,
+      "showStars" : true,
+      "enableAmbientOcclusion" : true,
+      "enableEyeDomeLighting" : true
+    },
+    "layers" : [
+      "CIMPATH=map/_dataset_vrt.xml"
+    ],
+    "defaultViewingMode" : "Map",
+    "mapType" : "Map",
+    "defaultExtent" : {
+      "xmin" : -125.895685813900741,
+      "ymin" : 14.2068479882217993,
+      "xmax" : -66.3102524994904741,
+      "ymax" : 65.375504847905944,
+      "spatialReference" : {
+        "wkid" : 4326,
+        "latestWkid" : 4326
+      }
+    },
+    "elevationSurfaces" : [
+      {
+        "type" : "CIMMapElevationSurface",
+        "elevationMode" : "BaseGlobeSurface",
+        "name" : "Ground",
+        "verticalExaggeration" : 1,
+        "mapElevationID" : "{898F2553-05D3-4719-B747-5466725BAA27}",
+        "color" : {
+          "type" : "CIMRGBColor",
+          "values" : [
+            255,
+            255,
+            255,
+            100
+          ]
+        },
+        "surfaceTINShadingMode" : "Smooth",
+        "visibility" : true,
+        "expanded" : true
+      }
+    ],
+    "generalPlacementProperties" : {
+      "type" : "CIMMaplexGeneralPlacementProperties",
+      "invertedLabelTolerance" : 2,
+      "unplacedLabelColor" : {
+        "type" : "CIMRGBColor",
+        "values" : [
+          255,
+          0,
+          0,
+          100
+        ]
+      },
+      "keyNumberGroups" : [
+        {
+          "type" : "CIMMaplexKeyNumberGroup",
+          "delimiterCharacter" : ".",
+          "horizontalAlignment" : "Left",
+          "maximumNumberOfLines" : 20,
+          "minimumNumberOfLines" : 2,
+          "name" : "Default",
+          "numberResetType" : "None",
+          "keyNumberMethod" : "PreventUnplacedLabels"
+        }
+      ],
+      "placementQuality" : "High"
+    },
+    "snappingProperties" : {
+      "type" : "CIMSnappingProperties",
+      "xYTolerance" : 10,
+      "xYToleranceUnit" : "SnapXYToleranceUnitPixel",
+      "snapToSketchEnabled" : true,
+      "snapRequestType" : "SnapRequestType_GeometricAndVisualSnapping",
+      "isZSnappingEnabled" : true
+    },
+    "spatialReference" : {
+      "wkid" : 4326,
+      "latestWkid" : 4326
+    },
+    "timeDisplay" : {
+      "type" : "CIMMapTimeDisplay",
+      "defaultTimeIntervalUnits" : "esriTimeUnitsUnknown",
+      "timeValue" : {
+        "type" : "TimeExtent",
+        "start" : null,
+        "end" : null,
+        "empty" : false
+      },
+      "timeRelation" : "esriTimeRelationOverlaps"
+    },
+    "colorModel" : "RGB",
+    "scaleDisplayFormat" : "Value",
+    "clippingMode" : "None",
+    "nearPlaneClipDistanceMode" : "Automatic",
+    "rGBColorProfile" : "sRGB IEC61966-2-1 noBPC",
+    "cMYKColorProfile" : "U.S. Web Coated (SWOP) v2"
+  },
+  "layerDefinitions" : [
+    {
+      "type" : "CIMRasterLayer",
+      "name" : "Coastal Inundation Depth",
+      "uRI" : "CIMPATH=map/_dataset_vrt.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant",
+        "start" : 978307200000
+      },
+      "metadataURI" : "CIMPATH=Metadata/d37718d89ece7ecbefff4476d478739a.xml",
+      "useSourceMetadata" : true,
+      "description" : "_dataset.vrt",
+      "layerElevation" : {
+        "type" : "CIMLayerElevationSurface",
+        "mapElevationID" : "{898F2553-05D3-4719-B747-5466725BAA27}"
+      },
+      "layerType" : "Operational",
+      "minScale" : 500000,
+      "showLegends" : true,
+      "visibility" : true,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "dataConnection" : {
+        "type" : "CIMStandardDataConnection",
+        "workspaceConnectionString" : "DATABASE=\\\\10.26.150.30\\viz\\published\\raster_connection.acs\\ana_coastal_inundation_hi\\ana_coastal_inundation_hi\\published",
+        "workspaceFactory" : "Raster",
+        "dataset" : "_dataset.vrt",
+        "datasetType" : "esriDTAny"
+      },
+      "colorizer" : {
+        "type" : "CIMRasterClassifyColorizer",
+        "resamplingType" : "NearestNeighbor",
+        "noDataColor" : {
+          "type" : "CIMRGBColor",
+          "values" : [
+            255,
+            255,
+            255,
+            0
+          ]
+        },
+        "normalizationType" : "Nothing",
+        "classBreaks" : [
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 1,
+            "label" : "< 1'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                115,
+                223,
+                255,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 3,
+            "label" : "1' - 3'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                0,
+                112,
+                255,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 6,
+            "label" : "3' - 6'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                255,
+                0,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 9,
+            "label" : "6' - 9'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                170,
+                0,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 999,
+            "label" : "> 9'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                0,
+                0,
+                100
+              ]
+            }
+          }
+        ],
+        "classificationMethod" : "Manual",
+        "colorRamp" : {
+          "type" : "CIMLinearContinuousColorRamp",
+          "colorSpace" : {
+            "type" : "CIMICCColorSpace",
+            "url" : "Default RGB"
+          },
+          "fromColor" : {
+            "type" : "CIMHSVColor",
+            "values" : [
+              60,
+              100,
+              96,
+              100
+            ]
+          },
+          "toColor" : {
+            "type" : "CIMHSVColor",
+            "values" : [
+              0,
+              100,
+              96,
+              100
+            ]
+          }
+        },
+        "field" : "Value",
+        "hillshadeZFactor" : 1,
+        "showInAscendingOrder" : true,
+        "numberFormat" : {
+          "type" : "CIMNumericFormat",
+          "alignmentOption" : "esriAlignLeft",
+          "alignmentWidth" : 12,
+          "roundingOption" : "esriRoundNumberOfDecimals",
+          "roundingValue" : 6,
+          "useSeparator" : true
+        }
+      }
+    }
+  ],
+  "binaryReferences" : [
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/30bff489edcefad05cb0ccf40b0e4329.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>20152100</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri></metadata>\r\n"
+    },
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/511a310f06766413e4a9efb971180b16.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>19525300</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>Map</resTitle></idCitation></dataIdInfo></metadata>\r\n"
+    },
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/d37718d89ece7ecbefff4476d478739a.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>20055700</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri></metadata>\r\n"
+    }
+  ]
+}

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal_puertorico/ana_coastal_inundation_depth_prvi_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal_puertorico/ana_coastal_inundation_depth_prvi_noaa.yml
@@ -1,0 +1,11 @@
+service: ana_coastal_inundation_depth_prvi
+summary: Coastal Inundation Depth Analysis for Puerto Rico and Virgin Islands
+description: Depicts the inundation depth of the National Water Model (NWM) total water level forecast. 
+  This service is derived from the analysis and assimilation configuration of the NWM over Puerto Rico and the U.S. Virgin Islands.
+  Updated hourly.
+tags: national water model, nwm, ana, schism, coastal, fim, inundation, depth, prvi, puertorico
+credits: National Water Model, NOAA/NWS National Water Center
+egis_server: server
+egis_folder: nwm
+feature_service: false
+public_service: false

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_mem1_coastal/mrf_gfs_10day_max_coastal_inundation_depth_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_mem1_coastal/mrf_gfs_10day_max_coastal_inundation_depth_noaa.mapx
@@ -1,0 +1,1187 @@
+{
+  "type" : "CIMMapDocument",
+  "version" : "2.7.0",
+  "build" : 26828,
+  "mapDefinition" : {
+    "type" : "CIMMap",
+    "name" : "NWM Medium Range 10-Day Max GFS Coastal FIM Depth",
+    "uRI" : "CIMPATH=map/map.xml",
+    "sourceModifiedTime" : {
+      "type" : "TimeInstant"
+    },
+    "metadataURI" : "CIMPATH=Metadata/511a310f06766413e4a9efb971180b16.xml",
+    "useSourceMetadata" : true,
+    "illumination" : {
+      "type" : "CIMIlluminationProperties",
+      "ambientLight" : 75,
+      "sunPositionX" : -0.61237243569579003,
+      "sunPositionY" : 0.61237243569579003,
+      "sunPositionZ" : 0.5,
+      "illuminationSource" : "AbsoluteSunPosition",
+      "sunAzimuth" : 315,
+      "sunAltitude" : 30,
+      "showStars" : true,
+      "enableAmbientOcclusion" : true,
+      "enableEyeDomeLighting" : true
+    },
+    "layers" : [
+      "CIMPATH=nwm_medium_range_10_day_max_gfs_coastal_fim_depth/new_group_layer.xml",
+      "CIMPATH=nwm_medium_range_10_day_max_gfs_coastal_fim_depth/new_group_layer2.xml",
+      "CIMPATH=nwm_medium_range_10_day_max_gfs_coastal_fim_depth/new_group_layer3.xml"
+    ],
+    "defaultViewingMode" : "Map",
+    "mapType" : "Map",
+    "defaultExtent" : {
+      "xmin" : -154.96815635315798,
+      "ymin" : -0.86773556795071727,
+      "xmax" : -37.2377819602332352,
+      "ymax" : 80.450088404078457,
+      "spatialReference" : {
+        "wkid" : 4326,
+        "latestWkid" : 4326
+      }
+    },
+    "elevationSurfaces" : [
+      {
+        "type" : "CIMMapElevationSurface",
+        "elevationMode" : "BaseGlobeSurface",
+        "name" : "Ground",
+        "verticalExaggeration" : 1,
+        "mapElevationID" : "{898F2553-05D3-4719-B747-5466725BAA27}",
+        "color" : {
+          "type" : "CIMRGBColor",
+          "values" : [
+            255,
+            255,
+            255,
+            100
+          ]
+        },
+        "surfaceTINShadingMode" : "Smooth",
+        "visibility" : true,
+        "expanded" : true
+      }
+    ],
+    "generalPlacementProperties" : {
+      "type" : "CIMMaplexGeneralPlacementProperties",
+      "invertedLabelTolerance" : 2,
+      "unplacedLabelColor" : {
+        "type" : "CIMRGBColor",
+        "values" : [
+          255,
+          0,
+          0,
+          100
+        ]
+      },
+      "keyNumberGroups" : [
+        {
+          "type" : "CIMMaplexKeyNumberGroup",
+          "delimiterCharacter" : ".",
+          "horizontalAlignment" : "Left",
+          "maximumNumberOfLines" : 20,
+          "minimumNumberOfLines" : 2,
+          "name" : "Default",
+          "numberResetType" : "None",
+          "keyNumberMethod" : "PreventUnplacedLabels"
+        }
+      ],
+      "placementQuality" : "High"
+    },
+    "snappingProperties" : {
+      "type" : "CIMSnappingProperties",
+      "xYTolerance" : 10,
+      "xYToleranceUnit" : "SnapXYToleranceUnitPixel",
+      "snapToSketchEnabled" : true,
+      "snapRequestType" : "SnapRequestType_GeometricAndVisualSnapping",
+      "isZSnappingEnabled" : true
+    },
+    "spatialReference" : {
+      "wkid" : 4326,
+      "latestWkid" : 4326
+    },
+    "timeDisplay" : {
+      "type" : "CIMMapTimeDisplay",
+      "defaultTimeIntervalUnits" : "esriTimeUnitsUnknown",
+      "timeValue" : {
+        "type" : "TimeExtent",
+        "start" : null,
+        "end" : null,
+        "empty" : false
+      },
+      "timeRelation" : "esriTimeRelationOverlaps"
+    },
+    "colorModel" : "RGB",
+    "scaleDisplayFormat" : "Value",
+    "clippingMode" : "None",
+    "nearPlaneClipDistanceMode" : "Automatic",
+    "rGBColorProfile" : "sRGB IEC61966-2-1 noBPC",
+    "cMYKColorProfile" : "U.S. Web Coated (SWOP) v2"
+  },
+  "layerDefinitions" : [
+    {
+      "type" : "CIMRasterLayer",
+      "name" : "Atlantic and Gulf Coastal Inundation Depth",
+      "uRI" : "CIMPATH=map/_dataset_vrt.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant",
+        "start" : 978307200000
+      },
+      "metadataURI" : "CIMPATH=Metadata/d37718d89ece7ecbefff4476d478739a.xml",
+      "useSourceMetadata" : true,
+      "description" : "_dataset.vrt",
+      "layerElevation" : {
+        "type" : "CIMLayerElevationSurface",
+        "mapElevationID" : "{898F2553-05D3-4719-B747-5466725BAA27}"
+      },
+      "layerType" : "Operational",
+      "minScale" : 500000,
+      "showLegends" : true,
+      "visibility" : false,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "dataConnection" : {
+        "type" : "CIMStandardDataConnection",
+        "workspaceConnectionString" : "DATABASE=\\\\10.26.150.30\\viz\\published\\raster_connection.acs\\mrf_gfs_3day_max_coastal_inundation\\mrf_gfs_3day_max_coastal_inundation_atlgulf\\published",
+        "workspaceFactory" : "Raster",
+        "dataset" : "_dataset.vrt",
+        "datasetType" : "esriDTAny"
+      },
+      "colorizer" : {
+        "type" : "CIMRasterClassifyColorizer",
+        "resamplingType" : "NearestNeighbor",
+        "noDataColor" : {
+          "type" : "CIMRGBColor",
+          "values" : [
+            255,
+            255,
+            255,
+            0
+          ]
+        },
+        "normalizationType" : "Nothing",
+        "classBreaks" : [
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 1,
+            "label" : "< 1'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                115,
+                223,
+                255,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 3,
+            "label" : "1' - 3'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                0,
+                112,
+                255,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 6,
+            "label" : "3' - 6'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                255,
+                0,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 9,
+            "label" : "6' - 9'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                170,
+                0,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 999,
+            "label" : "> 9'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                0,
+                0,
+                100
+              ]
+            }
+          }
+        ],
+        "classificationMethod" : "Manual",
+        "colorRamp" : {
+          "type" : "CIMLinearContinuousColorRamp",
+          "colorSpace" : {
+            "type" : "CIMICCColorSpace",
+            "url" : "Default RGB"
+          },
+          "fromColor" : {
+            "type" : "CIMHSVColor",
+            "values" : [
+              60,
+              100,
+              96,
+              100
+            ]
+          },
+          "toColor" : {
+            "type" : "CIMHSVColor",
+            "values" : [
+              0,
+              100,
+              96,
+              100
+            ]
+          }
+        },
+        "field" : "Value",
+        "hillshadeZFactor" : 1,
+        "showInAscendingOrder" : true,
+        "numberFormat" : {
+          "type" : "CIMNumericFormat",
+          "alignmentOption" : "esriAlignLeft",
+          "alignmentWidth" : 12,
+          "roundingOption" : "esriRoundNumberOfDecimals",
+          "roundingValue" : 6,
+          "useSeparator" : true
+        }
+      }
+    },
+    {
+      "type" : "CIMRasterLayer",
+      "name" : "Pacific Coastal Inundation Depth",
+      "uRI" : "CIMPATH=map/_dataset_vrt2.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant",
+        "start" : 978307200000
+      },
+      "metadataURI" : "CIMPATH=Metadata/30bff489edcefad05cb0ccf40b0e4329.xml",
+      "useSourceMetadata" : true,
+      "description" : "_dataset.vrt",
+      "layerElevation" : {
+        "type" : "CIMLayerElevationSurface",
+        "mapElevationID" : "{898F2553-05D3-4719-B747-5466725BAA27}"
+      },
+      "layerType" : "Operational",
+      "minScale" : 500000,
+      "showLegends" : true,
+      "visibility" : false,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "dataConnection" : {
+        "type" : "CIMStandardDataConnection",
+        "workspaceConnectionString" : "DATABASE=\\\\10.26.150.30\\viz\\published\\raster_connection.acs\\mrf_gfs_3day_max_coastal_inundation\\mrf_gfs_3day_max_coastal_inundation_pacific\\published",
+        "workspaceFactory" : "Raster",
+        "dataset" : "_dataset.vrt",
+        "datasetType" : "esriDTAny"
+      },
+      "colorizer" : {
+        "type" : "CIMRasterClassifyColorizer",
+        "resamplingType" : "NearestNeighbor",
+        "noDataColor" : {
+          "type" : "CIMRGBColor",
+          "values" : [
+            255,
+            255,
+            255,
+            0
+          ]
+        },
+        "normalizationType" : "Nothing",
+        "classBreaks" : [
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 1,
+            "label" : "< 1'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                115,
+                223,
+                255,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 3,
+            "label" : "1' - 3'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                0,
+                112,
+                255,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 6,
+            "label" : "3' - 6'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                255,
+                0,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 9,
+            "label" : "6' - 9'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                170,
+                0,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 999,
+            "label" : "> 9'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                0,
+                0,
+                100
+              ]
+            }
+          }
+        ],
+        "classificationMethod" : "Manual",
+        "colorRamp" : {
+          "type" : "CIMLinearContinuousColorRamp",
+          "colorSpace" : {
+            "type" : "CIMICCColorSpace",
+            "url" : "Default RGB"
+          },
+          "fromColor" : {
+            "type" : "CIMHSVColor",
+            "values" : [
+              60,
+              100,
+              96,
+              100
+            ]
+          },
+          "toColor" : {
+            "type" : "CIMHSVColor",
+            "values" : [
+              0,
+              100,
+              96,
+              100
+            ]
+          }
+        },
+        "field" : "Value",
+        "hillshadeZFactor" : 1,
+        "showInAscendingOrder" : true,
+        "numberFormat" : {
+          "type" : "CIMNumericFormat",
+          "alignmentOption" : "esriAlignLeft",
+          "alignmentWidth" : 12,
+          "roundingOption" : "esriRoundNumberOfDecimals",
+          "roundingValue" : 6,
+          "useSeparator" : true
+        }
+      }
+    },
+    {
+      "type" : "CIMGroupLayer",
+      "name" : "3 Days",
+      "uRI" : "CIMPATH=nwm_medium_range_10_day_max_gfs_coastal_fim_depth/new_group_layer.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant"
+      },
+      "metadataURI" : "CIMPATH=Metadata/ce12e2023f05b9ca26d88439269acaaa.xml",
+      "useSourceMetadata" : true,
+      "description" : "New Group Layer",
+      "layerElevation" : {
+        "type" : "CIMLayerElevationSurface",
+        "mapElevationID" : "{898F2553-05D3-4719-B747-5466725BAA27}"
+      },
+      "expanded" : true,
+      "layerType" : "Operational",
+      "showLegends" : true,
+      "visibility" : false,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "layers" : [
+        "CIMPATH=map/_dataset_vrt.xml",
+        "CIMPATH=map/_dataset_vrt2.xml"
+      ]
+    },
+    {
+      "type" : "CIMRasterLayer",
+      "name" : "Atlantic and Gulf Coastal Inundation Depth",
+      "uRI" : "CIMPATH=map/_dataset_vrt3.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant",
+        "start" : 978307200000
+      },
+      "metadataURI" : "CIMPATH=Metadata/d37718d89ece7ecbefff4476d478739a.xml",
+      "useSourceMetadata" : true,
+      "description" : "_dataset.vrt",
+      "layerElevation" : {
+        "type" : "CIMLayerElevationSurface",
+        "mapElevationID" : "{898F2553-05D3-4719-B747-5466725BAA27}"
+      },
+      "layerType" : "Operational",
+      "minScale" : 500000,
+      "showLegends" : true,
+      "visibility" : false,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "dataConnection" : {
+        "type" : "CIMStandardDataConnection",
+        "workspaceConnectionString" : "DATABASE=\\\\10.26.150.30\\viz\\published\\raster_connection.acs\\mrf_gfs_5day_max_coastal_inundation\\mrf_gfs_5day_max_coastal_inundation_atlgulf\\published",
+        "workspaceFactory" : "Raster",
+        "dataset" : "_dataset.vrt",
+        "datasetType" : "esriDTAny"
+      },
+      "colorizer" : {
+        "type" : "CIMRasterClassifyColorizer",
+        "resamplingType" : "NearestNeighbor",
+        "noDataColor" : {
+          "type" : "CIMRGBColor",
+          "values" : [
+            255,
+            255,
+            255,
+            0
+          ]
+        },
+        "normalizationType" : "Nothing",
+        "classBreaks" : [
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 1,
+            "label" : "< 1'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                115,
+                223,
+                255,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 3,
+            "label" : "1' - 3'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                0,
+                112,
+                255,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 6,
+            "label" : "3' - 6'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                255,
+                0,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 9,
+            "label" : "6' - 9'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                170,
+                0,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 999,
+            "label" : "> 9'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                0,
+                0,
+                100
+              ]
+            }
+          }
+        ],
+        "classificationMethod" : "Manual",
+        "colorRamp" : {
+          "type" : "CIMLinearContinuousColorRamp",
+          "colorSpace" : {
+            "type" : "CIMICCColorSpace",
+            "url" : "Default RGB"
+          },
+          "fromColor" : {
+            "type" : "CIMHSVColor",
+            "values" : [
+              60,
+              100,
+              96,
+              100
+            ]
+          },
+          "toColor" : {
+            "type" : "CIMHSVColor",
+            "values" : [
+              0,
+              100,
+              96,
+              100
+            ]
+          }
+        },
+        "field" : "Value",
+        "hillshadeZFactor" : 1,
+        "showInAscendingOrder" : true,
+        "numberFormat" : {
+          "type" : "CIMNumericFormat",
+          "alignmentOption" : "esriAlignLeft",
+          "alignmentWidth" : 12,
+          "roundingOption" : "esriRoundNumberOfDecimals",
+          "roundingValue" : 6,
+          "useSeparator" : true
+        }
+      }
+    },
+    {
+      "type" : "CIMRasterLayer",
+      "name" : "Pacific Coastal Inundation Depth",
+      "uRI" : "CIMPATH=map/_dataset_vrt4.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant",
+        "start" : 978307200000
+      },
+      "metadataURI" : "CIMPATH=Metadata/30bff489edcefad05cb0ccf40b0e4329.xml",
+      "useSourceMetadata" : true,
+      "description" : "_dataset.vrt",
+      "layerElevation" : {
+        "type" : "CIMLayerElevationSurface",
+        "mapElevationID" : "{898F2553-05D3-4719-B747-5466725BAA27}"
+      },
+      "layerType" : "Operational",
+      "minScale" : 500000,
+      "showLegends" : true,
+      "visibility" : false,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "dataConnection" : {
+        "type" : "CIMStandardDataConnection",
+        "workspaceConnectionString" : "DATABASE=\\\\10.26.150.30\\viz\\published\\raster_connection.acs\\mrf_gfs_5day_max_coastal_inundation\\mrf_gfs_5day_max_coastal_inundation_pacific\\published",
+        "workspaceFactory" : "Raster",
+        "dataset" : "_dataset.vrt",
+        "datasetType" : "esriDTAny"
+      },
+      "colorizer" : {
+        "type" : "CIMRasterClassifyColorizer",
+        "resamplingType" : "NearestNeighbor",
+        "noDataColor" : {
+          "type" : "CIMRGBColor",
+          "values" : [
+            255,
+            255,
+            255,
+            0
+          ]
+        },
+        "normalizationType" : "Nothing",
+        "classBreaks" : [
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 1,
+            "label" : "< 1'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                115,
+                223,
+                255,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 3,
+            "label" : "1' - 3'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                0,
+                112,
+                255,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 6,
+            "label" : "3' - 6'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                255,
+                0,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 9,
+            "label" : "6' - 9'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                170,
+                0,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 999,
+            "label" : "> 9'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                0,
+                0,
+                100
+              ]
+            }
+          }
+        ],
+        "classificationMethod" : "Manual",
+        "colorRamp" : {
+          "type" : "CIMLinearContinuousColorRamp",
+          "colorSpace" : {
+            "type" : "CIMICCColorSpace",
+            "url" : "Default RGB"
+          },
+          "fromColor" : {
+            "type" : "CIMHSVColor",
+            "values" : [
+              60,
+              100,
+              96,
+              100
+            ]
+          },
+          "toColor" : {
+            "type" : "CIMHSVColor",
+            "values" : [
+              0,
+              100,
+              96,
+              100
+            ]
+          }
+        },
+        "field" : "Value",
+        "hillshadeZFactor" : 1,
+        "showInAscendingOrder" : true,
+        "numberFormat" : {
+          "type" : "CIMNumericFormat",
+          "alignmentOption" : "esriAlignLeft",
+          "alignmentWidth" : 12,
+          "roundingOption" : "esriRoundNumberOfDecimals",
+          "roundingValue" : 6,
+          "useSeparator" : true
+        }
+      }
+    },
+    {
+      "type" : "CIMGroupLayer",
+      "name" : "5 Days",
+      "uRI" : "CIMPATH=nwm_medium_range_10_day_max_gfs_coastal_fim_depth/new_group_layer2.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant"
+      },
+      "metadataURI" : "CIMPATH=Metadata/a59d5fa3e830b5beb448c1464c3b777c.xml",
+      "useSourceMetadata" : true,
+      "description" : "New Group Layer",
+      "layerElevation" : {
+        "type" : "CIMLayerElevationSurface",
+        "mapElevationID" : "{898F2553-05D3-4719-B747-5466725BAA27}"
+      },
+      "expanded" : true,
+      "layerType" : "Operational",
+      "showLegends" : true,
+      "visibility" : false,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "layers" : [
+        "CIMPATH=map/_dataset_vrt3.xml",
+        "CIMPATH=map/_dataset_vrt4.xml"
+      ]
+    },
+    {
+      "type" : "CIMRasterLayer",
+      "name" : "Atlantic and Gulf Coastal Inundation Depth",
+      "uRI" : "CIMPATH=map/_dataset_vrt5.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant",
+        "start" : 978307200000
+      },
+      "metadataURI" : "CIMPATH=Metadata/d37718d89ece7ecbefff4476d478739a.xml",
+      "useSourceMetadata" : true,
+      "description" : "_dataset.vrt",
+      "layerElevation" : {
+        "type" : "CIMLayerElevationSurface",
+        "mapElevationID" : "{898F2553-05D3-4719-B747-5466725BAA27}"
+      },
+      "layerType" : "Operational",
+      "minScale" : 500000,
+      "showLegends" : true,
+      "visibility" : true,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "dataConnection" : {
+        "type" : "CIMStandardDataConnection",
+        "workspaceConnectionString" : "DATABASE=\\\\10.26.150.30\\viz\\published\\raster_connection.acs\\mrf_gfs_10day_max_coastal_inundation\\mrf_gfs_10day_max_coastal_inundation_atlgulf\\published",
+        "workspaceFactory" : "Raster",
+        "dataset" : "_dataset.vrt",
+        "datasetType" : "esriDTAny"
+      },
+      "colorizer" : {
+        "type" : "CIMRasterClassifyColorizer",
+        "resamplingType" : "NearestNeighbor",
+        "noDataColor" : {
+          "type" : "CIMRGBColor",
+          "values" : [
+            255,
+            255,
+            255,
+            0
+          ]
+        },
+        "normalizationType" : "Nothing",
+        "classBreaks" : [
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 1,
+            "label" : "< 1'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                115,
+                223,
+                255,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 3,
+            "label" : "1' - 3'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                0,
+                112,
+                255,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 6,
+            "label" : "3' - 6'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                255,
+                0,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 9,
+            "label" : "6' - 9'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                170,
+                0,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 999,
+            "label" : "> 9'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                0,
+                0,
+                100
+              ]
+            }
+          }
+        ],
+        "classificationMethod" : "Manual",
+        "colorRamp" : {
+          "type" : "CIMLinearContinuousColorRamp",
+          "colorSpace" : {
+            "type" : "CIMICCColorSpace",
+            "url" : "Default RGB"
+          },
+          "fromColor" : {
+            "type" : "CIMHSVColor",
+            "values" : [
+              60,
+              100,
+              96,
+              100
+            ]
+          },
+          "toColor" : {
+            "type" : "CIMHSVColor",
+            "values" : [
+              0,
+              100,
+              96,
+              100
+            ]
+          }
+        },
+        "field" : "Value",
+        "hillshadeZFactor" : 1,
+        "showInAscendingOrder" : true,
+        "numberFormat" : {
+          "type" : "CIMNumericFormat",
+          "alignmentOption" : "esriAlignLeft",
+          "alignmentWidth" : 12,
+          "roundingOption" : "esriRoundNumberOfDecimals",
+          "roundingValue" : 6,
+          "useSeparator" : true
+        }
+      }
+    },
+    {
+      "type" : "CIMRasterLayer",
+      "name" : "Pacific Coastal Inundation Depth",
+      "uRI" : "CIMPATH=map/_dataset_vrt6.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant",
+        "start" : 978307200000
+      },
+      "metadataURI" : "CIMPATH=Metadata/30bff489edcefad05cb0ccf40b0e4329.xml",
+      "useSourceMetadata" : true,
+      "description" : "_dataset.vrt",
+      "layerElevation" : {
+        "type" : "CIMLayerElevationSurface",
+        "mapElevationID" : "{898F2553-05D3-4719-B747-5466725BAA27}"
+      },
+      "layerType" : "Operational",
+      "minScale" : 500000,
+      "showLegends" : true,
+      "visibility" : true,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "dataConnection" : {
+        "type" : "CIMStandardDataConnection",
+        "workspaceConnectionString" : "DATABASE=\\\\10.26.150.30\\viz\\published\\raster_connection.acs\\mrf_gfs_10day_max_coastal_inundation\\mrf_gfs_10day_max_coastal_inundation_pacific\\published",
+        "workspaceFactory" : "Raster",
+        "dataset" : "_dataset.vrt",
+        "datasetType" : "esriDTAny"
+      },
+      "colorizer" : {
+        "type" : "CIMRasterClassifyColorizer",
+        "resamplingType" : "NearestNeighbor",
+        "noDataColor" : {
+          "type" : "CIMRGBColor",
+          "values" : [
+            255,
+            255,
+            255,
+            0
+          ]
+        },
+        "normalizationType" : "Nothing",
+        "classBreaks" : [
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 1,
+            "label" : "< 1'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                115,
+                223,
+                255,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 3,
+            "label" : "1' - 3'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                0,
+                112,
+                255,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 6,
+            "label" : "3' - 6'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                255,
+                0,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 9,
+            "label" : "6' - 9'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                170,
+                0,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 999,
+            "label" : "> 9'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                0,
+                0,
+                100
+              ]
+            }
+          }
+        ],
+        "classificationMethod" : "Manual",
+        "colorRamp" : {
+          "type" : "CIMLinearContinuousColorRamp",
+          "colorSpace" : {
+            "type" : "CIMICCColorSpace",
+            "url" : "Default RGB"
+          },
+          "fromColor" : {
+            "type" : "CIMHSVColor",
+            "values" : [
+              60,
+              100,
+              96,
+              100
+            ]
+          },
+          "toColor" : {
+            "type" : "CIMHSVColor",
+            "values" : [
+              0,
+              100,
+              96,
+              100
+            ]
+          }
+        },
+        "field" : "Value",
+        "hillshadeZFactor" : 1,
+        "showInAscendingOrder" : true,
+        "numberFormat" : {
+          "type" : "CIMNumericFormat",
+          "alignmentOption" : "esriAlignLeft",
+          "alignmentWidth" : 12,
+          "roundingOption" : "esriRoundNumberOfDecimals",
+          "roundingValue" : 6,
+          "useSeparator" : true
+        }
+      }
+    },
+    {
+      "type" : "CIMGroupLayer",
+      "name" : "10 Days",
+      "uRI" : "CIMPATH=nwm_medium_range_10_day_max_gfs_coastal_fim_depth/new_group_layer3.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant"
+      },
+      "metadataURI" : "CIMPATH=Metadata/bab6e252acb6df20b926dd65f498572f.xml",
+      "useSourceMetadata" : true,
+      "description" : "New Group Layer",
+      "layerElevation" : {
+        "type" : "CIMLayerElevationSurface",
+        "mapElevationID" : "{898F2553-05D3-4719-B747-5466725BAA27}"
+      },
+      "expanded" : true,
+      "layerType" : "Operational",
+      "showLegends" : true,
+      "visibility" : true,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "layers" : [
+        "CIMPATH=map/_dataset_vrt5.xml",
+        "CIMPATH=map/_dataset_vrt6.xml"
+      ]
+    }
+  ],
+  "binaryReferences" : [
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/30bff489edcefad05cb0ccf40b0e4329.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>20152100</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri></metadata>\r\n"
+    },
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/511a310f06766413e4a9efb971180b16.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>19525300</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>Map</resTitle></idCitation></dataIdInfo></metadata>\r\n"
+    },
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/a59d5fa3e830b5beb448c1464c3b777c.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>21485500</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>New Group Layer</resTitle></idCitation><idAbs>New Group Layer</idAbs><idCredit></idCredit><idPurp></idPurp><resConst><Consts><useLimit></useLimit></Consts></resConst></dataIdInfo></metadata>\r\n"
+    },
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/bab6e252acb6df20b926dd65f498572f.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>21490100</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>New Group Layer</resTitle></idCitation><idAbs>New Group Layer</idAbs><idCredit></idCredit><idPurp></idPurp><resConst><Consts><useLimit></useLimit></Consts></resConst></dataIdInfo></metadata>\r\n"
+    },
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/ce12e2023f05b9ca26d88439269acaaa.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>21480900</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>New Group Layer</resTitle></idCitation><idAbs>New Group Layer</idAbs><idCredit></idCredit><idPurp></idPurp><resConst><Consts><useLimit></useLimit></Consts></resConst></dataIdInfo></metadata>\r\n"
+    },
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/d37718d89ece7ecbefff4476d478739a.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>20055700</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri></metadata>\r\n"
+    }
+  ]
+}

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_mem1_coastal/mrf_gfs_10day_max_coastal_inundation_depth_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_mem1_coastal/mrf_gfs_10day_max_coastal_inundation_depth_noaa.yml
@@ -1,0 +1,11 @@
+service: mrf_gfs_10day_max_coastal_inundation_depth_noaa
+summary: Medium-Range GFS 10 Day Maximum Coastal Inundation Depth Forecast
+description: Depicts the inundation depth of the peak National Water Model (NWM) total water level forecast 
+  over the next 3, 5, and 10 days. This service is derived from the medium-range configuration of the NWM 
+  over the contiguous U.S. Updated every 6 hours.
+tags: national water model, nwm, mrf, medium, range, conus, schism, coastal, fim, inundation, depth
+credits: National Water Model, NOAA/NWS National Water Center
+egis_server: server
+egis_folder: nwm
+feature_service: false
+public_service: false

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal/srf_18hr_max_coastal_inundation_depth_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal/srf_18hr_max_coastal_inundation_depth_noaa.mapx
@@ -1,0 +1,453 @@
+{
+  "type" : "CIMMapDocument",
+  "version" : "2.7.0",
+  "build" : 26828,
+  "mapDefinition" : {
+    "type" : "CIMMap",
+    "name" : "NWM 18-Hour Max Coastal Inundation Depth",
+    "uRI" : "CIMPATH=map/map.xml",
+    "sourceModifiedTime" : {
+      "type" : "TimeInstant"
+    },
+    "metadataURI" : "CIMPATH=Metadata/511a310f06766413e4a9efb971180b16.xml",
+    "useSourceMetadata" : true,
+    "illumination" : {
+      "type" : "CIMIlluminationProperties",
+      "ambientLight" : 75,
+      "sunPositionX" : -0.61237243569579003,
+      "sunPositionY" : 0.61237243569579003,
+      "sunPositionZ" : 0.5,
+      "illuminationSource" : "AbsoluteSunPosition",
+      "sunAzimuth" : 315,
+      "sunAltitude" : 30,
+      "showStars" : true,
+      "enableAmbientOcclusion" : true,
+      "enableEyeDomeLighting" : true
+    },
+    "layers" : [
+      "CIMPATH=map/_dataset_vrt.xml",
+      "CIMPATH=map/_dataset_vrt2.xml"
+    ],
+    "defaultViewingMode" : "Map",
+    "mapType" : "Map",
+    "defaultExtent" : {
+      "xmin" : -125.895685813900741,
+      "ymin" : 14.2068479882217993,
+      "xmax" : -66.3102524994904741,
+      "ymax" : 65.375504847905944,
+      "spatialReference" : {
+        "wkid" : 4326,
+        "latestWkid" : 4326
+      }
+    },
+    "elevationSurfaces" : [
+      {
+        "type" : "CIMMapElevationSurface",
+        "elevationMode" : "BaseGlobeSurface",
+        "name" : "Ground",
+        "verticalExaggeration" : 1,
+        "mapElevationID" : "{898F2553-05D3-4719-B747-5466725BAA27}",
+        "color" : {
+          "type" : "CIMRGBColor",
+          "values" : [
+            255,
+            255,
+            255,
+            100
+          ]
+        },
+        "surfaceTINShadingMode" : "Smooth",
+        "visibility" : true,
+        "expanded" : true
+      }
+    ],
+    "generalPlacementProperties" : {
+      "type" : "CIMMaplexGeneralPlacementProperties",
+      "invertedLabelTolerance" : 2,
+      "unplacedLabelColor" : {
+        "type" : "CIMRGBColor",
+        "values" : [
+          255,
+          0,
+          0,
+          100
+        ]
+      },
+      "keyNumberGroups" : [
+        {
+          "type" : "CIMMaplexKeyNumberGroup",
+          "delimiterCharacter" : ".",
+          "horizontalAlignment" : "Left",
+          "maximumNumberOfLines" : 20,
+          "minimumNumberOfLines" : 2,
+          "name" : "Default",
+          "numberResetType" : "None",
+          "keyNumberMethod" : "PreventUnplacedLabels"
+        }
+      ],
+      "placementQuality" : "High"
+    },
+    "snappingProperties" : {
+      "type" : "CIMSnappingProperties",
+      "xYTolerance" : 10,
+      "xYToleranceUnit" : "SnapXYToleranceUnitPixel",
+      "snapToSketchEnabled" : true,
+      "snapRequestType" : "SnapRequestType_GeometricAndVisualSnapping",
+      "isZSnappingEnabled" : true
+    },
+    "spatialReference" : {
+      "wkid" : 4326,
+      "latestWkid" : 4326
+    },
+    "timeDisplay" : {
+      "type" : "CIMMapTimeDisplay",
+      "defaultTimeIntervalUnits" : "esriTimeUnitsUnknown",
+      "timeValue" : {
+        "type" : "TimeExtent",
+        "start" : null,
+        "end" : null,
+        "empty" : false
+      },
+      "timeRelation" : "esriTimeRelationOverlaps"
+    },
+    "colorModel" : "RGB",
+    "scaleDisplayFormat" : "Value",
+    "clippingMode" : "None",
+    "nearPlaneClipDistanceMode" : "Automatic",
+    "rGBColorProfile" : "sRGB IEC61966-2-1 noBPC",
+    "cMYKColorProfile" : "U.S. Web Coated (SWOP) v2"
+  },
+  "layerDefinitions" : [
+    {
+      "type" : "CIMRasterLayer",
+      "name" : "Atlantic and Gulf Coastal Inundation Depth",
+      "uRI" : "CIMPATH=map/_dataset_vrt.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant",
+        "start" : 978307200000
+      },
+      "metadataURI" : "CIMPATH=Metadata/d37718d89ece7ecbefff4476d478739a.xml",
+      "useSourceMetadata" : true,
+      "description" : "_dataset.vrt",
+      "layerElevation" : {
+        "type" : "CIMLayerElevationSurface",
+        "mapElevationID" : "{898F2553-05D3-4719-B747-5466725BAA27}"
+      },
+      "layerType" : "Operational",
+      "minScale" : 500000,
+      "showLegends" : true,
+      "visibility" : true,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "dataConnection" : {
+        "type" : "CIMStandardDataConnection",
+        "workspaceConnectionString" : "DATABASE=\\\\10.26.150.30\\viz\\published\\raster_connection.acs\\srf_18hr_max_coastal_inundation\\srf_18hr_max_coastal_inundation_atlgulf\\published",
+        "workspaceFactory" : "Raster",
+        "dataset" : "_dataset.vrt",
+        "datasetType" : "esriDTAny"
+      },
+      "colorizer" : {
+        "type" : "CIMRasterClassifyColorizer",
+        "resamplingType" : "NearestNeighbor",
+        "noDataColor" : {
+          "type" : "CIMRGBColor",
+          "values" : [
+            255,
+            255,
+            255,
+            0
+          ]
+        },
+        "normalizationType" : "Nothing",
+        "classBreaks" : [
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 1,
+            "label" : "< 1'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                115,
+                223,
+                255,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 3,
+            "label" : "1' - 3'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                0,
+                112,
+                255,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 6,
+            "label" : "3' - 6'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                255,
+                0,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 9,
+            "label" : "6' - 9'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                170,
+                0,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 999,
+            "label" : "> 9'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                0,
+                0,
+                100
+              ]
+            }
+          }
+        ],
+        "classificationMethod" : "Manual",
+        "colorRamp" : {
+          "type" : "CIMLinearContinuousColorRamp",
+          "colorSpace" : {
+            "type" : "CIMICCColorSpace",
+            "url" : "Default RGB"
+          },
+          "fromColor" : {
+            "type" : "CIMHSVColor",
+            "values" : [
+              60,
+              100,
+              96,
+              100
+            ]
+          },
+          "toColor" : {
+            "type" : "CIMHSVColor",
+            "values" : [
+              0,
+              100,
+              96,
+              100
+            ]
+          }
+        },
+        "field" : "Value",
+        "hillshadeZFactor" : 1,
+        "showInAscendingOrder" : true,
+        "numberFormat" : {
+          "type" : "CIMNumericFormat",
+          "alignmentOption" : "esriAlignLeft",
+          "alignmentWidth" : 12,
+          "roundingOption" : "esriRoundNumberOfDecimals",
+          "roundingValue" : 6,
+          "useSeparator" : true
+        }
+      }
+    },
+    {
+      "type" : "CIMRasterLayer",
+      "name" : "Pacific Coastal Inundation Depth",
+      "uRI" : "CIMPATH=map/_dataset_vrt2.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant",
+        "start" : 978307200000
+      },
+      "metadataURI" : "CIMPATH=Metadata/30bff489edcefad05cb0ccf40b0e4329.xml",
+      "useSourceMetadata" : true,
+      "description" : "_dataset.vrt",
+      "layerElevation" : {
+        "type" : "CIMLayerElevationSurface",
+        "mapElevationID" : "{898F2553-05D3-4719-B747-5466725BAA27}"
+      },
+      "layerType" : "Operational",
+      "minScale" : 500000,
+      "showLegends" : true,
+      "visibility" : true,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "dataConnection" : {
+        "type" : "CIMStandardDataConnection",
+        "workspaceConnectionString" : "DATABASE=\\\\10.26.150.30\\viz\\published\\raster_connection.acs\\srf_18hr_max_coastal_inundation\\srf_18hr_max_coastal_inundation_pacific\\published",
+        "workspaceFactory" : "Raster",
+        "dataset" : "_dataset.vrt",
+        "datasetType" : "esriDTAny"
+      },
+      "colorizer" : {
+        "type" : "CIMRasterClassifyColorizer",
+        "resamplingType" : "NearestNeighbor",
+        "noDataColor" : {
+          "type" : "CIMRGBColor",
+          "values" : [
+            255,
+            255,
+            255,
+            0
+          ]
+        },
+        "normalizationType" : "Nothing",
+        "classBreaks" : [
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 1,
+            "label" : "< 1'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                115,
+                223,
+                255,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 3,
+            "label" : "1' - 3'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                0,
+                112,
+                255,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 6,
+            "label" : "3' - 6'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                255,
+                0,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 9,
+            "label" : "6' - 9'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                170,
+                0,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 999,
+            "label" : "> 9'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                0,
+                0,
+                100
+              ]
+            }
+          }
+        ],
+        "classificationMethod" : "Manual",
+        "colorRamp" : {
+          "type" : "CIMLinearContinuousColorRamp",
+          "colorSpace" : {
+            "type" : "CIMICCColorSpace",
+            "url" : "Default RGB"
+          },
+          "fromColor" : {
+            "type" : "CIMHSVColor",
+            "values" : [
+              60,
+              100,
+              96,
+              100
+            ]
+          },
+          "toColor" : {
+            "type" : "CIMHSVColor",
+            "values" : [
+              0,
+              100,
+              96,
+              100
+            ]
+          }
+        },
+        "field" : "Value",
+        "hillshadeZFactor" : 1,
+        "showInAscendingOrder" : true,
+        "numberFormat" : {
+          "type" : "CIMNumericFormat",
+          "alignmentOption" : "esriAlignLeft",
+          "alignmentWidth" : 12,
+          "roundingOption" : "esriRoundNumberOfDecimals",
+          "roundingValue" : 6,
+          "useSeparator" : true
+        }
+      }
+    }
+  ],
+  "binaryReferences" : [
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/30bff489edcefad05cb0ccf40b0e4329.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>20152100</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri></metadata>\r\n"
+    },
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/511a310f06766413e4a9efb971180b16.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>19525300</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>Map</resTitle></idCitation></dataIdInfo></metadata>\r\n"
+    },
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/d37718d89ece7ecbefff4476d478739a.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>20055700</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri></metadata>\r\n"
+    }
+  ]
+}

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal/srf_18hr_max_coastal_inundation_depth_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal/srf_18hr_max_coastal_inundation_depth_noaa.yml
@@ -1,0 +1,11 @@
+service: srf_18hr_max_coastal_inundation_depth_noaa
+summary: Short-Range 18 Hour Maximum Coastal Inundation Depth Forecast
+description: Depicts the peak inundation depth of the National Water Model (NWM) total water level forecast 
+  over the next 18 hours. This service is derived from the analysis and assimilation configuration of the 
+  NWM over the contiguous U.S. Updated hourly.
+tags: national water model, nwm, srf, short, range, conus, schism, coastal, fim, inundation, extent
+credits: National Water Model, NOAA/NWS National Water Center
+egis_server: server
+egis_folder: nwm
+feature_service: false
+public_service: false

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal_hawaii/srf_48hr_max_coastal_inundation_depth_hi_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal_hawaii/srf_48hr_max_coastal_inundation_depth_hi_noaa.mapx
@@ -1,0 +1,295 @@
+{
+  "type" : "CIMMapDocument",
+  "version" : "2.7.0",
+  "build" : 26828,
+  "mapDefinition" : {
+    "type" : "CIMMap",
+    "name" : "NWM 48-Hour Max Coastal Inundation Depth - Hawaii",
+    "uRI" : "CIMPATH=map/map.xml",
+    "sourceModifiedTime" : {
+      "type" : "TimeInstant"
+    },
+    "metadataURI" : "CIMPATH=Metadata/511a310f06766413e4a9efb971180b16.xml",
+    "useSourceMetadata" : true,
+    "illumination" : {
+      "type" : "CIMIlluminationProperties",
+      "ambientLight" : 75,
+      "sunPositionX" : -0.61237243569579003,
+      "sunPositionY" : 0.61237243569579003,
+      "sunPositionZ" : 0.5,
+      "illuminationSource" : "AbsoluteSunPosition",
+      "sunAzimuth" : 315,
+      "sunAltitude" : 30,
+      "showStars" : true,
+      "enableAmbientOcclusion" : true,
+      "enableEyeDomeLighting" : true
+    },
+    "layers" : [
+      "CIMPATH=map/_dataset_vrt.xml"
+    ],
+    "defaultViewingMode" : "Map",
+    "mapType" : "Map",
+    "defaultExtent" : {
+      "xmin" : -125.895685813900741,
+      "ymin" : 14.2068479882217993,
+      "xmax" : -66.3102524994904741,
+      "ymax" : 65.375504847905944,
+      "spatialReference" : {
+        "wkid" : 4326,
+        "latestWkid" : 4326
+      }
+    },
+    "elevationSurfaces" : [
+      {
+        "type" : "CIMMapElevationSurface",
+        "elevationMode" : "BaseGlobeSurface",
+        "name" : "Ground",
+        "verticalExaggeration" : 1,
+        "mapElevationID" : "{898F2553-05D3-4719-B747-5466725BAA27}",
+        "color" : {
+          "type" : "CIMRGBColor",
+          "values" : [
+            255,
+            255,
+            255,
+            100
+          ]
+        },
+        "surfaceTINShadingMode" : "Smooth",
+        "visibility" : true,
+        "expanded" : true
+      }
+    ],
+    "generalPlacementProperties" : {
+      "type" : "CIMMaplexGeneralPlacementProperties",
+      "invertedLabelTolerance" : 2,
+      "unplacedLabelColor" : {
+        "type" : "CIMRGBColor",
+        "values" : [
+          255,
+          0,
+          0,
+          100
+        ]
+      },
+      "keyNumberGroups" : [
+        {
+          "type" : "CIMMaplexKeyNumberGroup",
+          "delimiterCharacter" : ".",
+          "horizontalAlignment" : "Left",
+          "maximumNumberOfLines" : 20,
+          "minimumNumberOfLines" : 2,
+          "name" : "Default",
+          "numberResetType" : "None",
+          "keyNumberMethod" : "PreventUnplacedLabels"
+        }
+      ],
+      "placementQuality" : "High"
+    },
+    "snappingProperties" : {
+      "type" : "CIMSnappingProperties",
+      "xYTolerance" : 10,
+      "xYToleranceUnit" : "SnapXYToleranceUnitPixel",
+      "snapToSketchEnabled" : true,
+      "snapRequestType" : "SnapRequestType_GeometricAndVisualSnapping",
+      "isZSnappingEnabled" : true
+    },
+    "spatialReference" : {
+      "wkid" : 4326,
+      "latestWkid" : 4326
+    },
+    "timeDisplay" : {
+      "type" : "CIMMapTimeDisplay",
+      "defaultTimeIntervalUnits" : "esriTimeUnitsUnknown",
+      "timeValue" : {
+        "type" : "TimeExtent",
+        "start" : null,
+        "end" : null,
+        "empty" : false
+      },
+      "timeRelation" : "esriTimeRelationOverlaps"
+    },
+    "colorModel" : "RGB",
+    "scaleDisplayFormat" : "Value",
+    "clippingMode" : "None",
+    "nearPlaneClipDistanceMode" : "Automatic",
+    "rGBColorProfile" : "sRGB IEC61966-2-1 noBPC",
+    "cMYKColorProfile" : "U.S. Web Coated (SWOP) v2"
+  },
+  "layerDefinitions" : [
+    {
+      "type" : "CIMRasterLayer",
+      "name" : "Coastal Inundation Depth",
+      "uRI" : "CIMPATH=map/_dataset_vrt.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant",
+        "start" : 978307200000
+      },
+      "metadataURI" : "CIMPATH=Metadata/d37718d89ece7ecbefff4476d478739a.xml",
+      "useSourceMetadata" : true,
+      "description" : "_dataset.vrt",
+      "layerElevation" : {
+        "type" : "CIMLayerElevationSurface",
+        "mapElevationID" : "{898F2553-05D3-4719-B747-5466725BAA27}"
+      },
+      "layerType" : "Operational",
+      "minScale" : 500000,
+      "showLegends" : true,
+      "visibility" : true,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "dataConnection" : {
+        "type" : "CIMStandardDataConnection",
+        "workspaceConnectionString" : "DATABASE=\\\\10.26.150.30\\viz\\published\\raster_connection.acs\\srf_48hr_max_coastal_inundation_hi\\srf_48hr_max_coastal_inundation_hi\\published",
+        "workspaceFactory" : "Raster",
+        "dataset" : "_dataset.vrt",
+        "datasetType" : "esriDTAny"
+      },
+      "colorizer" : {
+        "type" : "CIMRasterClassifyColorizer",
+        "resamplingType" : "NearestNeighbor",
+        "noDataColor" : {
+          "type" : "CIMRGBColor",
+          "values" : [
+            255,
+            255,
+            255,
+            0
+          ]
+        },
+        "normalizationType" : "Nothing",
+        "classBreaks" : [
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 1,
+            "label" : "< 1'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                115,
+                223,
+                255,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 3,
+            "label" : "1' - 3'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                0,
+                112,
+                255,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 6,
+            "label" : "3' - 6'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                255,
+                0,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 9,
+            "label" : "6' - 9'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                170,
+                0,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 999,
+            "label" : "> 9'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                0,
+                0,
+                100
+              ]
+            }
+          }
+        ],
+        "classificationMethod" : "Manual",
+        "colorRamp" : {
+          "type" : "CIMLinearContinuousColorRamp",
+          "colorSpace" : {
+            "type" : "CIMICCColorSpace",
+            "url" : "Default RGB"
+          },
+          "fromColor" : {
+            "type" : "CIMHSVColor",
+            "values" : [
+              60,
+              100,
+              96,
+              100
+            ]
+          },
+          "toColor" : {
+            "type" : "CIMHSVColor",
+            "values" : [
+              0,
+              100,
+              96,
+              100
+            ]
+          }
+        },
+        "field" : "Value",
+        "hillshadeZFactor" : 1,
+        "showInAscendingOrder" : true,
+        "numberFormat" : {
+          "type" : "CIMNumericFormat",
+          "alignmentOption" : "esriAlignLeft",
+          "alignmentWidth" : 12,
+          "roundingOption" : "esriRoundNumberOfDecimals",
+          "roundingValue" : 6,
+          "useSeparator" : true
+        }
+      }
+    }
+  ],
+  "binaryReferences" : [
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/30bff489edcefad05cb0ccf40b0e4329.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>20152100</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri></metadata>\r\n"
+    },
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/511a310f06766413e4a9efb971180b16.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>19525300</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>Map</resTitle></idCitation></dataIdInfo></metadata>\r\n"
+    },
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/d37718d89ece7ecbefff4476d478739a.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>20055700</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri></metadata>\r\n"
+    }
+  ]
+}

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal_hawaii/srf_48hr_max_coastal_inundation_depth_hi_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal_hawaii/srf_48hr_max_coastal_inundation_depth_hi_noaa.yml
@@ -1,0 +1,11 @@
+service: srf_48hr_max_coastal_inundation_depth_hi_noaa
+summary: Short-Range 48 Hour Maximum Coastal Inundation Depth Forecast for Hawaii
+description: Depicts the peak inundation depth of the National Water Model (NWM) total water level forecast 
+  over the next 48 hours. This service is derived from the analysis and assimilation configuration of the 
+  NWM over Hawaii. Updated hourly.
+tags: national water model, nwm, srf, short, range, schism, coastal, fim, inundation, depth, hawaii, hi
+credits: National Water Model, NOAA/NWS National Water Center
+egis_server: server
+egis_folder: nwm
+feature_service: false
+public_service: false

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal_puertorico/srf_48hr_max_coastal_inundation_depth_prvi_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal_puertorico/srf_48hr_max_coastal_inundation_depth_prvi_noaa.mapx
@@ -1,0 +1,295 @@
+{
+  "type" : "CIMMapDocument",
+  "version" : "2.7.0",
+  "build" : 26828,
+  "mapDefinition" : {
+    "type" : "CIMMap",
+    "name" : "48-Hour Max Coastal Inundation Depth - Puerto Rico & U.S. Virgin Islands",
+    "uRI" : "CIMPATH=map/map.xml",
+    "sourceModifiedTime" : {
+      "type" : "TimeInstant"
+    },
+    "metadataURI" : "CIMPATH=Metadata/511a310f06766413e4a9efb971180b16.xml",
+    "useSourceMetadata" : true,
+    "illumination" : {
+      "type" : "CIMIlluminationProperties",
+      "ambientLight" : 75,
+      "sunPositionX" : -0.61237243569579003,
+      "sunPositionY" : 0.61237243569579003,
+      "sunPositionZ" : 0.5,
+      "illuminationSource" : "AbsoluteSunPosition",
+      "sunAzimuth" : 315,
+      "sunAltitude" : 30,
+      "showStars" : true,
+      "enableAmbientOcclusion" : true,
+      "enableEyeDomeLighting" : true
+    },
+    "layers" : [
+      "CIMPATH=map/_dataset_vrt.xml"
+    ],
+    "defaultViewingMode" : "Map",
+    "mapType" : "Map",
+    "defaultExtent" : {
+      "xmin" : -125.895685813900741,
+      "ymin" : 14.2068479882217993,
+      "xmax" : -66.3102524994904741,
+      "ymax" : 65.375504847905944,
+      "spatialReference" : {
+        "wkid" : 4326,
+        "latestWkid" : 4326
+      }
+    },
+    "elevationSurfaces" : [
+      {
+        "type" : "CIMMapElevationSurface",
+        "elevationMode" : "BaseGlobeSurface",
+        "name" : "Ground",
+        "verticalExaggeration" : 1,
+        "mapElevationID" : "{898F2553-05D3-4719-B747-5466725BAA27}",
+        "color" : {
+          "type" : "CIMRGBColor",
+          "values" : [
+            255,
+            255,
+            255,
+            100
+          ]
+        },
+        "surfaceTINShadingMode" : "Smooth",
+        "visibility" : true,
+        "expanded" : true
+      }
+    ],
+    "generalPlacementProperties" : {
+      "type" : "CIMMaplexGeneralPlacementProperties",
+      "invertedLabelTolerance" : 2,
+      "unplacedLabelColor" : {
+        "type" : "CIMRGBColor",
+        "values" : [
+          255,
+          0,
+          0,
+          100
+        ]
+      },
+      "keyNumberGroups" : [
+        {
+          "type" : "CIMMaplexKeyNumberGroup",
+          "delimiterCharacter" : ".",
+          "horizontalAlignment" : "Left",
+          "maximumNumberOfLines" : 20,
+          "minimumNumberOfLines" : 2,
+          "name" : "Default",
+          "numberResetType" : "None",
+          "keyNumberMethod" : "PreventUnplacedLabels"
+        }
+      ],
+      "placementQuality" : "High"
+    },
+    "snappingProperties" : {
+      "type" : "CIMSnappingProperties",
+      "xYTolerance" : 10,
+      "xYToleranceUnit" : "SnapXYToleranceUnitPixel",
+      "snapToSketchEnabled" : true,
+      "snapRequestType" : "SnapRequestType_GeometricAndVisualSnapping",
+      "isZSnappingEnabled" : true
+    },
+    "spatialReference" : {
+      "wkid" : 4326,
+      "latestWkid" : 4326
+    },
+    "timeDisplay" : {
+      "type" : "CIMMapTimeDisplay",
+      "defaultTimeIntervalUnits" : "esriTimeUnitsUnknown",
+      "timeValue" : {
+        "type" : "TimeExtent",
+        "start" : null,
+        "end" : null,
+        "empty" : false
+      },
+      "timeRelation" : "esriTimeRelationOverlaps"
+    },
+    "colorModel" : "RGB",
+    "scaleDisplayFormat" : "Value",
+    "clippingMode" : "None",
+    "nearPlaneClipDistanceMode" : "Automatic",
+    "rGBColorProfile" : "sRGB IEC61966-2-1 noBPC",
+    "cMYKColorProfile" : "U.S. Web Coated (SWOP) v2"
+  },
+  "layerDefinitions" : [
+    {
+      "type" : "CIMRasterLayer",
+      "name" : "Coastal Inundation Depth",
+      "uRI" : "CIMPATH=map/_dataset_vrt.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant",
+        "start" : 978307200000
+      },
+      "metadataURI" : "CIMPATH=Metadata/d37718d89ece7ecbefff4476d478739a.xml",
+      "useSourceMetadata" : true,
+      "description" : "_dataset.vrt",
+      "layerElevation" : {
+        "type" : "CIMLayerElevationSurface",
+        "mapElevationID" : "{898F2553-05D3-4719-B747-5466725BAA27}"
+      },
+      "layerType" : "Operational",
+      "minScale" : 500000,
+      "showLegends" : true,
+      "visibility" : true,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "dataConnection" : {
+        "type" : "CIMStandardDataConnection",
+        "workspaceConnectionString" : "DATABASE=\\\\10.26.150.30\\viz\\published\\raster_connection.acs\\srf_48hr_max_coastal_inundation_prvi\\srf_48hr_max_coastal_inundation_prvi\\published",
+        "workspaceFactory" : "Raster",
+        "dataset" : "_dataset.vrt",
+        "datasetType" : "esriDTAny"
+      },
+      "colorizer" : {
+        "type" : "CIMRasterClassifyColorizer",
+        "resamplingType" : "NearestNeighbor",
+        "noDataColor" : {
+          "type" : "CIMRGBColor",
+          "values" : [
+            255,
+            255,
+            255,
+            0
+          ]
+        },
+        "normalizationType" : "Nothing",
+        "classBreaks" : [
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 1,
+            "label" : "< 1'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                115,
+                223,
+                255,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 3,
+            "label" : "1' - 3'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                0,
+                112,
+                255,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 6,
+            "label" : "3' - 6'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                255,
+                0,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 9,
+            "label" : "6' - 9'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                170,
+                0,
+                100
+              ]
+            }
+          },
+          {
+            "type" : "CIMRasterClassBreak",
+            "upperBound" : 999,
+            "label" : "> 9'",
+            "color" : {
+              "type" : "CIMRGBColor",
+              "values" : [
+                255,
+                0,
+                0,
+                100
+              ]
+            }
+          }
+        ],
+        "classificationMethod" : "Manual",
+        "colorRamp" : {
+          "type" : "CIMLinearContinuousColorRamp",
+          "colorSpace" : {
+            "type" : "CIMICCColorSpace",
+            "url" : "Default RGB"
+          },
+          "fromColor" : {
+            "type" : "CIMHSVColor",
+            "values" : [
+              60,
+              100,
+              96,
+              100
+            ]
+          },
+          "toColor" : {
+            "type" : "CIMHSVColor",
+            "values" : [
+              0,
+              100,
+              96,
+              100
+            ]
+          }
+        },
+        "field" : "Value",
+        "hillshadeZFactor" : 1,
+        "showInAscendingOrder" : true,
+        "numberFormat" : {
+          "type" : "CIMNumericFormat",
+          "alignmentOption" : "esriAlignLeft",
+          "alignmentWidth" : 12,
+          "roundingOption" : "esriRoundNumberOfDecimals",
+          "roundingValue" : 6,
+          "useSeparator" : true
+        }
+      }
+    }
+  ],
+  "binaryReferences" : [
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/30bff489edcefad05cb0ccf40b0e4329.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>20152100</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri></metadata>\r\n"
+    },
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/511a310f06766413e4a9efb971180b16.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>19525300</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>Map</resTitle></idCitation></dataIdInfo></metadata>\r\n"
+    },
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/d37718d89ece7ecbefff4476d478739a.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>20055700</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri></metadata>\r\n"
+    }
+  ]
+}

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal_puertorico/srf_48hr_max_coastal_inundation_depth_prvi_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal_puertorico/srf_48hr_max_coastal_inundation_depth_prvi_noaa.yml
@@ -1,0 +1,11 @@
+service: srf_48hr_max_coastal_inundation_depth_prvi_noaa
+summary: Short-Range 48 Hour Maximum Coastal Inundation Depth Forecast for Puerto Rico and Virgin Islands
+description: Depicts the peak inundation depth of the National Water Model (NWM) total water level forecast 
+  over the next 48 hours. This service is derived from the analysis and assimilation configuration of the 
+  NWM over Puerto Rico and the U.S. Virgin Islands. Updated hourly.
+tags: national water model, nwm, srf, short, range, schism, coastal, fim, inundation, depth, puertorico, prvi
+credits: National Water Model, NOAA/NWS National Water Center
+egis_server: server
+egis_folder: nwm
+feature_service: false
+public_service: false

--- a/Core/LAMBDA/viz_functions/viz_update_egis_data/lambda_function.py
+++ b/Core/LAMBDA/viz_functions/viz_update_egis_data/lambda_function.py
@@ -59,6 +59,7 @@ def lambda_handler(event, context):
             for s3_key in workspace_rasters:
                 s3_object = {"Bucket": s3_bucket, "Key": s3_key}
                 s3_filename = os.path.basename(s3_key)
+                s3_extension = os.path.splitext(s3_filename)[1]
                 cache_key = f"{cache_path}/{s3_filename}"
     
                 print(f"Caching {s3_key} at {cache_key}")
@@ -67,11 +68,16 @@ def lambda_handler(event, context):
                 print("Deleting tif workspace raster")
                 s3.Object(s3_bucket, s3_key).delete()
     
-                raster_name = s3_filename.replace(".tif", "")
-                mrf_workspace_prefix = s3_key.replace("/tif/", "/mrf/").replace(".tif", "")
+                raster_name = s3_filename.replace(s3_extension, "")
+                mrf_workspace_prefix = s3_key.replace("/tif/", "/mrf/").replace(s3_extension, "")
                 published_prefix = f"{processing_prefix}/published/{raster_name}"
                 
-                for extension in mrf_extensions:
+                if s3_extension == '.tif':
+                    process_extensions = mrf_extensions
+                else:
+                    process_extensions = [s3_extension[1:]]
+
+                for extension in process_extensions:
                     mrf_workspace_raster = {"Bucket": s3_bucket, "Key": f"{mrf_workspace_prefix}.{extension}"}
                     mrf_published_raster = f"{published_prefix}.{extension}"
                     

--- a/Core/StepFunctions/schism_fim_processing.json.tftpl
+++ b/Core/StepFunctions/schism_fim_processing.json.tftpl
@@ -94,6 +94,34 @@
         }
       },
       "ResultPath": null,
+      "Next": "Create VRT"
+    },
+    "Create VRT": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "${optimize_rasters_arn}",
+        "Payload": {
+          "step": "create_vrt",
+          "output_bucket.$": "$.data_bucket",
+          "output_prefix.$": "$.data_prefix",
+          "args": {
+            "fim_config.$": "$.fim_config",
+            "product.$": "$.product"
+          }
+        }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "IntervalSeconds": 1,
+          "MaxAttempts": 2,
+          "BackoffRate": 2
+        }
+      ],
+      "ResultPath": null,
       "End": true
     }
   }


### PR DESCRIPTION
Once merged, this code will introduce the necessary changes to produce the "coastal inundation depth" services. This includes the following changes:

* The `viz_optimize_rasters` function was updated to also handle creating VRTs if `"step": "create_vrt"` is included in the lambda event. If the `step` key is omitted, the standard original behavior (i.e. running the cloud optimize raster logic) remains the default. The `create_vrt` path will kick off the creation of two VRT's - one for the TIF datasets and another for the MRF. Both are created only because the `viz_update_egis_data` function uses the datasets in the `tif` folder as the basis of what gets copied from the `mrf` folder to the `publish` folder.

* The `schism_fim_processing.json.tftpl` (i.e. the `process_schism_fim` step function) was updated to include the call to the `viz_optimize_rasters` function using the `"step": "create_vrt"` key/value pair and thus kick off the creation of the VRT following the creation of each individual HUC-based raster.

* The `viz_update_egis_data` lambda function was updated to be able to copy over the `.vrt` file it encounters in the `tif` folder - since before it was hard-coded to expect only `.tif` files in that folder.

* The `.mapx` and service config `.yml` files for all of these new inundation depth services were created and included.

* The product config `.yml` files were updated to include the inundation depth service under the `services` section, so that it gets properly published