### PR TITLE
Portal Item Update Logic Fix

### DIFF
--- a/Core/LAMBDA/viz_functions/viz_publish_service/lambda_function.py
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/lambda_function.py
@@ -47,6 +47,7 @@ def lambda_handler(event, context):
         raise Exception(f"Could not find appropriate GIS server for {server}")
 
     # Check to see if the service already exists and a publish flag is present or not.
+    time.sleep(30)
     matching_services = [service for service in publish_server.services.list(folder=folder) if service.properties['serviceName'] == service_name or service.properties['serviceName'] == service_name_publish]  # noqa: E501
     publish_flag = s3_file(publish_flag_bucket, publish_flag_key).check_existence()
     if len(matching_services) > 0 and publish_flag is True:
@@ -75,25 +76,6 @@ def lambda_handler(event, context):
             publish_server.services.publish_sd(sd_file=local_sd_file, folder=folder)
             print(f"---> Published {sd_s3_path}")
 
-            # Find the new service and update its item properties and sharing to match what's in the db
-            # (yes, the ArcGIS Python API uses another class to do this for some reason)
-            try:
-                portal_contents = gis.content.search(service_name, item_type='Map Service')
-                new_item = [item for item in portal_contents if item.title == service_name_publish][0]
-            except IndexError as e:
-                print(f"Error: Didn't find the just published {service_name} on portal: {portal_contents}")
-                raise e
-            new_item.update(item_properties={'snippet': summary, 'description': description,
-                            'tags': tags, 'accessInformation': credits})
-            
-            print(f"---> Updated {service_name} descriptions, tags, and credits in Portal.")
-            if public_service:
-                new_item.share(org=True, everyone=True)
-                print(f"---> Updated {service_name} sharing to org and public in Portal.")
-            else:    
-                new_item.share(org=True)
-                print(f"---> Updated {service_name} sharing to org in Portal.")
-
             # Ensuring that the description for the service matches the iteminfo
             matching_service = [service for service in publish_server.services.list(folder=folder) if service.properties['serviceName'] == service_name or service.properties['serviceName'] == service_name_publish][0]
             if not matching_service.properties['description']:
@@ -106,6 +88,19 @@ def lambda_handler(event, context):
                     matching_service = [service for service in publish_server.services.list(folder=folder) if service.properties['serviceName'] == service_name or service.properties['serviceName'] == service_name_publish][0]
                     if not matching_service.properties['description']:
                         raise Exception("Failed to update the map service description")
+                        
+            portalItems = matching_service.properties["portalProperties"]['portalItems']
+            for portalItem in portalItems:
+                new_item = gis.content.get(portalItem['itemID'])
+                new_item.update(item_properties={'snippet': summary, 'description': description, 'tags': tags, 'accessInformation': credits})
+            
+                print(f"---> Updated {portalItem} descriptions, tags, and credits in Portal.")
+                if public_service:
+                    new_item.share(org=True, everyone=True)
+                    print(f"---> Updated {portalItem} sharing to org and public in Portal.")
+                else:    
+                    new_item.share(org=True)
+                    print(f"---> Updated {portalItem} sharing to org in Portal.")
             
             # Create publish flag file
             tmp_published_file = f"/tmp/{service_name}"


### PR DESCRIPTION
When the publish service lambda would use the gis.content.search functionality, the response would sometimes be an empty list. This was often seen in the lambda in the non-active AWS region. I wonder if this has to do with the DNS routing or something. Either way, I updated to the code to instead grab the portal items from the service and then use the gis.content.get method using the portal item ids. 

This is a more robust method for 2 reasons

1. We ensure that we are updating the correct portal items that are associated with the service. 
2. We are also now updating both the map service and the feature service portal items where we were only updating the map service portal item before