### PR TITLE
Remove hard-coded "para" logic

### DIFF
--- a/Core/LAMBDA/layers/viz_lambda_shared_funcs/python/viz_lambda_shared_funcs.py
+++ b/Core/LAMBDA/layers/viz_lambda_shared_funcs/python/viz_lambda_shared_funcs.py
@@ -567,11 +567,6 @@ def check_if_file_exists(bucket, file, download=False):
                 if requests.head(https_file).status_code == 200:
                     file_exists = True
                     print("File does not exist on S3 (even though it should), but does exists on Google Cloud.")
-            elif "/para" in file:
-                https_file = file.replace("common/data/model/com/nwm/para", "https://para.nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/para")
-                if requests.head(https_file).status_code == 200:
-                    file_exists = True
-                    print("File does not exist on S3 (even though it should), but does exists on NOMADS para.")
             else:
                 raise Exception("Code could not handle request for file")
 
@@ -592,10 +587,6 @@ def check_if_file_exists(bucket, file, download=False):
                 except:
                     print(f"Failed to open {download_path}. Retrying in case file was corrupted on download")
                     tries +=1
-
-            if "para" in file:
-                print(f"Uploading {file} to {bucket}")
-                s3.upload_file(download_path, bucket, file)
         else:
             print(f"Downloading {file} from s3")
             s3.download_file(bucket, file, download_path)


### PR DESCRIPTION
We no longer need this hard-coded "para" stuff since we have the NWM_DATAFLOW_VERSION environment variable and and the para files are coming in on the nwm-shared bucket.