### PR TITLE
RnR Domain Generator Ref Time Query Fix

### DIFF
--- a/Core/LAMBDA/rnr_functions/rnr_domain_generator/lambda_function.py
+++ b/Core/LAMBDA/rnr_functions/rnr_domain_generator/lambda_function.py
@@ -39,7 +39,7 @@ def lambda_handler(event, context):
             result = cur.fetchone()
             connection.commit()
 
-        reference_time = result[0].strftime(DT_FORMAT)
+        reference_time = dt.datetime.strptime(result[0], '%Y-%m-%d %H:%M:%S UTC').strftime(DT_FORMAT)
         run_time_obj = dt.datetime.strptime(event['run_time'], '%Y-%m-%dT%H:%M:%SZ')
         run_time = run_time_obj.strftime(DT_FORMAT)
         

--- a/Core/LAMBDA/rnr_functions/rnr_domain_generator/sql/domain.sql
+++ b/Core/LAMBDA/rnr_functions/rnr_domain_generator/sql/domain.sql
@@ -10,9 +10,7 @@ WITH
 
 ref_time AS (
 	SELECT reference_time
-	FROM admin.ingest_status 
-	WHERE target = 'ingest.nwm_channel_rt_ana'
-	AND status = 'Import Complete'
+	FROM ingest.nwm_channel_rt_ana
 	ORDER BY reference_time DESC LIMIT 1
 ),
 
@@ -119,9 +117,7 @@ WITH RECURSIVE
 
 ref_time AS (
 	SELECT reference_time
-	FROM admin.ingest_status 
-	WHERE target = 'ingest.nwm_channel_rt_ana'
-	AND status = 'Import Complete'
+	FROM ingest.nwm_channel_rt_ana
 	ORDER BY reference_time DESC LIMIT 1	
 ),
 
@@ -386,7 +382,5 @@ ORDER BY base.nws_station_id;
 -------------------------------------------------------------
 -------------------------------------------------------------
 SELECT reference_time
-FROM admin.ingest_status 
-WHERE target = 'ingest.nwm_channel_rt_ana'
-AND status = 'Import Complete'
-ORDER BY reference_time DESC LIMIT 1;
+FROM ingest.nwm_channel_rt_ana
+ORDER BY reference_time DESC LIMIT 1


### PR DESCRIPTION
The current RnR domain generator looks at the admin.ingest_status table to determine the latest AnA reference time that was ingested into the DB. One of our latest PRs actually removed the logging to the DB table and caused the RnR domain generator to be stuck on using an old reference time. 

This fix will make the RnR domain generator point to the ingest.nwm_channel_ana table instead to get the reference time, which will actually be more of a valid query anyway