### PR TITLE
Historic Run Fixes #3

### DIFF
--- a/Core/StepFunctions/viz_processing_pipeline.json.tftpl
+++ b/Core/StepFunctions/viz_processing_pipeline.json.tftpl
@@ -717,7 +717,7 @@
           },
           "Parallelize Summaries": {
             "Type": "Map",
-            "Next": "Parallel",
+            "Next": "Auto vs. Past Event Run",
             "Iterator": {
               "StartAt": "Postprocess SQL - Summary",
               "States": {
@@ -795,9 +795,20 @@
             },
             "ResultPath": null
           },
+          "Auto vs. Past Event Run": {
+            "Type": "Choice",
+            "Choices": [
+              {
+                "Variable": "$.job_type",
+                "StringEquals": "past_event",
+                "Next": "Pass"
+              }
+            ],
+            "Default": "Parallel"
+          },
           "Parallel": {
             "Type": "Parallel",
-            "Next": "Auto vs. Past Event Run",
+            "Next": "Service Publishing",
             "Branches": [
               {
                 "StartAt": "Update EGIS Data - Unstage DB Tables",
@@ -902,17 +913,6 @@
               }
             ],
             "ResultPath": null
-          },
-          "Auto vs. Past Event Run": {
-            "Type": "Choice",
-            "Choices": [
-              {
-                "Variable": "$.job_type",
-                "StringEquals": "past_event",
-                "Next": "Pass"
-              }
-            ],
-            "Default": "Service Publishing"
           },
           "Service Publishing": {
             "Type": "Map",

--- a/Source/Visualizations/aws_loosa/utils/viz_cache_csvs_to_clipped_geospatial.py
+++ b/Source/Visualizations/aws_loosa/utils/viz_cache_csvs_to_clipped_geospatial.py
@@ -82,7 +82,8 @@ def convert_csv_to_geospatial(csv_file, parts=1, output_format = 'gpkg', clip_to
             return
 
     print("... Converting to geodataframe...")
-    gdf = gpd.GeoDataFrame(df_all, geometry=df['geom'].apply(wkt.loads), crs='EPSG:3857')
+    df_all.drop(df_all[df_all['geom'].isna()].index, inplace=True) #Remove any null geoms
+    gdf = gpd.GeoDataFrame(df_all, geometry=df_all['geom'].apply(wkt.loads), crs='EPSG:3857')
     gdf = gdf.drop(columns=['geom'])
     output_filename = csv_file.replace(".csv",f".{output_format}").replace("_publish_", "_") # change file extension and remove publish schema reference from filename.
 
@@ -136,14 +137,14 @@ if __name__ == '__main__':
     ########## Specify your Args Here #############
     sso_profile = None # The name of the AWS SSO profile you created, or set to None if you want to pull from the current environment of an EC2 machine (see notes above)
     bucket_name = 'hydrovis-ti-fim-us-east-1' # Set this based on the hydrovis environment you are pulling from, e.g. 'hydrovis-ti-fim-us-east-1', 'hydrovis-uat-fim-us-east-1', 'hydrovis-prod-fim-us-east-1'
-    start_date = date(2017, 8, 25)
-    end_date = date(2017, 9, 4)
-    reference_times = ["0000","0100","0200","0300","0400","0500"]
-    include_files_with = ["ana_inundation"] # Anything you want to be included when filtering S3 files e.g ["ana", "mrf"] or ["mrf_"]
+    start_date = date(2022, 9, 17)
+    end_date = date(2022, 9, 20)
+    reference_times = ["1200"]
+    include_files_with = ["ref", "prvi"] # Anything you want to be included when filtering S3 files e.g ["ana", "mrf"] or ["mrf_"]
     skip_files_with = [] # Anything you want to be skipped when filtering S3 files e.g. ["ana_streamflow", "rapid_onset_flooding"]
     clip_to_states = [] # Provide a list of state abbreviations to clip to set states, e.g. ["AL", "GA", "MS"]
     output_format = "gpkg" # Set to gpkg or shp - Can add any OGR formats, with some tweaks to the file_format logic in the functions above. BEWARE - large FIM files can be too large for shapefiles, and results may be truncated.
-    output_dir = r"C:\dev\VPP Data Requests" # Directory where you want output files saved.
+    output_dir = r"C:\Users\arcgis\Desktop\Dev\VPP Data Requests" # Directory where you want output files saved.
     overwrite = False # This will automatically skip files that have already been downloaded and/or converted when running the script when set to False (default).
     delete_csv = True # This will delete the csv files after conversion
     ###############################################


### PR DESCRIPTION
This PR includes a few additional minor fixes to allow past_event pipeline runs, and one operational change: Having the EC2 pipeline export geopackage instead of shapefiles. An important bug fix is also present in the viz_cache_csvs_to_clipped_geospatial.py util script that Ops uses to pull archived data from S3.

Note / ToDos:

- The recently added states_to_run_fim input arg to the Initialize Pipeline function is not currently working with the current version of the FIM Data Prep function due to recent changes to the SQL files that fetch streamflow. I'm not going to fix this now, as the recent Ras2FIM PR further changes the structure of that process, and the upcoming HAND Flood Stacks enhancement will also further re-engineer that part of the pipeline.
- I also have not updated past_event functionality for the in-progress RnR updates that @shawncrawley is currently implementing.
- There also seem to be some in-progress changes to the rfc_max_stage / ahps table schemas that I have not accounted for. These services already require manual work to run past events (getting forecast and metadata csvs from on-prem WRDS API due to limited scope of HydroVIS forecast database), so I'm not worry about fixing it.

Both of these points bring up an ongoing consideration on how much effort we should put into maintaining past event functionality in the pipelines moving forward. At this time, I'd recommend not worrying about it given the intimidating burden of testing past events with each PR. With our archive strategy constantly improving, FIM pipeline enhancements on the horizon, and historic requests seemingly consolidating into FIM X% training efforts - it seems it might be better to just continue the effort to formalize / consolidate historic requests into occasional efforts that require some hardening like we did on this last batch for the FIM 10% group... at least until we can implement some type of automatic past_event unit test that can run as part of a CI/CD pipeline.