### PR TITLE
RnR Streamflow: Ensure all forecast points are included

### DIFF
--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/replace_route/rfc_based_5day_max_streamflow.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/replace_route/rfc_based_5day_max_streamflow.sql
@@ -103,8 +103,8 @@ root_status_trace_reaches AS (
 		ON fcst.lid = mf.nws_station_id
 	LEFT JOIN threshold
 		ON threshold.nws_station_id = mf.nws_station_id
-	WHERE rfc_defined_fcst_point IS TRUE
-	ORDER BY feature_id, rfc_defined_fcst_point DESC
+	WHERE rfc_defined_fcst_point IS TRUE OR issue_time IS NOT NULL
+	ORDER BY feature_id, issue_time, rfc_defined_fcst_point DESC
 ),
 
 status_trace AS (


### PR DESCRIPTION
There are sites that have rfc_defined_fcst_point = FALSE, yet still have an official forecast. These sites were being excluded from the downstream status trace. Not anymore, thanks to the simple tweak herein.