### PR TITLE
Non-FIM HI and PRVI Empty Row Fix

### DIFF
--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/analysis_assim_hawaii/ana_high_flow_magnitude_hi.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/analysis_assim_hawaii/ana_high_flow_magnitude_hi.sql
@@ -51,3 +51,8 @@ SELECT channels.feature_id,
 INTO publish.ana_high_flow_magnitude_hi
 FROM derived.channels_hi channels
 JOIN high_flow_mag ON channels.feature_id = high_flow_mag.feature_id;
+
+--Add an empty row so that service monitor will pick up a reference and update time in the event of no fim features
+INSERT INTO publish.ana_high_flow_magnitude_hi(
+	feature_id, feature_id_str, strm_order, name, huc6, state, nwm_vers, reference_time, valid_time, max_flow, recur_cat, high_water_threshold, flow_2yr, flow_5yr, flow_10yr, flow_25yr, flow_50yr, flow_100yr, update_time, geom)
+	VALUES (NULL, NULL, NULL, NULL, NULL, 'HI', NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UtC'), NULL);

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/analysis_assim_puertorico/ana_high_flow_magnitude_prvi.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/analysis_assim_puertorico/ana_high_flow_magnitude_prvi.sql
@@ -51,3 +51,8 @@ SELECT channels.feature_id,
 INTO publish.ana_high_flow_magnitude_prvi
 FROM derived.channels_prvi channels
 JOIN high_flow_mag ON channels.feature_id = high_flow_mag.feature_id;
+
+--Add an empty row so that service monitor will pick up a reference and update time in the event of no fim features
+INSERT INTO publish.ana_high_flow_magnitude_prvi(
+	feature_id, feature_id_str, strm_order, name, huc6, state, nwm_vers, reference_time, valid_time, max_flow, recur_cat, high_water_threshold, flow_2yr, flow_5yr, flow_10yr, flow_25yr, flow_50yr, flow_100yr, update_time, geom)
+	VALUES (NULL, NULL, NULL, NULL, NULL, 'PRVI', NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UtC'), NULL);

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_hawaii/srf_48hr_high_water_arrival_time_hi.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_hawaii/srf_48hr_high_water_arrival_time_hi.sql
@@ -45,3 +45,8 @@ SELECT channels.feature_id,
 INTO publish.srf_48hr_high_water_arrival_time_hi
 FROM derived.channels_hi channels
 JOIN arrival_time ON channels.feature_id = arrival_time.feature_id;
+
+--Add an empty row so that service monitor will pick up a reference and update time in the event of no fim features
+INSERT INTO publish.srf_48hr_high_water_arrival_time_hi(
+	feature_id, feature_id_str, name, strm_order, huc6, state, nwm_vers, reference_time, t_high_water_threshold, t_normal, duration, high_water_threshold, max_flow, update_time, geom)
+	VALUES (NULL, NULL, NULL, NULL, NULL, 'HI', NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), NULL, NULL, NULL, NULL, NULL, to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UtC'), NULL);

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_hawaii/srf_48hr_max_high_flow_magnitude_hi.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_hawaii/srf_48hr_max_high_flow_magnitude_hi.sql
@@ -46,4 +46,9 @@ SELECT channels.feature_id,
     channels.geom
 INTO publish.srf_48hr_max_high_flow_magnitude_hi
 FROM derived.channels_hi channels
-JOIN high_flow_mag ON channels.feature_id = high_flow_mag.feature_id
+JOIN high_flow_mag ON channels.feature_id = high_flow_mag.feature_id;
+
+--Add an empty row so that service monitor will pick up a reference and update time in the event of no fim features
+INSERT INTO publish.srf_48hr_max_high_flow_magnitude_hi(
+	feature_id, feature_id_str, strm_order, name, huc6, state, nwm_vers, reference_time, max_flow, recur_cat, high_water_threshold, flow_2yr, flow_5yr, flow_10yr, flow_25yr, flow_50yr, flow_100yr, update_time, geom)
+	VALUES (NULL, NULL, NULL, NULL, NULL, 'HI', NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UtC'), NULL);

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_hawaii/srf_48hr_peak_flow_arrival_time_hi.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_hawaii/srf_48hr_peak_flow_arrival_time_hi.sql
@@ -33,4 +33,9 @@ JOIN derived.recurrence_flows_hi as rf ON forecasts.feature_id = rf.feature_id
 JOIN publish.srf_48hr_high_water_arrival_time_hi as arrival_time ON forecasts.feature_id = arrival_time.feature_id and forecasts.reference_time = arrival_time.reference_time
 
 WHERE (rf.high_water_threshold > 0 OR rf.high_water_threshold = '-9999') AND forecasts.streamflow * 35.315::double precision >= rf.high_water_threshold
-GROUP BY forecasts.feature_id, forecasts.reference_time, forecasts.nwm_vers, channels.name, channels.strm_order, channels.huc6, rf.high_water_threshold, arrival_time.t_normal, max_flows.maxflow_48hour_cms, channels.geom
+GROUP BY forecasts.feature_id, forecasts.reference_time, forecasts.nwm_vers, channels.name, channels.strm_order, channels.huc6, rf.high_water_threshold, arrival_time.t_normal, max_flows.maxflow_48hour_cms, channels.geom;
+
+--Add an empty row so that service monitor will pick up a reference and update time in the event of no fim features
+INSERT INTO publish.srf_48hr_peak_flow_arrival_time_hi(
+	feature_id, feature_id_str, name, strm_order, huc6, state, nwm_vers, reference_time, peak_flow_arrival_hour, below_bank_return_time, max_flow_cfs, high_water_threshold, update_time, geom)
+	VALUES (NULL, NULL, NULL, NULL, NULL, 'HI', NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), NULL, NULL, NULL, NULL, to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), NULL);

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_puertorico/srf_48hr_high_water_arrival_time_prvi.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_puertorico/srf_48hr_high_water_arrival_time_prvi.sql
@@ -45,3 +45,8 @@ SELECT channels.feature_id,
 INTO publish.srf_48hr_high_water_arrival_time_prvi
 FROM derived.channels_prvi channels
 JOIN arrival_time ON channels.feature_id = arrival_time.feature_id;
+
+--Add an empty row so that service monitor will pick up a reference and update time in the event of no fim features
+INSERT INTO publish.srf_48hr_high_water_arrival_time_prvi(
+	feature_id, feature_id_str, name, strm_order, huc6, state, nwm_vers, reference_time, t_high_water_threshold, t_normal, duration, high_water_threshold, max_flow, update_time, geom)
+	VALUES (NULL, NULL, NULL, NULL, NULL, 'PRVI', NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), NULL, NULL, NULL, NULL, NULL, to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UtC'), NULL);

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_puertorico/srf_48hr_max_high_flow_magnitude_prvi.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_puertorico/srf_48hr_max_high_flow_magnitude_prvi.sql
@@ -46,4 +46,9 @@ SELECT channels.feature_id,
     channels.geom
 INTO publish.srf_48hr_max_high_flow_magnitude_prvi
 FROM derived.channels_prvi channels
-JOIN high_flow_mag ON channels.feature_id = high_flow_mag.feature_id
+JOIN high_flow_mag ON channels.feature_id = high_flow_mag.feature_id;
+
+--Add an empty row so that service monitor will pick up a reference and update time in the event of no fim features
+INSERT INTO publish.srf_48hr_max_high_flow_magnitude_prvi(
+	feature_id, feature_id_str, strm_order, name, huc6, state, nwm_vers, reference_time, max_flow, recur_cat, high_water_threshold, flow_2yr, flow_5yr, flow_10yr, flow_25yr, flow_50yr, flow_100yr, update_time, geom)
+	VALUES (NULL, NULL, NULL, NULL, NULL, 'PRVI', NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UtC'), NULL);

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_puertorico/srf_48hr_peak_flow_arrival_time_prvi.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_puertorico/srf_48hr_peak_flow_arrival_time_prvi.sql
@@ -33,4 +33,9 @@ JOIN derived.recurrence_flows_prvi as rf ON forecasts.feature_id = rf.feature_id
 JOIN publish.srf_48hr_high_water_arrival_time_prvi as arrival_time ON forecasts.feature_id = arrival_time.feature_id and forecasts.reference_time = arrival_time.reference_time
 
 WHERE round((forecasts.streamflow*35.315)::numeric, 2) >= rf.high_water_threshold
-GROUP BY forecasts.feature_id, forecasts.reference_time, forecasts.nwm_vers, channels.name, channels.strm_order, channels.huc6, rf.high_water_threshold, arrival_time.t_normal, max_flows.maxflow_48hour_cms, channels.geom
+GROUP BY forecasts.feature_id, forecasts.reference_time, forecasts.nwm_vers, channels.name, channels.strm_order, channels.huc6, rf.high_water_threshold, arrival_time.t_normal, max_flows.maxflow_48hour_cms, channels.geom;
+
+--Add an empty row so that service monitor will pick up a reference and update time in the event of no fim features
+INSERT INTO publish.srf_48hr_peak_flow_arrival_time_prvi(
+	feature_id, feature_id_str, name, strm_order, huc6, state, nwm_vers, reference_time, peak_flow_arrival_hour, below_bank_return_time, max_flow_cfs, high_water_threshold, update_time, geom)
+	VALUES (NULL, NULL, NULL, NULL, NULL, 'PRVI', NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), NULL, NULL, NULL, NULL, to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), NULL);


### PR DESCRIPTION
Added default empty rows to non-FIM services for HI and PRVI. This will ensure that monitoring issues are not shown for those services.