### PR TITLE
Enables feature service on a handful of services

### DIFF
--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim/ana_inundation_extent_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim/ana_inundation_extent_noaa.yml
@@ -16,5 +16,5 @@ tags: national water model, nwm, ana, conus, fim, inundation, extent
 credits: National Water Model, NOAA/NWS National Water Center
 egis_server: server
 egis_folder: nwm
-feature_service: false
+feature_service: true
 public_service: false

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_hawaii/ana_inundation_extent_hi_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_hawaii/ana_inundation_extent_hi_noaa.yml
@@ -13,5 +13,5 @@ tags: national water model, nwm, ana, hawaii, hi, fim, inundation, extent
 credits: National Water Model, NOAA/NWS National Water Center
 egis_server: server
 egis_folder: nwm
-feature_service: false
+feature_service: true
 public_service: false

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_puertorico/ana_inundation_extent_prvi_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_puertorico/ana_inundation_extent_prvi_noaa.yml
@@ -13,5 +13,5 @@ tags: national water model, nwm, ana, puertorico, prvi, fim, inundation, extent
 credits: National Water Model, NOAA/NWS National Water Center
 egis_server: server
 egis_folder: nwm
-feature_service: false
+feature_service: true
 public_service: false

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_mem1/mrf_gfs_10day_high_water_arrival_time.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_mem1/mrf_gfs_10day_high_water_arrival_time.yml
@@ -9,5 +9,5 @@ tags: arrival time, national water model, nwm, mrf, medium, range, conus
 credits: National Water Model, NOAA/NWS National Water Center
 egis_server: server
 egis_folder: nwm
-feature_service: false
+feature_service: true
 public_service: true

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_mem1/mrf_gfs_10day_max_inundation_extent_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_mem1/mrf_gfs_10day_max_inundation_extent_noaa.yml
@@ -19,5 +19,5 @@ tags: national water model, nwm, mrf, medium, range, conus, fim, inundation, ext
 credits: National Water Model, NOAA/NWS National Water Center
 egis_server: server
 egis_folder: nwm
-feature_service: false
+feature_service: true
 public_service: false

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_mem1/mrf_gfs_5day_rapid_onset_flooding_probability.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_mem1/mrf_gfs_5day_rapid_onset_flooding_probability.yml
@@ -16,5 +16,5 @@ tags: medium, range, forecast, streamflow, rapid, onset, flood, probability, nat
 credits: National Water Model, NOAA/NWS National Water Center
 egis_server: server
 egis_folder: nwm
-feature_service: false
+feature_service: true
 public_service: true

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/reference/static_flow_based_catfim_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/reference/static_flow_based_catfim_noaa.yml
@@ -12,5 +12,5 @@ tags: nws, flood, categorical, hand, fim, catfim, inundation, library, rfc, heig
 credits: National Water Model, NOAA/NWS National Water Center, Advanced Hydrologic Prediction Service, National River Layer Database
 egis_server: server
 egis_folder: fim_libs
-feature_service: false
+feature_service: true
 public_service: false

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/reference/static_nwm_aep_inundation_extent_library_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/reference/static_nwm_aep_inundation_extent_library_noaa.yml
@@ -8,5 +8,5 @@ tags: nws, flood, categorical, hand, fim, inundation, height, above, nearest, dr
 credits: National Water Model, NOAA/NWS National Water Center
 egis_server: server
 egis_folder: fim_libs
-feature_service: false
+feature_service: true
 public_service: false

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/reference/static_nwm_flowlines.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/reference/static_nwm_flowlines.yml
@@ -5,5 +5,5 @@ tags: national water model, nwm, reference, flowlines, conus
 credits: National Water Model, NOAA/NWS National Water Center
 egis_server: server
 egis_folder: reference
-feature_service: false
+feature_service: true
 public_service: true

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/reference/static_nwm_flowlines_hi.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/reference/static_nwm_flowlines_hi.yml
@@ -5,5 +5,5 @@ tags: national water model, nwm, reference, flowlines, hawaii, hi
 credits: National Water Model, NOAA/NWS National Water Center
 egis_server: server
 egis_folder: reference
