### PR TITLE
Update Service Description Fix

### DIFF
--- a/Core/LAMBDA/viz_functions/viz_publish_service/lambda_function.py
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/lambda_function.py
@@ -100,7 +100,12 @@ def lambda_handler(event, context):
                 print("Updating service property description to match iteminfo")
                 service_properties = matching_service.properties
                 service_properties['description'] = matching_service.iteminformation.properties['description']
-                matching_service.edit(dict(service_properties))
+                try:
+                    matching_service.edit(dict(service_properties))
+                except:
+                    matching_service = [service for service in publish_server.services.list(folder=folder) if service.properties['serviceName'] == service_name or service.properties['serviceName'] == service_name_publish][0]
+                    if not matching_service.properties['description']:
+                        raise Exception("Failed to update the map service description")
             
             # Create publish flag file
             tmp_published_file = f"/tmp/{service_name}"


### PR DESCRIPTION
Sometimes the publish service lambda function would throw a "JSONDecodeError: Expecting value: line 1 column 1 (char 0)" error when updating the map service description. When I would go to check the description, the description looked fine, which meant that the ArcGIS python API was throwing a bad error.

To fix this, I added a try/except block to retrieve the service again and check for a new description. If the description looks fine, then the code continues, otherwise it will throw an error.


