### PR TITLE
Hawaii and Puerto Rico FIMpact Empty Rows with Reference Time

### DIFF
--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/ana_inundation_hi/building_footprints_fimpact.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/ana_inundation_hi/building_footprints_fimpact.sql
@@ -55,3 +55,7 @@ JOIN derived.channels_county_crosswalk AS crosswalk ON counties.geoid = crosswal
 JOIN publish.ana_inundation_hi AS fim on crosswalk.feature_id = fim.feature_id
 JOIN publish.ana_inundation_building_footprints_hi AS buildings ON crosswalk.feature_id = buildings.feature_id
 GROUP BY counties.geoid, counties.name, counties.geom, buildings.prop_st;
+
+INSERT INTO publish.ana_inundation_counties_hi(
+	geoid, county, state, max_flow_cfs, avg_flow_cfs, max_fim_stage_ft, avg_fim_stage_ft, buildings_impacted, building_sqft_impacted, bldgs_agriculture, bldgs_assembly, bldgs_commercial, bldgs_education, bldgs_government, bldgs_industrial, bldgs_residential, bldgs_utility_msc, bldgs_other, reference_time, update_time, geom)
+	VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), NULL);

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/ana_inundation_prvi/building_footprints_fimpact.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/ana_inundation_prvi/building_footprints_fimpact.sql
@@ -55,3 +55,7 @@ JOIN derived.channels_county_crosswalk AS crosswalk ON counties.geoid = crosswal
 JOIN publish.ana_inundation_prvi AS fim on crosswalk.feature_id = fim.feature_id
 JOIN publish.ana_inundation_building_footprints_prvi AS buildings ON crosswalk.feature_id = buildings.feature_id
 GROUP BY counties.geoid, counties.name, counties.geom, buildings.prop_st;
+
+INSERT INTO publish.ana_inundation_counties_prvi(
+	geoid, county, state, max_flow_cfs, avg_flow_cfs, max_fim_stage_ft, avg_fim_stage_ft, buildings_impacted, building_sqft_impacted, bldgs_agriculture, bldgs_assembly, bldgs_commercial, bldgs_education, bldgs_government, bldgs_industrial, bldgs_residential, bldgs_utility_msc, bldgs_other, reference_time, update_time, geom)
+	VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), NULL);

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/srf_48hr_max_inundation_hi/building_footprints_fimpact.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/srf_48hr_max_inundation_hi/building_footprints_fimpact.sql
@@ -55,3 +55,7 @@ JOIN derived.channels_county_crosswalk AS crosswalk ON counties.geoid = crosswal
 JOIN publish.srf_48hr_max_inundation_hi AS fim on crosswalk.feature_id = fim.feature_id
 JOIN publish.srf_48hr_max_inundation_building_footprints_hi AS buildings ON crosswalk.feature_id = buildings.feature_id
 GROUP BY counties.geoid, counties.name, counties.geom, buildings.prop_st;
+
+INSERT INTO publish.srf_48hr_max_inundation_counties_hi(
+	geoid, county, state, max_flow_cfs, avg_flow_cfs, max_fim_stage_ft, avg_fim_stage_ft, buildings_impacted, building_sqft_impacted, bldgs_agriculture, bldgs_assembly, bldgs_commercial, bldgs_education, bldgs_government, bldgs_industrial, bldgs_residential, bldgs_utility_msc, bldgs_other, reference_time, update_time, geom)
+	VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), NULL);

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/srf_48hr_max_inundation_prvi/building_footprints_fimpact.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/srf_48hr_max_inundation_prvi/building_footprints_fimpact.sql
@@ -55,3 +55,7 @@ JOIN derived.channels_county_crosswalk AS crosswalk ON counties.geoid = crosswal
 JOIN publish.srf_48hr_max_inundation_prvi AS fim on crosswalk.feature_id = fim.feature_id
 JOIN publish.srf_48hr_max_inundation_building_footprints_prvi AS buildings ON crosswalk.feature_id = buildings.feature_id
 GROUP BY counties.geoid, counties.name, counties.geom, buildings.prop_st;
+
+INSERT INTO publish.srf_48hr_max_inundation_counties_prvi(
+	geoid, county, state, max_flow_cfs, avg_flow_cfs, max_fim_stage_ft, avg_fim_stage_ft, buildings_impacted, building_sqft_impacted, bldgs_agriculture, bldgs_assembly, bldgs_commercial, bldgs_education, bldgs_government, bldgs_industrial, bldgs_residential, bldgs_utility_msc, bldgs_other, reference_time, update_time, geom)
+	VALUES (NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), NULL);


### PR DESCRIPTION
The Ops monitor currently checks the fimpact layers (counties specifically) for the reference time for Hawaii and Puerto Rico inundation services. However, these layers will be empty if there is no inundation. This PR will add an empty row to the county fimpact layers for these domains so that the Ops monitor can get the correct reference time.