### PR TITLE
SSM Policy States:SendTaskSuccess Permission Updates

### DIFF
--- a/Core/IAM/Roles/ssm.json.tftpl
+++ b/Core/IAM/Roles/ssm.json.tftpl
@@ -114,6 +114,11 @@
         "Effect": "Allow",
         "Action": "kms:GenerateDataKey",
         "Resource": "*"
+    },
+    {
+        "Action": "states:SendTaskSuccess",
+        "Effect": "Allow",
+        "Resource": "*"
     }
   ]
 }


### PR DESCRIPTION
Added the states:SendTaskSuccess permission to the general SSM policy. This will allow the IAM role to notify Step Function when processing is finished for a synchronous process 