-feature_service: false
+feature_service: true
 public_service: true

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/reference/static_nwm_flowlines_prvi.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/reference/static_nwm_flowlines_prvi.yml
@@ -5,5 +5,5 @@ tags: national water model, nwm, reference, flowlines, puertorico, prvi
 credits: National Water Model, NOAA/NWS National Water Center
 egis_server: server
 egis_folder: reference
-feature_service: false
+feature_service: true
 public_service: true

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/reference/static_stage_based_catfim_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/reference/static_stage_based_catfim_noaa.yml
@@ -12,5 +12,5 @@ tags: nws, flood, categorical, hand, fim, catfim, inundation, library, rfc, heig
 credits: National Water Model, NOAA/NWS National Water Center, Advanced Hydrologic Prediction Service, National River Layer Database
 egis_server: server
 egis_folder: fim_libs
-feature_service: false
+feature_service: true
 public_service: false

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/replace_route/rfc_based_5day_max_inundation_extent_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/replace_route/rfc_based_5day_max_inundation_extent_noaa.yml
@@ -17,5 +17,5 @@ tags: national water model, nwm, rfc, conus, fim, inundation, extent
 credits: National Water Model, NOAA/NWS National Water Center
 egis_server: server
 egis_folder: rfc
-feature_service: false
+feature_service: true
 public_service: false

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/replace_route/rfc_based_5day_max_streamflow.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/replace_route/rfc_based_5day_max_streamflow.yml
@@ -8,5 +8,5 @@ tags: streamflow, national water model, nwm, rfc, conus
 credits: National Water Model, NOAA/NWS National Water Center
 egis_server: server
 egis_folder: rfc
-feature_service: false
+feature_service: true
 public_service: false

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range/srf_18hr_max_inundation_extent_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range/srf_18hr_max_inundation_extent_noaa.yml
@@ -20,5 +20,5 @@ tags: national water model, nwm, srf, short, range, conus, fim, inundation, exte
 credits: National Water Model, NOAA/NWS National Water Center
 egis_server: server
 egis_folder: nwm
-feature_service: false
+feature_service: true
 public_service: false

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_hawaii/srf_48hr_max_inundation_extent_hi_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_hawaii/srf_48hr_max_inundation_extent_hi_noaa.yml
@@ -17,5 +17,5 @@ tags: national water model, nwm, srf, short, range, hawaii, hi, fim, inundation,
 credits: National Water Model, NOAA/NWS National Water Center
 egis_server: server
 egis_folder: nwm
-feature_service: false
+feature_service: true
 public_service: false

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_puertorico/srf_48hr_max_inundation_extent_prvi_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_puertorico/srf_48hr_max_inundation_extent_prvi_noaa.yml
@@ -18,5 +18,5 @@ tags: national water model, nwm, srf, short, range, puertorico, prvi, fim, inund
 credits: National Water Model, NOAA/NWS National Water Center
 egis_server: server
 egis_folder: nwm
-feature_service: false
+feature_service: true
 public_service: false


### PR DESCRIPTION
The changes herein are in response to the following request made by @cfitzpat479:

> I realized we need the FeatureServer turned on for several HydroVIS Staging services and later for their production version. The feature services are necessary to configure our apps properly. Could you turn on/push the following feature services to HydroVIS Staging as soon as possible (so I can finish configuring applications today)? Thank you in advance!
>
> ana_inundation_extent_hi_noaa
ana_inundation_extent_prvi_noaa
ana_inundation_extent_noaa
mrf_gfs_10day_high_water_arrival_time
mrf_gfs_10day_max_inundation_extent_noaa
mrf_gfs_5day_rapid_onset_flooding_probability
srf_48hr_max_inundation_extent_hi_noaa
srf_48hr_max_inundation_extent_prvi_noaa
srf_18hr_max_inundation_extent_noaa
static_nwm_flowlines_hi
static_nwm_flowlines_prvi
static_nwm_flowlines
rfc_based_5day_max_inundation_extent_noaa
rfc_based_5day_max_streamflow
rfc_max_forecast
static_flow_based_catfim_noaa
static_nwm_aep_inundation_extent_library_noaa
static_stage_based_catfim_noaa