### PR TITLE
added EXPERIMENTAL label to publicly available FIM layers

### DIFF
--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim/ana_inundation_extent.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim/ana_inundation_extent.mapx
@@ -1,7 +1,7 @@
 {
   "type" : "CIMMapDocument",
-  "version" : "2.7.0",
-  "build" : 26828,
+  "version" : "3.0.0",
+  "build" : 36056,
   "mapDefinition" : {
     "type" : "CIMMap",
     "name" : "NWM FIM Extent Analysis",
@@ -30,6 +30,8 @@
     ],
     "defaultViewingMode" : "Map",
     "mapType" : "Map",
+    "groundElevationSurfaceLayer" : "CIMPATH=97f1c81bd1784b909267ea02efe4da60.json",
+    "defaultColorVisionDeficiencyMode" : "None",
     "customFullExtent" : {
       "rings" : [
         [
@@ -57,7 +59,17 @@
       ],
       "spatialReference" : {
         "wkid" : 102100,
-        "latestWkid" : 3857
+        "latestWkid" : 3857,
+        "xyTolerance" : 0.001,
+        "zTolerance" : 0.001,
+        "mTolerance" : 0.001,
+        "falseX" : -20037700,
+        "falseY" : -30241100,
+        "xyUnits" : 10000,
+        "falseZ" : -100000,
+        "zUnits" : 10000,
+        "falseM" : -100000,
+        "mUnits" : 10000
       }
     },
     "datumTransforms" : [
@@ -92,35 +104,24 @@
     ],
     "defaultExtent" : {
       "xmin" : -16791651.2146173716,
-      "ymin" : 1474107.38979748264,
+      "ymin" : 430606.152465584688,
       "xmax" : -4310232.918508362,
-      "ymax" : 8534243.619137926,
+      "ymax" : 9577744.85646982491,
       "spatialReference" : {
         "wkid" : 102100,
-        "latestWkid" : 3857
+        "latestWkid" : 3857,
+        "xyTolerance" : 0.001,
+        "zTolerance" : 0.001,
+        "mTolerance" : 0.001,
+        "falseX" : -20037700,
+        "falseY" : -30241100,
+        "xyUnits" : 10000,
+        "falseZ" : -100000,
+        "zUnits" : 10000,
+        "falseM" : -100000,
+        "mUnits" : 10000
       }
     },
-    "elevationSurfaces" : [
-      {
-        "type" : "CIMMapElevationSurface",
-        "elevationMode" : "BaseGlobeSurface",
-        "name" : "Ground",
-        "verticalExaggeration" : 1,
-        "mapElevationID" : "{84F61CAA-CD53-4C26-BBF2-C7F7CA71C354}",
-        "color" : {
-          "type" : "CIMRGBColor",
-          "values" : [
-            255,
-            255,
-            255,
-            100
-          ]
-        },
-        "surfaceTINShadingMode" : "Smooth",
-        "visibility" : true,
-        "expanded" : true
-      }
-    ],
     "generalPlacementProperties" : {
       "type" : "CIMMaplexGeneralPlacementProperties",
       "invertedLabelTolerance" : 2,
@@ -153,11 +154,22 @@
       "xYToleranceUnit" : "SnapXYToleranceUnitPixel",
       "snapToSketchEnabled" : true,
       "snapRequestType" : "SnapRequestType_GeometricAndVisualSnapping",
-      "isZSnappingEnabled" : true
+      "isZSnappingEnabled" : true,
+      "snapTipDisplayParts" : 3
     },
     "spatialReference" : {
       "wkid" : 102100,
-      "latestWkid" : 3857
+      "latestWkid" : 3857,
+      "xyTolerance" : 0.001,
+      "zTolerance" : 0.001,
+      "mTolerance" : 0.001,
+      "falseX" : -20037700,
+      "falseY" : -30241100,
+      "xyUnits" : 10000,
+      "falseZ" : -100000,
+      "zUnits" : 10000,
+      "falseM" : -100000,
+      "mUnits" : 10000
     },
     "timeDisplay" : {
       "type" : "CIMMapTimeDisplay",
@@ -243,12 +255,13 @@
     "clippingMode" : "None",
     "nearPlaneClipDistanceMode" : "Automatic",
     "rGBColorProfile" : "sRGB IEC61966-2-1 noBPC",
-    "cMYKColorProfile" : "U.S. Web Coated (SWOP) v2"
+    "cMYKColorProfile" : "U.S. Web Coated (SWOP) v2",
+    "autoFillFeatureCache" : true
   },
   "layerDefinitions" : [
     {
       "type" : "CIMFeatureLayer",
-      "name" : "Inundation Extent",
+      "name" : "Inundation Extent (EXPERIMENTAL)",
       "uRI" : "CIMPATH=nwm_analysis_and_assimilation_fim/hydrovis_services_ana_inundation.xml",
       "sourceModifiedTime" : {
         "type" : "TimeInstant",
@@ -259,7 +272,7 @@
       "description" : "hydrovis.services.ana_inundation",
       "layerElevation" : {
         "type" : "CIMLayerElevationSurface",
-        "mapElevationID" : "{84F61CAA-CD53-4C26-BBF2-C7F7CA71C354}"
+        "elevationSurfaceLayerURI" : "CIMPATH=97f1c81bd1784b909267ea02efe4da60.json"
       },
       "expanded" : true,
       "layerType" : "Operational",
@@ -273,6 +286,7 @@
       "refreshRate" : -1,
       "refreshRateUnit" : "esriTimeUnitsSeconds",
       "blendingMode" : "Alpha",
+      "allowDrapingOnIntegratedMesh" : true,
       "autoGenerateFeatureTemplates" : true,
       "featureElevationExpression" : "0",
       "featureTable" : {
@@ -349,7 +363,17 @@
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
-            "latestWkid" : 3857
+            "latestWkid" : 3857,
+            "xyTolerance" : 0.001,
+            "zTolerance" : 0.001,
+            "mTolerance" : 0.001,
+            "falseX" : -20037700,
+            "falseY" : -30241100,
+            "xyUnits" : 10000,
+            "falseZ" : -100000,
+            "zUnits" : 10000,
+            "falseM" : -100000,
+            "mUnits" : 10000
           },
           "oIDFields" : "oid",
           "geometryType" : "esriGeometryPolygon",
@@ -360,37 +384,59 @@
             "ymax" : 3115075,
             "spatialReference" : {
               "wkid" : 102039,
-              "latestWkid" : 102039
+              "latestWkid" : 102039,
+              "xyTolerance" : 0.001,
+              "zTolerance" : 0.001,
+              "mTolerance" : 0.001,
+              "falseX" : -16901100,
+              "falseY" : -6972200,
+              "xyUnits" : 10000,
+              "falseZ" : -100000,
+              "zUnits" : 10000,
+              "falseM" : -100000,
+              "mUnits" : 10000
             }
           },
           "queryFields" : [
             {
               "name" : "streamflow_cfs",
               "type" : "esriFieldTypeDouble",
-              "alias" : "streamflow_cfs"
+              "isNullable" : true,
+              "length" : 0,
+              "precision" : 0,
+              "scale" : 0
             },
             {
               "name" : "feature_id",
               "type" : "esriFieldTypeString",
-              "alias" : "feature_id",
-              "length" : 12
+              "isNullable" : true,
+              "length" : 12,
+              "precision" : 0,
+              "scale" : 0
             },
             {
               "name" : "reference_time",
               "type" : "esriFieldTypeString",
-              "alias" : "reference_time",
-              "length" : 25
+              "isNullable" : true,
+              "length" : 25,
+              "precision" : 0,
+              "scale" : 0
             },
             {
               "name" : "update_time",
               "type" : "esriFieldTypeString",
-              "alias" : "update_time",
-              "length" : 25
+              "isNullable" : true,
+              "length" : 25,
+              "precision" : 0,
+              "scale" : 0
             },
             {
               "name" : "geom",
               "type" : "esriFieldTypeGeometry",
-              "alias" : "geom",
+              "isNullable" : true,
+              "length" : 0,
+              "precision" : 0,
+              "scale" : 0,
               "geometryDef" : {
                 "avgNumPoints" : 0,
                 "geometryType" : "esriGeometryPolygon",
@@ -398,14 +444,27 @@
                 "hasZ" : false,
                 "spatialReference" : {
                   "wkid" : 102100,
-                  "latestWkid" : 3857
+                  "latestWkid" : 3857,
+                  "xyTolerance" : 0.001,
+                  "zTolerance" : 0.001,
+                  "mTolerance" : 0.001,
+                  "falseX" : -20037700,
+                  "falseY" : -30241100,
+                  "xyUnits" : 10000,
+                  "falseZ" : -100000,
+                  "zUnits" : 10000,
+                  "falseM" : -100000,
+                  "mUnits" : 10000
                 }
               }
             },
             {
               "name" : "oid",
               "type" : "esriFieldTypeInteger",
-              "alias" : "oid"
+              "isNullable" : true,
+              "length" : 0,
+              "precision" : 0,
+              "scale" : 0
             }
           ],
           "spatialStorageType" : 8
@@ -416,7 +475,6 @@
       "htmlPopupEnabled" : true,
       "selectable" : true,
       "featureCacheType" : "Session",
-      "displayFilters" : [],
       "displayFiltersType" : "ByScale",
       "featureBlendingMode" : "Alpha",
       "labelClasses" : [
@@ -468,7 +526,8 @@
                   "visible" : true,
                   "splitAfter" : true
                 }
-              ]
+              ],
+              "trimStackingSeparators" : true
             },
             "lineFeatureType" : "General",
             "linePlacementMethod" : "OffsetCurvedFromLine",
@@ -688,6 +747,39 @@
       "type" : "CIMBinaryReference",
       "uRI" : "CIMPATH=Metadata/4075db63627214f834d442a7b40b14ff.xml",
       "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20221014</CreaDate><CreaTime>18283400</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri></metadata>\r\n"
+    }
+  ],
+  "elevationSurfaceLayerDefinitions" : [
+    {
+      "type" : "CIMElevationSurfaceLayer",
+      "name" : "Ground",
+      "uRI" : "CIMPATH=97f1c81bd1784b909267ea02efe4da60.json",
+      "useSourceMetadata" : true,
+      "description" : "Ground",
+      "expanded" : true,
+      "layerType" : "Operational",
+      "showLegends" : false,
+      "visibility" : true,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "allowDrapingOnIntegratedMesh" : true,
+      "elevationMode" : "BaseGlobeSurface",
+      "verticalExaggeration" : 1,
+      "color" : {
+        "type" : "CIMRGBColor",
+        "values" : [
+          255,
+          255,
+          255,
+          100
+        ]
+      },
+      "surfaceTINShadingMode" : "Smooth"
     }
   ]
 }

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim/ana_inundation_extent.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim/ana_inundation_extent.mapx
@@ -1,7 +1,7 @@
 {
   "type" : "CIMMapDocument",
-  "version" : "3.0.0",
-  "build" : 36056,
+  "version" : "2.7.0",
+  "build" : 26828,
   "mapDefinition" : {
     "type" : "CIMMap",
     "name" : "NWM FIM Extent Analysis",
@@ -30,8 +30,6 @@
     ],
     "defaultViewingMode" : "Map",
     "mapType" : "Map",
-    "groundElevationSurfaceLayer" : "CIMPATH=97f1c81bd1784b909267ea02efe4da60.json",
-    "defaultColorVisionDeficiencyMode" : "None",
     "customFullExtent" : {
       "rings" : [
         [
@@ -59,17 +57,7 @@
       ],
       "spatialReference" : {
         "wkid" : 102100,
-        "latestWkid" : 3857,
-        "xyTolerance" : 0.001,
-        "zTolerance" : 0.001,
-        "mTolerance" : 0.001,
-        "falseX" : -20037700,
-        "falseY" : -30241100,
-        "xyUnits" : 10000,
-        "falseZ" : -100000,
-        "zUnits" : 10000,
-        "falseM" : -100000,
-        "mUnits" : 10000
+        "latestWkid" : 3857
       }
     },
     "datumTransforms" : [
@@ -104,24 +92,35 @@
     ],
     "defaultExtent" : {
       "xmin" : -16791651.2146173716,
-      "ymin" : 430606.152465584688,
+      "ymin" : 1474107.38979748264,
       "xmax" : -4310232.918508362,
-      "ymax" : 9577744.85646982491,
+      "ymax" : 8534243.619137926,
       "spatialReference" : {
         "wkid" : 102100,
-        "latestWkid" : 3857,
-        "xyTolerance" : 0.001,
-        "zTolerance" : 0.001,
-        "mTolerance" : 0.001,
-        "falseX" : -20037700,
-        "falseY" : -30241100,
-        "xyUnits" : 10000,
-        "falseZ" : -100000,
-        "zUnits" : 10000,
-        "falseM" : -100000,
-        "mUnits" : 10000
+        "latestWkid" : 3857
       }
     },
+    "elevationSurfaces" : [
+      {
+        "type" : "CIMMapElevationSurface",
+        "elevationMode" : "BaseGlobeSurface",
+        "name" : "Ground",
+        "verticalExaggeration" : 1,
+        "mapElevationID" : "{84F61CAA-CD53-4C26-BBF2-C7F7CA71C354}",
+        "color" : {
+          "type" : "CIMRGBColor",
+          "values" : [
+            255,
+            255,
+            255,
+            100
+          ]
+        },
+        "surfaceTINShadingMode" : "Smooth",
+        "visibility" : true,
+        "expanded" : true
+      }
+    ],
     "generalPlacementProperties" : {
       "type" : "CIMMaplexGeneralPlacementProperties",
       "invertedLabelTolerance" : 2,
@@ -154,22 +153,11 @@
       "xYToleranceUnit" : "SnapXYToleranceUnitPixel",
       "snapToSketchEnabled" : true,
       "snapRequestType" : "SnapRequestType_GeometricAndVisualSnapping",
-      "isZSnappingEnabled" : true,
-      "snapTipDisplayParts" : 3
+      "isZSnappingEnabled" : true
     },
     "spatialReference" : {
       "wkid" : 102100,
-      "latestWkid" : 3857,
-      "xyTolerance" : 0.001,
-      "zTolerance" : 0.001,
-      "mTolerance" : 0.001,
-      "falseX" : -20037700,
-      "falseY" : -30241100,
-      "xyUnits" : 10000,
-      "falseZ" : -100000,
-      "zUnits" : 10000,
-      "falseM" : -100000,
-      "mUnits" : 10000
+      "latestWkid" : 3857
     },
     "timeDisplay" : {
       "type" : "CIMMapTimeDisplay",
@@ -255,8 +243,7 @@
     "clippingMode" : "None",
     "nearPlaneClipDistanceMode" : "Automatic",
     "rGBColorProfile" : "sRGB IEC61966-2-1 noBPC",
-    "cMYKColorProfile" : "U.S. Web Coated (SWOP) v2",
-    "autoFillFeatureCache" : true
+    "cMYKColorProfile" : "U.S. Web Coated (SWOP) v2"
   },
   "layerDefinitions" : [
     {
@@ -272,7 +259,7 @@
       "description" : "hydrovis.services.ana_inundation",
       "layerElevation" : {
         "type" : "CIMLayerElevationSurface",
-        "elevationSurfaceLayerURI" : "CIMPATH=97f1c81bd1784b909267ea02efe4da60.json"
+        "mapElevationID" : "{84F61CAA-CD53-4C26-BBF2-C7F7CA71C354}"
       },
       "expanded" : true,
       "layerType" : "Operational",
@@ -286,7 +273,6 @@
       "refreshRate" : -1,
       "refreshRateUnit" : "esriTimeUnitsSeconds",
       "blendingMode" : "Alpha",
-      "allowDrapingOnIntegratedMesh" : true,
       "autoGenerateFeatureTemplates" : true,
       "featureElevationExpression" : "0",
       "featureTable" : {
@@ -363,17 +349,7 @@
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
-            "latestWkid" : 3857,
-            "xyTolerance" : 0.001,
-            "zTolerance" : 0.001,
-            "mTolerance" : 0.001,
-            "falseX" : -20037700,
-            "falseY" : -30241100,
-            "xyUnits" : 10000,
-            "falseZ" : -100000,
-            "zUnits" : 10000,
-            "falseM" : -100000,
-            "mUnits" : 10000
+            "latestWkid" : 3857
           },
           "oIDFields" : "oid",
           "geometryType" : "esriGeometryPolygon",
@@ -384,59 +360,37 @@
             "ymax" : 3115075,
             "spatialReference" : {
               "wkid" : 102039,
-              "latestWkid" : 102039,
-              "xyTolerance" : 0.001,
-              "zTolerance" : 0.001,
-              "mTolerance" : 0.001,
-              "falseX" : -16901100,
-              "falseY" : -6972200,
-              "xyUnits" : 10000,
-              "falseZ" : -100000,
-              "zUnits" : 10000,
-              "falseM" : -100000,
-              "mUnits" : 10000
+              "latestWkid" : 102039
             }
           },
           "queryFields" : [
             {
               "name" : "streamflow_cfs",
               "type" : "esriFieldTypeDouble",
-              "isNullable" : true,
-              "length" : 0,
-              "precision" : 0,
-              "scale" : 0
+              "alias" : "streamflow_cfs"
             },
             {
               "name" : "feature_id",
               "type" : "esriFieldTypeString",
-              "isNullable" : true,
-              "length" : 12,
-              "precision" : 0,
-              "scale" : 0
+              "alias" : "feature_id",
+              "length" : 12
             },
             {
               "name" : "reference_time",
               "type" : "esriFieldTypeString",
-              "isNullable" : true,
-              "length" : 25,
-              "precision" : 0,
-              "scale" : 0
+              "alias" : "reference_time",
+              "length" : 25
             },
             {
               "name" : "update_time",
               "type" : "esriFieldTypeString",
-              "isNullable" : true,
-              "length" : 25,
-              "precision" : 0,
-              "scale" : 0
+              "alias" : "update_time",
+              "length" : 25
             },
             {
               "name" : "geom",
               "type" : "esriFieldTypeGeometry",
-              "isNullable" : true,
-              "length" : 0,
-              "precision" : 0,
-              "scale" : 0,
+              "alias" : "geom",
               "geometryDef" : {
                 "avgNumPoints" : 0,
                 "geometryType" : "esriGeometryPolygon",
@@ -444,27 +398,14 @@
                 "hasZ" : false,
                 "spatialReference" : {
                   "wkid" : 102100,
-                  "latestWkid" : 3857,
-                  "xyTolerance" : 0.001,
-                  "zTolerance" : 0.001,
-                  "mTolerance" : 0.001,
-                  "falseX" : -20037700,
-                  "falseY" : -30241100,
-                  "xyUnits" : 10000,
-                  "falseZ" : -100000,
-                  "zUnits" : 10000,
-                  "falseM" : -100000,
-                  "mUnits" : 10000
+                  "latestWkid" : 3857
                 }
               }
             },
             {
               "name" : "oid",
               "type" : "esriFieldTypeInteger",
-              "isNullable" : true,
-              "length" : 0,
-              "precision" : 0,
-              "scale" : 0
+              "alias" : "oid"
             }
           ],
           "spatialStorageType" : 8
@@ -475,6 +416,7 @@
       "htmlPopupEnabled" : true,
       "selectable" : true,
       "featureCacheType" : "Session",
+      "displayFilters" : [],
       "displayFiltersType" : "ByScale",
       "featureBlendingMode" : "Alpha",
       "labelClasses" : [
@@ -526,8 +468,7 @@
                   "visible" : true,
                   "splitAfter" : true
                 }
-              ],
-              "trimStackingSeparators" : true
+              ]
             },
             "lineFeatureType" : "General",
             "linePlacementMethod" : "OffsetCurvedFromLine",
@@ -747,39 +688,6 @@
       "type" : "CIMBinaryReference",
       "uRI" : "CIMPATH=Metadata/4075db63627214f834d442a7b40b14ff.xml",
       "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20221014</CreaDate><CreaTime>18283400</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri></metadata>\r\n"
-    }
-  ],
-  "elevationSurfaceLayerDefinitions" : [
-    {
-      "type" : "CIMElevationSurfaceLayer",
-      "name" : "Ground",
-      "uRI" : "CIMPATH=97f1c81bd1784b909267ea02efe4da60.json",
-      "useSourceMetadata" : true,
-      "description" : "Ground",
-      "expanded" : true,
-      "layerType" : "Operational",
-      "showLegends" : false,
-      "visibility" : true,
-      "displayCacheType" : "Permanent",
-      "maxDisplayCacheAge" : 5,
-      "showPopups" : true,
-      "serviceLayerID" : -1,
-      "refreshRate" : -1,
-      "refreshRateUnit" : "esriTimeUnitsSeconds",
-      "blendingMode" : "Alpha",
-      "allowDrapingOnIntegratedMesh" : true,
-      "elevationMode" : "BaseGlobeSurface",
-      "verticalExaggeration" : 1,
-      "color" : {
-        "type" : "CIMRGBColor",
-        "values" : [
-          255,
-          255,
-          255,
-          100
-        ]
-      },
-      "surfaceTINShadingMode" : "Smooth"
     }
   ]
 }

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim/ana_inundation_extent.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim/ana_inundation_extent.yml
@@ -1,5 +1,5 @@
 service: ana_inundation_extent
-summary: Inundation Extent Analysis
+summary: Inundation Extent Analysis (EXPERIMENTAL)
 description: 'Depicts the inundation extent of the National Water Model (NWM) streamflow forecast where the NWM is signaling high water. 
   This service is derived from the analysis and assimilation configuration of the NWM over the contiguous U.S. Shown are reaches with flow 
   at or above high water thresholds. High water thresholds (regionally varied) and AEPs were derived using the 40-year NWM v2.1 reanalysis 

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim/ana_inundation_extent_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim/ana_inundation_extent_noaa.yml
@@ -1,5 +1,5 @@
 service: ana_inundation_extent_noaa
-summary: Inundation Extent Analysis
+summary: Inundation Extent Analysis (EXPERIMENTAL)
 description: 'Depicts the inundation extent of the National Water Model (NWM) streamflow forecast where the NWM is signaling high water. 
   This service is derived from the analysis and assimilation configuration of the NWM over the contiguous U.S. Shown are reaches with flow 
   at or above high water thresholds. High water thresholds (regionally varied) and AEPs were derived using the 40-year NWM v2.1 reanalysis 

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_mem1/mrf_gfs_5day_max_inundation_extent.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_mem1/mrf_gfs_5day_max_inundation_extent.mapx
@@ -1,7 +1,7 @@
 {
   "type" : "CIMMapDocument",
-  "version" : "3.0.0",
-  "build" : 36056,
+  "version" : "2.7.0",
+  "build" : 26828,
   "mapDefinition" : {
     "type" : "CIMMap",
     "name" : "NWM Medium-Range Max FIM Extent Forecast",
@@ -30,8 +30,6 @@
     ],
     "defaultViewingMode" : "Map",
     "mapType" : "Map",
-    "groundElevationSurfaceLayer" : "CIMPATH=84b2890013e84625a1794584635dfa01.json",
-    "defaultColorVisionDeficiencyMode" : "None",
     "customFullExtent" : {
       "rings" : [
         [
@@ -59,17 +57,7 @@
       ],
       "spatialReference" : {
         "wkid" : 102100,
-        "latestWkid" : 3857,
-        "xyTolerance" : 0.001,
-        "zTolerance" : 0.001,
-        "mTolerance" : 0.001,
-        "falseX" : -20037700,
-        "falseY" : -30241100,
-        "xyUnits" : 10000,
-        "falseZ" : -100000,
-        "zUnits" : 10000,
-        "falseM" : -100000,
-        "mUnits" : 10000
+        "latestWkid" : 3857
       }
     },
     "datumTransforms" : [
@@ -104,24 +92,35 @@
     ],
     "defaultExtent" : {
       "xmin" : -14640306.1120054573,
-      "ymin" : 1440325.048916054,
-      "xmax" : -5918710.33622092009,
-      "ymax" : 7832038.26521205064,
+      "ymin" : 1551990.404746464,
+      "xmax" : -5918710.336220921,
+      "ymax" : 7720372.90938164108,
       "spatialReference" : {
         "wkid" : 102100,
-        "latestWkid" : 3857,
-        "xyTolerance" : 0.001,
-        "zTolerance" : 0.001,
-        "mTolerance" : 0.001,
-        "falseX" : -20037700,
-        "falseY" : -30241100,
-        "xyUnits" : 10000,
-        "falseZ" : -100000,
-        "zUnits" : 10000,
-        "falseM" : -100000,
-        "mUnits" : 10000
+        "latestWkid" : 3857
       }
     },
+    "elevationSurfaces" : [
+      {
+        "type" : "CIMMapElevationSurface",
+        "elevationMode" : "BaseGlobeSurface",
+        "name" : "Ground",
+        "verticalExaggeration" : 1,
+        "mapElevationID" : "{84F61CAA-CD53-4C26-BBF2-C7F7CA71C354}",
+        "color" : {
+          "type" : "CIMRGBColor",
+          "values" : [
+            255,
+            255,
+            255,
+            100
+          ]
+        },
+        "surfaceTINShadingMode" : "Smooth",
+        "visibility" : true,
+        "expanded" : true
+      }
+    ],
     "generalPlacementProperties" : {
       "type" : "CIMMaplexGeneralPlacementProperties",
       "invertedLabelTolerance" : 2,
@@ -154,22 +153,11 @@
       "xYToleranceUnit" : "SnapXYToleranceUnitPixel",
       "snapToSketchEnabled" : true,
       "snapRequestType" : "SnapRequestType_GeometricAndVisualSnapping",
-      "isZSnappingEnabled" : true,
-      "snapTipDisplayParts" : 3
+      "isZSnappingEnabled" : true
     },
     "spatialReference" : {
       "wkid" : 102100,
-      "latestWkid" : 3857,
-      "xyTolerance" : 0.001,
-      "zTolerance" : 0.001,
-      "mTolerance" : 0.001,
-      "falseX" : -20037700,
-      "falseY" : -30241100,
-      "xyUnits" : 10000,
-      "falseZ" : -100000,
-      "zUnits" : 10000,
-      "falseM" : -100000,
-      "mUnits" : 10000
+      "latestWkid" : 3857
     },
     "timeDisplay" : {
       "type" : "CIMMapTimeDisplay",
@@ -255,8 +243,7 @@
     "clippingMode" : "None",
     "nearPlaneClipDistanceMode" : "Automatic",
     "rGBColorProfile" : "sRGB IEC61966-2-1 noBPC",
-    "cMYKColorProfile" : "U.S. Web Coated (SWOP) v2",
-    "autoFillFeatureCache" : true
+    "cMYKColorProfile" : "U.S. Web Coated (SWOP) v2"
   },
   "layerDefinitions" : [
     {
@@ -272,7 +259,7 @@
       "description" : "hydrovis.services.ana_inundation",
       "layerElevation" : {
         "type" : "CIMLayerElevationSurface",
-        "elevationSurfaceLayerURI" : "CIMPATH=84b2890013e84625a1794584635dfa01.json"
+        "mapElevationID" : "{84F61CAA-CD53-4C26-BBF2-C7F7CA71C354}"
       },
       "expanded" : true,
       "layerType" : "Operational",
@@ -286,7 +273,6 @@
       "refreshRate" : -1,
       "refreshRateUnit" : "esriTimeUnitsSeconds",
       "blendingMode" : "Alpha",
-      "allowDrapingOnIntegratedMesh" : true,
       "autoGenerateFeatureTemplates" : true,
       "featureElevationExpression" : "0",
       "featureTable" : {
@@ -363,17 +349,7 @@
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
-            "latestWkid" : 3857,
-            "xyTolerance" : 0.001,
-            "zTolerance" : 0.001,
-            "mTolerance" : 0.001,
-            "falseX" : -20037700,
-            "falseY" : -30241100,
-            "xyUnits" : 10000,
-            "falseZ" : -100000,
-            "zUnits" : 10000,
-            "falseM" : -100000,
-            "mUnits" : 10000
+            "latestWkid" : 3857
           },
           "oIDFields" : "oid",
           "geometryType" : "esriGeometryPolygon",
@@ -384,59 +360,37 @@
             "ymax" : 3115075,
             "spatialReference" : {
               "wkid" : 102039,
-              "latestWkid" : 102039,
-              "xyTolerance" : 0.001,
-              "zTolerance" : 0.001,
-              "mTolerance" : 0.001,
-              "falseX" : -16901100,
-              "falseY" : -6972200,
-              "xyUnits" : 10000,
-              "falseZ" : -100000,
-              "zUnits" : 10000,
-              "falseM" : -100000,
-              "mUnits" : 10000
+              "latestWkid" : 102039
             }
           },
           "queryFields" : [
             {
               "name" : "streamflow_cfs",
               "type" : "esriFieldTypeDouble",
-              "isNullable" : true,
-              "length" : 0,
-              "precision" : 0,
-              "scale" : 0
+              "alias" : "streamflow_cfs"
             },
             {
               "name" : "feature_id",
               "type" : "esriFieldTypeString",
-              "isNullable" : true,
-              "length" : 12,
-              "precision" : 0,
-              "scale" : 0
+              "alias" : "feature_id",
+              "length" : 12
             },
             {
               "name" : "reference_time",
               "type" : "esriFieldTypeString",
-              "isNullable" : true,
-              "length" : 25,
-              "precision" : 0,
-              "scale" : 0
+              "alias" : "reference_time",
+              "length" : 25
             },
             {
               "name" : "update_time",
               "type" : "esriFieldTypeString",
-              "isNullable" : true,
-              "length" : 25,
-              "precision" : 0,
-              "scale" : 0
+              "alias" : "update_time",
+              "length" : 25
             },
             {
               "name" : "geom",
               "type" : "esriFieldTypeGeometry",
-              "isNullable" : true,
-              "length" : 0,
-              "precision" : 0,
-              "scale" : 0,
+              "alias" : "geom",
               "geometryDef" : {
                 "avgNumPoints" : 0,
                 "geometryType" : "esriGeometryPolygon",
@@ -444,27 +398,14 @@
                 "hasZ" : false,
                 "spatialReference" : {
                   "wkid" : 102100,
-                  "latestWkid" : 3857,
-                  "xyTolerance" : 0.001,
-                  "zTolerance" : 0.001,
-                  "mTolerance" : 0.001,
-                  "falseX" : -20037700,
-                  "falseY" : -30241100,
-                  "xyUnits" : 10000,
-                  "falseZ" : -100000,
-                  "zUnits" : 10000,
-                  "falseM" : -100000,
-                  "mUnits" : 10000
+                  "latestWkid" : 3857
                 }
               }
             },
             {
               "name" : "oid",
               "type" : "esriFieldTypeInteger",
-              "isNullable" : true,
-              "length" : 0,
-              "precision" : 0,
-              "scale" : 0
+              "alias" : "oid"
             }
           ],
           "spatialStorageType" : 8
@@ -475,6 +416,7 @@
       "htmlPopupEnabled" : true,
       "selectable" : true,
       "featureCacheType" : "Session",
+      "displayFilters" : [],
       "displayFiltersType" : "ByScale",
       "featureBlendingMode" : "Alpha",
       "labelClasses" : [
@@ -526,8 +468,7 @@
                   "visible" : true,
                   "splitAfter" : true
                 }
-              ],
-              "trimStackingSeparators" : true
+              ]
             },
             "lineFeatureType" : "General",
             "linePlacementMethod" : "OffsetCurvedFromLine",
@@ -747,39 +688,6 @@
       "type" : "CIMBinaryReference",
       "uRI" : "CIMPATH=Metadata/14fe75088d76b1922ea8443fd1723cc8.xml",
       "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20220127</CreaDate><CreaTime>19155000</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>Map</resTitle></idCitation></dataIdInfo><Binary><Thumbnail><Data EsriPropertyType=\"PictureX\">/9j/4AAQSkZJRgABAQEAAAAAAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a\r\nHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy\r\nMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCADIASwDAREA\r\nAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA\r\nAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3\r\nODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm\r\np6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA\r\nAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx\r\nBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK\r\nU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3\r\nuLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3+gAo\r\nAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAjliSaIxuuVbq\r\nKAWhjNqg0y8+y3BJjY/uix5I9vWo95X00NlCM0rPU1oLmK5XdE4b1HcVSaexnKLi7MnpkhQAUAFA\r\nBQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAc\r\n14n0m1vfImliHmqSFl7qe1Cr1KS916PfzNaNGFSVpb9DmtK12Sy1+LSb+TNxnesiDAZPQj14963l\r\nhOaj9bpK0dmv66A6/wC8eFq6y3TPRopUmjEkbblboawTuZtNOzJKBBQAUAFABQAUAFABQAUAFABQ\r\nAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQA10V1KuoZT2IzQBw3i3Q\r\nIbpXIRUfG6BwMFG9qvD4qWGqqX2XuujNpUI4mk4v4lsy94F1aTU9JlE4C3FvKYpFznLDqR9a1xeH\r\njQqWg/daTXozmp15Vo3ktVo/VHW1zlhQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAU\r\nAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAU76xjv7cxOSD1VgeVPrRZdUVGTjszzv7NqvhO+ln\r\n0+3N3JMSJlLdW6g49O35V3QrUsTaFeXJy7adO36/eZzozpR56Uebm39f60+429G+Iem3872t8DY3\r\nCDJEnQ9ePyFa1crrQgpw95PscsMZTc3CWj8zsIZo7iJZYnV42GVZTkEV5rTTszrTT1RLSGFABQAU\r\nAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFAEcsgiiaQ9F\r\nGaGNK7sR2lyl3brKnQ9vSkndXHKLi7MsUySpdWEV2dzZVwMbhUygpbmlOrKGxx2t+AI9Wu5pomEM\r\ngUCORuQT7iu7BY2phvc3h2OfFUYV1z/aNDwjpmqaNbLY3EyzW6FskjBVvb1FLGYmniJuajb9SaNB\r\n0YJc1zrK5DYKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKA\r\nCgAoAKAMvWL1bW0dMZd179APU1E5W0NaVNyd+iOb8ETNNcXpMu5RKxGGypHtXTXiouKWmiM0+ZSf\r\nmzuKxEFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUA\r\nFABQAUAFABQBxXjyeCG0jWWQxrJhZWHUKT2H51thoylWXIrtajnJRpPndkzS8PxWthp5n+SKNgAn\r\nGOB7Vz80m3Kb1NqqWkILRGld6vbWlukzF5A/QRrk/X2FUrPqZKEm7WJ7G8S/tVnjVgjdN3ej1FJW\r\nZaoEFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFA\r\nBQAUAcR41sI9Rjmjl/gUMjE4CnFXh8ROhXUoGssPCth2pGJ9unktre1huArsuNykHb64FLljzSnN\r\naLoacz5Yxg9X1IbjR9ULoYNQd5OQNx+Uj3reljMP8M6en4/IyqYWt8UKmv4fM9L0uHyNLtYu6RKD\r\n7nHWueUuZuXcz5eXQu0gCgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKA\r\nCgAoAKACgAoAKACgAoAKAKdxp1tduWlTcSMH0NLlV7lqpJLlWxhHwmkd150IjBPBI4wKUudx5b6G\r\nsasE+bl1OghsoIUiUICYxhWI5p2MOZlmmIKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoA\r\nKACgAoAKACgAoAKAMrVdTWyTYjYkPU4+6KicraLc2o0uZ3exFpWr/a5fKZg+RkMKUJNu0iq1KMVz\r\nRehtVoc4UAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAhIAyTgCgBiyx\r\nspZWUqOpBoCwkU0U67onDDpxSTT2G01oyWmIKACgAoAKACgCKaUQwvIQSEUsQPagaV3YwU18XN9C\r\nqIybH2OpPBzj/wDXWbnqvM6FRtGV90UPFk0aGbc2CAoGPpQouVVJFQko0W2T+FzGuwNjeU4PqamD\r\nXOx10/ZrsdXWxxhQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFAFTUP8A\r\nkHz8E4QnApS2KhpJHIWMss93OkDP5ICrtHIPHt9awtJRSXU724OTb6HY2dqlrAEXOTyxPc1tGKir\r\nI4Zzc3dlmqICgAoAKACgAoAq3zMtlKyMFIXqRnilLYqFuZXOHXNvq8sWGTciyZJ59M8/QVjJP2cZ\r\nP+up3RcXOUV2L+v3dnLa+bEreYVwSeMtjpj1qklOSsZRUoRfNsW/DejT2tnbSTMVI+faxyef5VpN\r\nc1RzMva2p+zR1FMxCgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgDPv8AU47E\r\nbQu+TGducYFRKaia06TnsQaZrSagxRk2tkgbeQcdaFO7sxzpOKutjVIDKQeh4NWYle0sLaxVlt4w\r\ngY5PvSSsNyb3LVMQUAFABQAUAFABQAhAIwRkUAcFqgPnyTS/M8ZYN83JPTArnu3LlueilFQUkg0l\r\nJDcLPMnnbPmEJGQp9frVxlytqKM6keZJzdjtrWc3EO9o2jOcYNaJ3RySjyu1yxTJCgAoAKACgAoA\r\nKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgDh9dnEzu6th2faAD26Vz7zPQiuWkkavh6zj2i\r\ndVVdgKgKe/rV01d8zMcRNWUEjo61OUKACgAoAKACgAoAKACgCvdz/ZrWSXG4qOB6ntSbsrlRi5NJ\r\nHA3EjXFwqEAEN5khPY81gtIuT6ne91BdDsdFtBBaeYUAeQ5P0rSnGyOSvPmloataGIUAFABQAUAF\r\nABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFAHMa7plusgm4RZMhvrWNRW95HZh5c3uyK/\r\nhmdvtAjLgIm5Tz94DoapK0xVXemjrQQwBByD3rQ5B1ABQAUAFABQAUAFABQBR1ZC+mTheoAb8AQf\r\n6VM/hZpSdpo4eNY1vZWLdVBOehIz/jWLu6aO9JKbO0tdTtWjjjL7HwAA1axnFnDOjOL1RoggjIqz\r\nIWgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAhuIVnhaNlDZHH1pNXQ4tx\r\nd0eeTO+j6sUu1K27MF8wkEKx9eeOo5pxoOtC0H7y6d15HV7ZQleXwvr5+Z22j3IuLPaE2+X8v1Hr\r\n/Oog7oxrQcZepp1ZkFABQAUAFABQAUAFADHRZEZGGVYYI9qAON1HTbm3kXasv7sH5gu4EVgk43TV\r\n0eh7SMkmnZmaVvF2ygl0UYYMMEe4oXJLRqxXvrVao39F1lQhRiWgB4Y9U9qak4PlkY1KSmueB0ys\r\nGUMpBBGQRWxxjqACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgDN1HR7TVI2\r\nW4TO9drEdx6UotxkpR0aKUvdcXszlrvw5qGkGP8AsbULpYFZXEJJbhSMgnrgiulYqLk5Thdu/l87\r\nbGSotx5VO1reZ1GlG9KN9pyU/hL/AHq5Y36nRVUE/dNOqMgoAKACgAoAKACgAoAKAKN9YR3aZAAl\r\nH3W/xqZxUkaUqjg79DjLsNZ3kkjKflP7yPOB/wDrrJK65JHbzL+JHYup4laztQrOqLnIP3sD0qqa\r\nnL3Y7mVWNPm5paI0tC18amIw3KyA7G4zx6/lWklKE3TlujGUIygqkNjoqZiFABQAUAFABQAUAFAB\r\nQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFAGRqmlyXkgkhKAl\r\ncNuHWs5wu7o3pVuRNM53T/Cym4yVkJzgu/OzHpmqdWpP3dkXalBcy1Z1VjpNnp0YW2hVcEnOOcnq\r\nf1NW227s5r6WL9IQUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFA\r\nBQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAF\r\nABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUA\r\nFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAU\r\nAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQA\r\nUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQ\r\nAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFAB\r\nQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFA\r\nBQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQB//9k=</Data></Thumbnail></Binary></metadata>\r\n"
-    }
-  ],
-  "elevationSurfaceLayerDefinitions" : [
-    {
-      "type" : "CIMElevationSurfaceLayer",
-      "name" : "Ground",
-      "uRI" : "CIMPATH=84b2890013e84625a1794584635dfa01.json",
-      "useSourceMetadata" : true,
-      "description" : "Ground",
-      "expanded" : true,
-      "layerType" : "Operational",
-      "showLegends" : false,
-      "visibility" : true,
-      "displayCacheType" : "Permanent",
-      "maxDisplayCacheAge" : 5,
-      "showPopups" : true,
-      "serviceLayerID" : -1,
-      "refreshRate" : -1,
-      "refreshRateUnit" : "esriTimeUnitsSeconds",
-      "blendingMode" : "Alpha",
-      "allowDrapingOnIntegratedMesh" : true,
-      "elevationMode" : "BaseGlobeSurface",
-      "verticalExaggeration" : 1,
-      "color" : {
-        "type" : "CIMRGBColor",
-        "values" : [
-          255,
-          255,
-          255,
-          100
-        ]
-      },
-      "surfaceTINShadingMode" : "Smooth"
     }
   ]
 }

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_mem1/mrf_gfs_5day_max_inundation_extent.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_mem1/mrf_gfs_5day_max_inundation_extent.mapx
@@ -1,7 +1,7 @@
 {
   "type" : "CIMMapDocument",
-  "version" : "2.7.0",
-  "build" : 26828,
+  "version" : "3.0.0",
+  "build" : 36056,
   "mapDefinition" : {
     "type" : "CIMMap",
     "name" : "NWM Medium-Range Max FIM Extent Forecast",
@@ -30,6 +30,8 @@
     ],
     "defaultViewingMode" : "Map",
     "mapType" : "Map",
+    "groundElevationSurfaceLayer" : "CIMPATH=84b2890013e84625a1794584635dfa01.json",
+    "defaultColorVisionDeficiencyMode" : "None",
     "customFullExtent" : {
       "rings" : [
         [
@@ -57,7 +59,17 @@
       ],
       "spatialReference" : {
         "wkid" : 102100,
-        "latestWkid" : 3857
+        "latestWkid" : 3857,
+        "xyTolerance" : 0.001,
+        "zTolerance" : 0.001,
+        "mTolerance" : 0.001,
+        "falseX" : -20037700,
+        "falseY" : -30241100,
+        "xyUnits" : 10000,
+        "falseZ" : -100000,
+        "zUnits" : 10000,
+        "falseM" : -100000,
+        "mUnits" : 10000
       }
     },
     "datumTransforms" : [
@@ -92,35 +104,24 @@
     ],
     "defaultExtent" : {
       "xmin" : -14640306.1120054573,
-      "ymin" : 1551990.404746464,
-      "xmax" : -5918710.336220921,
-      "ymax" : 7720372.90938164108,
+      "ymin" : 1440325.048916054,
+      "xmax" : -5918710.33622092009,
+      "ymax" : 7832038.26521205064,
       "spatialReference" : {
         "wkid" : 102100,
-        "latestWkid" : 3857
+        "latestWkid" : 3857,
+        "xyTolerance" : 0.001,
+        "zTolerance" : 0.001,
+        "mTolerance" : 0.001,
+        "falseX" : -20037700,
+        "falseY" : -30241100,
+        "xyUnits" : 10000,
+        "falseZ" : -100000,
+        "zUnits" : 10000,
+        "falseM" : -100000,
+        "mUnits" : 10000
       }
     },
-    "elevationSurfaces" : [
-      {
-        "type" : "CIMMapElevationSurface",
-        "elevationMode" : "BaseGlobeSurface",
-        "name" : "Ground",
-        "verticalExaggeration" : 1,
-        "mapElevationID" : "{84F61CAA-CD53-4C26-BBF2-C7F7CA71C354}",
-        "color" : {
-          "type" : "CIMRGBColor",
-          "values" : [
-            255,
-            255,
-            255,
-            100
-          ]
-        },
-        "surfaceTINShadingMode" : "Smooth",
-        "visibility" : true,
-        "expanded" : true
-      }
-    ],
     "generalPlacementProperties" : {
       "type" : "CIMMaplexGeneralPlacementProperties",
       "invertedLabelTolerance" : 2,
@@ -153,11 +154,22 @@
       "xYToleranceUnit" : "SnapXYToleranceUnitPixel",
       "snapToSketchEnabled" : true,
       "snapRequestType" : "SnapRequestType_GeometricAndVisualSnapping",
-      "isZSnappingEnabled" : true
+      "isZSnappingEnabled" : true,
+      "snapTipDisplayParts" : 3
     },
     "spatialReference" : {
       "wkid" : 102100,
-      "latestWkid" : 3857
+      "latestWkid" : 3857,
+      "xyTolerance" : 0.001,
+      "zTolerance" : 0.001,
+      "mTolerance" : 0.001,
+      "falseX" : -20037700,
+      "falseY" : -30241100,
+      "xyUnits" : 10000,
+      "falseZ" : -100000,
+      "zUnits" : 10000,
+      "falseM" : -100000,
+      "mUnits" : 10000
     },
     "timeDisplay" : {
       "type" : "CIMMapTimeDisplay",
@@ -243,12 +255,13 @@
     "clippingMode" : "None",
     "nearPlaneClipDistanceMode" : "Automatic",
     "rGBColorProfile" : "sRGB IEC61966-2-1 noBPC",
-    "cMYKColorProfile" : "U.S. Web Coated (SWOP) v2"
+    "cMYKColorProfile" : "U.S. Web Coated (SWOP) v2",
+    "autoFillFeatureCache" : true
   },
   "layerDefinitions" : [
     {
       "type" : "CIMFeatureLayer",
-      "name" : "5 Days - Inundation Extent",
+      "name" : "5 Days - Inundation Extent (EXPERIMENTAL)",
       "uRI" : "CIMPATH=nwm_medium_range_max_fim_extent_forecast/5_days___inundation_extent.xml",
       "sourceModifiedTime" : {
         "type" : "TimeInstant",
@@ -259,7 +272,7 @@
       "description" : "hydrovis.services.ana_inundation",
       "layerElevation" : {
         "type" : "CIMLayerElevationSurface",
-        "mapElevationID" : "{84F61CAA-CD53-4C26-BBF2-C7F7CA71C354}"
+        "elevationSurfaceLayerURI" : "CIMPATH=84b2890013e84625a1794584635dfa01.json"
       },
       "expanded" : true,
       "layerType" : "Operational",
@@ -273,6 +286,7 @@
       "refreshRate" : -1,
       "refreshRateUnit" : "esriTimeUnitsSeconds",
       "blendingMode" : "Alpha",
+      "allowDrapingOnIntegratedMesh" : true,
       "autoGenerateFeatureTemplates" : true,
       "featureElevationExpression" : "0",
       "featureTable" : {
@@ -349,7 +363,17 @@
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
-            "latestWkid" : 3857
+            "latestWkid" : 3857,
+            "xyTolerance" : 0.001,
+            "zTolerance" : 0.001,
+            "mTolerance" : 0.001,
+            "falseX" : -20037700,
+            "falseY" : -30241100,
+            "xyUnits" : 10000,
+            "falseZ" : -100000,
+            "zUnits" : 10000,
+            "falseM" : -100000,
+            "mUnits" : 10000
           },
           "oIDFields" : "oid",
           "geometryType" : "esriGeometryPolygon",
@@ -360,37 +384,59 @@
             "ymax" : 3115075,
             "spatialReference" : {
               "wkid" : 102039,
-              "latestWkid" : 102039
+              "latestWkid" : 102039,
+              "xyTolerance" : 0.001,
+              "zTolerance" : 0.001,
+              "mTolerance" : 0.001,
+              "falseX" : -16901100,
+              "falseY" : -6972200,
+              "xyUnits" : 10000,
+              "falseZ" : -100000,
+              "zUnits" : 10000,
+              "falseM" : -100000,
+              "mUnits" : 10000
             }
           },
           "queryFields" : [
             {
               "name" : "streamflow_cfs",
               "type" : "esriFieldTypeDouble",
-              "alias" : "streamflow_cfs"
+              "isNullable" : true,
+              "length" : 0,
+              "precision" : 0,
+              "scale" : 0
             },
             {
               "name" : "feature_id",
               "type" : "esriFieldTypeString",
-              "alias" : "feature_id",
-              "length" : 12
+              "isNullable" : true,
+              "length" : 12,
+              "precision" : 0,
+              "scale" : 0
             },
             {
               "name" : "reference_time",
               "type" : "esriFieldTypeString",
-              "alias" : "reference_time",
-              "length" : 25
+              "isNullable" : true,
+              "length" : 25,
+              "precision" : 0,
+              "scale" : 0
             },
             {
               "name" : "update_time",
               "type" : "esriFieldTypeString",
-              "alias" : "update_time",
-              "length" : 25
+              "isNullable" : true,
+              "length" : 25,
+              "precision" : 0,
+              "scale" : 0
             },
             {
               "name" : "geom",
               "type" : "esriFieldTypeGeometry",
-              "alias" : "geom",
+              "isNullable" : true,
+              "length" : 0,
+              "precision" : 0,
+              "scale" : 0,
               "geometryDef" : {
                 "avgNumPoints" : 0,
                 "geometryType" : "esriGeometryPolygon",
@@ -398,14 +444,27 @@
                 "hasZ" : false,
                 "spatialReference" : {
                   "wkid" : 102100,
-                  "latestWkid" : 3857
+                  "latestWkid" : 3857,
+                  "xyTolerance" : 0.001,
+                  "zTolerance" : 0.001,
+                  "mTolerance" : 0.001,
+                  "falseX" : -20037700,
+                  "falseY" : -30241100,
+                  "xyUnits" : 10000,
+                  "falseZ" : -100000,
+                  "zUnits" : 10000,
+                  "falseM" : -100000,
+                  "mUnits" : 10000
                 }
               }
             },
             {
               "name" : "oid",
               "type" : "esriFieldTypeInteger",
-              "alias" : "oid"
+              "isNullable" : true,
+              "length" : 0,
+              "precision" : 0,
+              "scale" : 0
             }
           ],
           "spatialStorageType" : 8
@@ -416,7 +475,6 @@
       "htmlPopupEnabled" : true,
       "selectable" : true,
       "featureCacheType" : "Session",
-      "displayFilters" : [],
       "displayFiltersType" : "ByScale",
       "featureBlendingMode" : "Alpha",
       "labelClasses" : [
@@ -468,7 +526,8 @@
                   "visible" : true,
                   "splitAfter" : true
                 }
-              ]
+              ],
+              "trimStackingSeparators" : true
             },
             "lineFeatureType" : "General",
             "linePlacementMethod" : "OffsetCurvedFromLine",
@@ -688,6 +747,39 @@
       "type" : "CIMBinaryReference",
       "uRI" : "CIMPATH=Metadata/14fe75088d76b1922ea8443fd1723cc8.xml",
       "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20220127</CreaDate><CreaTime>19155000</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>Map</resTitle></idCitation></dataIdInfo><Binary><Thumbnail><Data EsriPropertyType=\"PictureX\">/9j/4AAQSkZJRgABAQEAAAAAAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a\r\nHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy\r\nMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCADIASwDAREA\r\nAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA\r\nAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3\r\nODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm\r\np6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA\r\nAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx\r\nBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK\r\nU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3\r\nuLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3+gAo\r\nAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAjliSaIxuuVbq\r\nKAWhjNqg0y8+y3BJjY/uix5I9vWo95X00NlCM0rPU1oLmK5XdE4b1HcVSaexnKLi7MnpkhQAUAFA\r\nBQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAc\r\n14n0m1vfImliHmqSFl7qe1Cr1KS916PfzNaNGFSVpb9DmtK12Sy1+LSb+TNxnesiDAZPQj14963l\r\nhOaj9bpK0dmv66A6/wC8eFq6y3TPRopUmjEkbblboawTuZtNOzJKBBQAUAFABQAUAFABQAUAFABQ\r\nAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQA10V1KuoZT2IzQBw3i3Q\r\nIbpXIRUfG6BwMFG9qvD4qWGqqX2XuujNpUI4mk4v4lsy94F1aTU9JlE4C3FvKYpFznLDqR9a1xeH\r\njQqWg/daTXozmp15Vo3ktVo/VHW1zlhQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAU\r\nAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAU76xjv7cxOSD1VgeVPrRZdUVGTjszzv7NqvhO+ln\r\n0+3N3JMSJlLdW6g49O35V3QrUsTaFeXJy7adO36/eZzozpR56Uebm39f60+429G+Iem3872t8DY3\r\nCDJEnQ9ePyFa1crrQgpw95PscsMZTc3CWj8zsIZo7iJZYnV42GVZTkEV5rTTszrTT1RLSGFABQAU\r\nAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFAEcsgiiaQ9F\r\nGaGNK7sR2lyl3brKnQ9vSkndXHKLi7MsUySpdWEV2dzZVwMbhUygpbmlOrKGxx2t+AI9Wu5pomEM\r\ngUCORuQT7iu7BY2phvc3h2OfFUYV1z/aNDwjpmqaNbLY3EyzW6FskjBVvb1FLGYmniJuajb9SaNB\r\n0YJc1zrK5DYKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKA\r\nCgAoAKAMvWL1bW0dMZd179APU1E5W0NaVNyd+iOb8ETNNcXpMu5RKxGGypHtXTXiouKWmiM0+ZSf\r\nmzuKxEFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUA\r\nFABQAUAFABQBxXjyeCG0jWWQxrJhZWHUKT2H51thoylWXIrtajnJRpPndkzS8PxWthp5n+SKNgAn\r\nGOB7Vz80m3Kb1NqqWkILRGld6vbWlukzF5A/QRrk/X2FUrPqZKEm7WJ7G8S/tVnjVgjdN3ej1FJW\r\nZaoEFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFA\r\nBQAUAcR41sI9Rjmjl/gUMjE4CnFXh8ROhXUoGssPCth2pGJ9unktre1huArsuNykHb64FLljzSnN\r\naLoacz5Yxg9X1IbjR9ULoYNQd5OQNx+Uj3reljMP8M6en4/IyqYWt8UKmv4fM9L0uHyNLtYu6RKD\r\n7nHWueUuZuXcz5eXQu0gCgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKA\r\nCgAoAKACgAoAKACgAoAKAKdxp1tduWlTcSMH0NLlV7lqpJLlWxhHwmkd150IjBPBI4wKUudx5b6G\r\nsasE+bl1OghsoIUiUICYxhWI5p2MOZlmmIKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoA\r\nKACgAoAKACgAoAKAMrVdTWyTYjYkPU4+6KicraLc2o0uZ3exFpWr/a5fKZg+RkMKUJNu0iq1KMVz\r\nRehtVoc4UAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAhIAyTgCgBiyx\r\nspZWUqOpBoCwkU0U67onDDpxSTT2G01oyWmIKACgAoAKACgCKaUQwvIQSEUsQPagaV3YwU18XN9C\r\nqIybH2OpPBzj/wDXWbnqvM6FRtGV90UPFk0aGbc2CAoGPpQouVVJFQko0W2T+FzGuwNjeU4PqamD\r\nXOx10/ZrsdXWxxhQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFAFTUP8A\r\nkHz8E4QnApS2KhpJHIWMss93OkDP5ICrtHIPHt9awtJRSXU724OTb6HY2dqlrAEXOTyxPc1tGKir\r\nI4Zzc3dlmqICgAoAKACgAoAq3zMtlKyMFIXqRnilLYqFuZXOHXNvq8sWGTciyZJ59M8/QVjJP2cZ\r\nP+up3RcXOUV2L+v3dnLa+bEreYVwSeMtjpj1qklOSsZRUoRfNsW/DejT2tnbSTMVI+faxyef5VpN\r\nc1RzMva2p+zR1FMxCgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgDPv8AU47E\r\nbQu+TGducYFRKaia06TnsQaZrSagxRk2tkgbeQcdaFO7sxzpOKutjVIDKQeh4NWYle0sLaxVlt4w\r\ngY5PvSSsNyb3LVMQUAFABQAUAFABQAhAIwRkUAcFqgPnyTS/M8ZYN83JPTArnu3LlueilFQUkg0l\r\nJDcLPMnnbPmEJGQp9frVxlytqKM6keZJzdjtrWc3EO9o2jOcYNaJ3RySjyu1yxTJCgAoAKACgAoA\r\nKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgDh9dnEzu6th2faAD26Vz7zPQiuWkkavh6zj2i\r\ndVVdgKgKe/rV01d8zMcRNWUEjo61OUKACgAoAKACgAoAKACgCvdz/ZrWSXG4qOB6ntSbsrlRi5NJ\r\nHA3EjXFwqEAEN5khPY81gtIuT6ne91BdDsdFtBBaeYUAeQ5P0rSnGyOSvPmloataGIUAFABQAUAF\r\nABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFAHMa7plusgm4RZMhvrWNRW95HZh5c3uyK/\r\nhmdvtAjLgIm5Tz94DoapK0xVXemjrQQwBByD3rQ5B1ABQAUAFABQAUAFABQBR1ZC+mTheoAb8AQf\r\n6VM/hZpSdpo4eNY1vZWLdVBOehIz/jWLu6aO9JKbO0tdTtWjjjL7HwAA1axnFnDOjOL1RoggjIqz\r\nIWgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAhuIVnhaNlDZHH1pNXQ4tx\r\nd0eeTO+j6sUu1K27MF8wkEKx9eeOo5pxoOtC0H7y6d15HV7ZQleXwvr5+Z22j3IuLPaE2+X8v1Hr\r\n/Oog7oxrQcZepp1ZkFABQAUAFABQAUAFADHRZEZGGVYYI9qAON1HTbm3kXasv7sH5gu4EVgk43TV\r\n0eh7SMkmnZmaVvF2ygl0UYYMMEe4oXJLRqxXvrVao39F1lQhRiWgB4Y9U9qak4PlkY1KSmueB0ys\r\nGUMpBBGQRWxxjqACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgDN1HR7TVI2\r\nW4TO9drEdx6UotxkpR0aKUvdcXszlrvw5qGkGP8AsbULpYFZXEJJbhSMgnrgiulYqLk5Thdu/l87\r\nbGSotx5VO1reZ1GlG9KN9pyU/hL/AHq5Y36nRVUE/dNOqMgoAKACgAoAKACgAoAKAKN9YR3aZAAl\r\nH3W/xqZxUkaUqjg79DjLsNZ3kkjKflP7yPOB/wDrrJK65JHbzL+JHYup4laztQrOqLnIP3sD0qqa\r\nnL3Y7mVWNPm5paI0tC18amIw3KyA7G4zx6/lWklKE3TlujGUIygqkNjoqZiFABQAUAFABQAUAFAB\r\nQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFAGRqmlyXkgkhKAl\r\ncNuHWs5wu7o3pVuRNM53T/Cym4yVkJzgu/OzHpmqdWpP3dkXalBcy1Z1VjpNnp0YW2hVcEnOOcnq\r\nf1NW227s5r6WL9IQUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFA\r\nBQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAF\r\nABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUA\r\nFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAU\r\nAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQA\r\nUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQ\r\nAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFAB\r\nQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFA\r\nBQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQB//9k=</Data></Thumbnail></Binary></metadata>\r\n"
+    }
+  ],
+  "elevationSurfaceLayerDefinitions" : [
+    {
+      "type" : "CIMElevationSurfaceLayer",
+      "name" : "Ground",
+      "uRI" : "CIMPATH=84b2890013e84625a1794584635dfa01.json",
+      "useSourceMetadata" : true,
+      "description" : "Ground",
+      "expanded" : true,
+      "layerType" : "Operational",
+      "showLegends" : false,
+      "visibility" : true,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "allowDrapingOnIntegratedMesh" : true,
+      "elevationMode" : "BaseGlobeSurface",
+      "verticalExaggeration" : 1,
+      "color" : {
+        "type" : "CIMRGBColor",
+        "values" : [
+          255,
+          255,
+          255,
+          100
+        ]
+      },
+      "surfaceTINShadingMode" : "Smooth"
     }
   ]
 }

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_mem1/mrf_gfs_5day_max_inundation_extent.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_mem1/mrf_gfs_5day_max_inundation_extent.yml
@@ -1,5 +1,5 @@
 service: mrf_gfs_5day_max_inundation_extent
-summary: Medium-Range GFS 5 Day Max Inundation Extent Forecast
+summary: Medium-Range GFS 5 Day Max Inundation Extent Forecast (EXPERIMENTAL)
 description: 'Depicts the inundation extent of the peak National Water Model (NWM) streamflow forecast 
   over the next 5 days where the NWM is signaling high water. This service is derived from 
   the medium-range GFS configuration of the NWM over the contiguous U.S. Shown are reaches with peak flow 

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/replace_route/rfc_based_5day_max_inundation_extent.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/replace_route/rfc_based_5day_max_inundation_extent.mapx
@@ -1,7 +1,7 @@
 {
   "type" : "CIMMapDocument",
-  "version" : "2.7.0",
-  "build" : 26828,
+  "version" : "3.0.0",
+  "build" : 36056,
   "mapDefinition" : {
     "type" : "CIMMap",
     "name" : "NWM FIM Extent Analysis",
@@ -30,6 +30,8 @@
     ],
     "defaultViewingMode" : "Map",
     "mapType" : "Map",
+    "groundElevationSurfaceLayer" : "CIMPATH=65805ba43aee40c183f4c03d1f8df385.json",
+    "defaultColorVisionDeficiencyMode" : "None",
     "customFullExtent" : {
       "rings" : [
         [
@@ -57,7 +59,17 @@
       ],
       "spatialReference" : {
         "wkid" : 102100,
-        "latestWkid" : 3857
+        "latestWkid" : 3857,
+        "xyTolerance" : 0.001,
+        "zTolerance" : 0.001,
+        "mTolerance" : 0.001,
+        "falseX" : -20037700,
+        "falseY" : -30241100,
+        "xyUnits" : 10000,
+        "falseZ" : -100000,
+        "zUnits" : 10000,
+        "falseM" : -100000,
+        "mUnits" : 10000
       }
     },
     "datumTransforms" : [
@@ -91,36 +103,25 @@
       }
     ],
     "defaultExtent" : {
-      "xmin" : -16791651.2146173716,
-      "ymin" : 1474107.38979748264,
-      "xmax" : -4310232.918508362,
-      "ymax" : 8534243.619137926,
+      "xmin" : -18698534.5654118061,
+      "ymin" : -966873.371757284738,
+      "xmax" : -2403349.56771392934,
+      "ymax" : 10975224.3806926943,
       "spatialReference" : {
         "wkid" : 102100,
-        "latestWkid" : 3857
+        "latestWkid" : 3857,
+        "xyTolerance" : 0.001,
+        "zTolerance" : 0.001,
+        "mTolerance" : 0.001,
+        "falseX" : -20037700,
+        "falseY" : -30241100,
+        "xyUnits" : 10000,
+        "falseZ" : -100000,
+        "zUnits" : 10000,
+        "falseM" : -100000,
+        "mUnits" : 10000
       }
     },
-    "elevationSurfaces" : [
-      {
-        "type" : "CIMMapElevationSurface",
-        "elevationMode" : "BaseGlobeSurface",
-        "name" : "Ground",
-        "verticalExaggeration" : 1,
-        "mapElevationID" : "{84F61CAA-CD53-4C26-BBF2-C7F7CA71C354}",
-        "color" : {
-          "type" : "CIMRGBColor",
-          "values" : [
-            255,
-            255,
-            255,
-            100
-          ]
-        },
-        "surfaceTINShadingMode" : "Smooth",
-        "visibility" : true,
-        "expanded" : true
-      }
-    ],
     "generalPlacementProperties" : {
       "type" : "CIMMaplexGeneralPlacementProperties",
       "invertedLabelTolerance" : 2,
@@ -153,11 +154,22 @@
       "xYToleranceUnit" : "SnapXYToleranceUnitPixel",
       "snapToSketchEnabled" : true,
       "snapRequestType" : "SnapRequestType_GeometricAndVisualSnapping",
-      "isZSnappingEnabled" : true
+      "isZSnappingEnabled" : true,
+      "snapTipDisplayParts" : 3
     },
     "spatialReference" : {
       "wkid" : 102100,
-      "latestWkid" : 3857
+      "latestWkid" : 3857,
+      "xyTolerance" : 0.001,
+      "zTolerance" : 0.001,
+      "mTolerance" : 0.001,
+      "falseX" : -20037700,
+      "falseY" : -30241100,
+      "xyUnits" : 10000,
+      "falseZ" : -100000,
+      "zUnits" : 10000,
+      "falseM" : -100000,
+      "mUnits" : 10000
     },
     "timeDisplay" : {
       "type" : "CIMMapTimeDisplay",
@@ -243,12 +255,13 @@
     "clippingMode" : "None",
     "nearPlaneClipDistanceMode" : "Automatic",
     "rGBColorProfile" : "sRGB IEC61966-2-1 noBPC",
-    "cMYKColorProfile" : "U.S. Web Coated (SWOP) v2"
+    "cMYKColorProfile" : "U.S. Web Coated (SWOP) v2",
+    "autoFillFeatureCache" : true
   },
   "layerDefinitions" : [
     {
       "type" : "CIMFeatureLayer",
-      "name" : "Inundation Extent",
+      "name" : "5 Days - Inundation Extent (EXPERIMENTAL)",
       "uRI" : "CIMPATH=nwm_analysis_and_assimilation_fim/hydrovis_services_ana_inundation.xml",
       "sourceModifiedTime" : {
         "type" : "TimeInstant",
@@ -259,7 +272,7 @@
       "description" : "hydrovis.services.ana_inundation",
       "layerElevation" : {
         "type" : "CIMLayerElevationSurface",
-        "mapElevationID" : "{84F61CAA-CD53-4C26-BBF2-C7F7CA71C354}"
+        "elevationSurfaceLayerURI" : "CIMPATH=65805ba43aee40c183f4c03d1f8df385.json"
       },
       "expanded" : true,
       "layerType" : "Operational",
@@ -273,6 +286,7 @@
       "refreshRate" : -1,
       "refreshRateUnit" : "esriTimeUnitsSeconds",
       "blendingMode" : "Alpha",
+      "allowDrapingOnIntegratedMesh" : true,
       "autoGenerateFeatureTemplates" : true,
       "featureElevationExpression" : "0",
       "featureTable" : {
@@ -349,7 +363,17 @@
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
-            "latestWkid" : 3857
+            "latestWkid" : 3857,
+            "xyTolerance" : 0.001,
+            "zTolerance" : 0.001,
+            "mTolerance" : 0.001,
+            "falseX" : -20037700,
+            "falseY" : -30241100,
+            "xyUnits" : 10000,
+            "falseZ" : -100000,
+            "zUnits" : 10000,
+            "falseM" : -100000,
+            "mUnits" : 10000
           },
           "oIDFields" : "oid",
           "geometryType" : "esriGeometryPolygon",
@@ -360,37 +384,59 @@
             "ymax" : 3115075,
             "spatialReference" : {
               "wkid" : 102039,
-              "latestWkid" : 102039
+              "latestWkid" : 102039,
+              "xyTolerance" : 0.001,
+              "zTolerance" : 0.001,
+              "mTolerance" : 0.001,
+              "falseX" : -16901100,
+              "falseY" : -6972200,
+              "xyUnits" : 10000,
+              "falseZ" : -100000,
+              "zUnits" : 10000,
+              "falseM" : -100000,
+              "mUnits" : 10000
             }
           },
           "queryFields" : [
             {
               "name" : "streamflow_cfs",
               "type" : "esriFieldTypeDouble",
-              "alias" : "streamflow_cfs"
+              "isNullable" : true,
+              "length" : 0,
+              "precision" : 0,
+              "scale" : 0
             },
             {
               "name" : "feature_id",
               "type" : "esriFieldTypeString",
-              "alias" : "feature_id",
-              "length" : 12
+              "isNullable" : true,
+              "length" : 12,
+              "precision" : 0,
+              "scale" : 0
             },
             {
               "name" : "reference_time",
               "type" : "esriFieldTypeString",
-              "alias" : "reference_time",
-              "length" : 25
+              "isNullable" : true,
+              "length" : 25,
+              "precision" : 0,
+              "scale" : 0
             },
             {
               "name" : "update_time",
               "type" : "esriFieldTypeString",
-              "alias" : "update_time",
-              "length" : 25
+              "isNullable" : true,
+              "length" : 25,
+              "precision" : 0,
+              "scale" : 0
             },
             {
               "name" : "geom",
               "type" : "esriFieldTypeGeometry",
-              "alias" : "geom",
+              "isNullable" : true,
+              "length" : 0,
+              "precision" : 0,
+              "scale" : 0,
               "geometryDef" : {
                 "avgNumPoints" : 0,
                 "geometryType" : "esriGeometryPolygon",
@@ -398,14 +444,27 @@
                 "hasZ" : false,
                 "spatialReference" : {
                   "wkid" : 102100,
-                  "latestWkid" : 3857
+                  "latestWkid" : 3857,
+                  "xyTolerance" : 0.001,
+                  "zTolerance" : 0.001,
+                  "mTolerance" : 0.001,
+                  "falseX" : -20037700,
+                  "falseY" : -30241100,
+                  "xyUnits" : 10000,
+                  "falseZ" : -100000,
+                  "zUnits" : 10000,
+                  "falseM" : -100000,
+                  "mUnits" : 10000
                 }
               }
             },
             {
               "name" : "oid",
               "type" : "esriFieldTypeInteger",
-              "alias" : "oid"
+              "isNullable" : true,
+              "length" : 0,
+              "precision" : 0,
+              "scale" : 0
             }
           ],
           "spatialStorageType" : 8
@@ -416,7 +475,6 @@
       "htmlPopupEnabled" : true,
       "selectable" : true,
       "featureCacheType" : "Session",
-      "displayFilters" : [],
       "displayFiltersType" : "ByScale",
       "featureBlendingMode" : "Alpha",
       "labelClasses" : [
@@ -468,7 +526,8 @@
                   "visible" : true,
                   "splitAfter" : true
                 }
-              ]
+              ],
+              "trimStackingSeparators" : true
             },
             "lineFeatureType" : "General",
             "linePlacementMethod" : "OffsetCurvedFromLine",
@@ -688,6 +747,39 @@
       "type" : "CIMBinaryReference",
       "uRI" : "CIMPATH=Metadata/4075db63627214f834d442a7b40b14ff.xml",
       "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20221014</CreaDate><CreaTime>18283400</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri></metadata>\r\n"
+    }
+  ],
+  "elevationSurfaceLayerDefinitions" : [
+    {
+      "type" : "CIMElevationSurfaceLayer",
+      "name" : "Ground",
+      "uRI" : "CIMPATH=65805ba43aee40c183f4c03d1f8df385.json",
+      "useSourceMetadata" : true,
+      "description" : "Ground",
+      "expanded" : true,
+      "layerType" : "Operational",
+      "showLegends" : false,
+      "visibility" : true,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "allowDrapingOnIntegratedMesh" : true,
+      "elevationMode" : "BaseGlobeSurface",
+      "verticalExaggeration" : 1,
+      "color" : {
+        "type" : "CIMRGBColor",
+        "values" : [
+          255,
+          255,
+          255,
+          100
+        ]
+      },
+      "surfaceTINShadingMode" : "Smooth"
     }
   ]
 }

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/replace_route/rfc_based_5day_max_inundation_extent.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/replace_route/rfc_based_5day_max_inundation_extent.mapx
@@ -1,7 +1,7 @@
 {
   "type" : "CIMMapDocument",
-  "version" : "3.0.0",
-  "build" : 36056,
+  "version" : "2.7.0",
+  "build" : 26828,
   "mapDefinition" : {
     "type" : "CIMMap",
     "name" : "NWM FIM Extent Analysis",
@@ -30,8 +30,6 @@
     ],
     "defaultViewingMode" : "Map",
     "mapType" : "Map",
-    "groundElevationSurfaceLayer" : "CIMPATH=65805ba43aee40c183f4c03d1f8df385.json",
-    "defaultColorVisionDeficiencyMode" : "None",
     "customFullExtent" : {
       "rings" : [
         [
@@ -59,17 +57,7 @@
       ],
       "spatialReference" : {
         "wkid" : 102100,
-        "latestWkid" : 3857,
-        "xyTolerance" : 0.001,
-        "zTolerance" : 0.001,
-        "mTolerance" : 0.001,
-        "falseX" : -20037700,
-        "falseY" : -30241100,
-        "xyUnits" : 10000,
-        "falseZ" : -100000,
-        "zUnits" : 10000,
-        "falseM" : -100000,
-        "mUnits" : 10000
+        "latestWkid" : 3857
       }
     },
     "datumTransforms" : [
@@ -103,25 +91,36 @@
       }
     ],
     "defaultExtent" : {
-      "xmin" : -18698534.5654118061,
-      "ymin" : -966873.371757284738,
-      "xmax" : -2403349.56771392934,
-      "ymax" : 10975224.3806926943,
+      "xmin" : -16791651.2146173716,
+      "ymin" : 1474107.38979748264,
+      "xmax" : -4310232.918508362,
+      "ymax" : 8534243.619137926,
       "spatialReference" : {
         "wkid" : 102100,
-        "latestWkid" : 3857,
-        "xyTolerance" : 0.001,
-        "zTolerance" : 0.001,
-        "mTolerance" : 0.001,
-        "falseX" : -20037700,
-        "falseY" : -30241100,
-        "xyUnits" : 10000,
-        "falseZ" : -100000,
-        "zUnits" : 10000,
-        "falseM" : -100000,
-        "mUnits" : 10000
+        "latestWkid" : 3857
       }
     },
+    "elevationSurfaces" : [
+      {
+        "type" : "CIMMapElevationSurface",
+        "elevationMode" : "BaseGlobeSurface",
+        "name" : "Ground",
+        "verticalExaggeration" : 1,
+        "mapElevationID" : "{84F61CAA-CD53-4C26-BBF2-C7F7CA71C354}",
+        "color" : {
+          "type" : "CIMRGBColor",
+          "values" : [
+            255,
+            255,
+            255,
+            100
+          ]
+        },
+        "surfaceTINShadingMode" : "Smooth",
+        "visibility" : true,
+        "expanded" : true
+      }
+    ],
     "generalPlacementProperties" : {
       "type" : "CIMMaplexGeneralPlacementProperties",
       "invertedLabelTolerance" : 2,
@@ -154,22 +153,11 @@
       "xYToleranceUnit" : "SnapXYToleranceUnitPixel",
       "snapToSketchEnabled" : true,
       "snapRequestType" : "SnapRequestType_GeometricAndVisualSnapping",
-      "isZSnappingEnabled" : true,
-      "snapTipDisplayParts" : 3
+      "isZSnappingEnabled" : true
     },
     "spatialReference" : {
       "wkid" : 102100,
-      "latestWkid" : 3857,
-      "xyTolerance" : 0.001,
-      "zTolerance" : 0.001,
-      "mTolerance" : 0.001,
-      "falseX" : -20037700,
-      "falseY" : -30241100,
-      "xyUnits" : 10000,
-      "falseZ" : -100000,
-      "zUnits" : 10000,
-      "falseM" : -100000,
-      "mUnits" : 10000
+      "latestWkid" : 3857
     },
     "timeDisplay" : {
       "type" : "CIMMapTimeDisplay",
@@ -255,13 +243,12 @@
     "clippingMode" : "None",
     "nearPlaneClipDistanceMode" : "Automatic",
     "rGBColorProfile" : "sRGB IEC61966-2-1 noBPC",
-    "cMYKColorProfile" : "U.S. Web Coated (SWOP) v2",
-    "autoFillFeatureCache" : true
+    "cMYKColorProfile" : "U.S. Web Coated (SWOP) v2"
   },
   "layerDefinitions" : [
     {
       "type" : "CIMFeatureLayer",
-      "name" : "5 Days - Inundation Extent (EXPERIMENTAL)",
+      "name" : "5 Days -Inundation Extent (EXPERIMENTAL)",
       "uRI" : "CIMPATH=nwm_analysis_and_assimilation_fim/hydrovis_services_ana_inundation.xml",
       "sourceModifiedTime" : {
         "type" : "TimeInstant",
@@ -272,7 +259,7 @@
       "description" : "hydrovis.services.ana_inundation",
       "layerElevation" : {
         "type" : "CIMLayerElevationSurface",
-        "elevationSurfaceLayerURI" : "CIMPATH=65805ba43aee40c183f4c03d1f8df385.json"
+        "mapElevationID" : "{84F61CAA-CD53-4C26-BBF2-C7F7CA71C354}"
       },
       "expanded" : true,
       "layerType" : "Operational",
@@ -286,7 +273,6 @@
       "refreshRate" : -1,
       "refreshRateUnit" : "esriTimeUnitsSeconds",
       "blendingMode" : "Alpha",
-      "allowDrapingOnIntegratedMesh" : true,
       "autoGenerateFeatureTemplates" : true,
       "featureElevationExpression" : "0",
       "featureTable" : {
@@ -363,17 +349,7 @@
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
-            "latestWkid" : 3857,
-            "xyTolerance" : 0.001,
-            "zTolerance" : 0.001,
-            "mTolerance" : 0.001,
-            "falseX" : -20037700,
-            "falseY" : -30241100,
-            "xyUnits" : 10000,
-            "falseZ" : -100000,
-            "zUnits" : 10000,
-            "falseM" : -100000,
-            "mUnits" : 10000
+            "latestWkid" : 3857
           },
           "oIDFields" : "oid",
           "geometryType" : "esriGeometryPolygon",
@@ -384,59 +360,37 @@
             "ymax" : 3115075,
             "spatialReference" : {
               "wkid" : 102039,
-              "latestWkid" : 102039,
-              "xyTolerance" : 0.001,
-              "zTolerance" : 0.001,
-              "mTolerance" : 0.001,
-              "falseX" : -16901100,
-              "falseY" : -6972200,
-              "xyUnits" : 10000,
-              "falseZ" : -100000,
-              "zUnits" : 10000,
-              "falseM" : -100000,
-              "mUnits" : 10000
+              "latestWkid" : 102039
             }
           },
           "queryFields" : [
             {
               "name" : "streamflow_cfs",
               "type" : "esriFieldTypeDouble",
-              "isNullable" : true,
-              "length" : 0,
-              "precision" : 0,
-              "scale" : 0
+              "alias" : "streamflow_cfs"
             },
             {
               "name" : "feature_id",
               "type" : "esriFieldTypeString",
-              "isNullable" : true,
-              "length" : 12,
-              "precision" : 0,
-              "scale" : 0
+              "alias" : "feature_id",
+              "length" : 12
             },
             {
               "name" : "reference_time",
               "type" : "esriFieldTypeString",
-              "isNullable" : true,
-              "length" : 25,
-              "precision" : 0,
-              "scale" : 0
+              "alias" : "reference_time",
+              "length" : 25
             },
             {
               "name" : "update_time",
               "type" : "esriFieldTypeString",
-              "isNullable" : true,
-              "length" : 25,
-              "precision" : 0,
-              "scale" : 0
+              "alias" : "update_time",
+              "length" : 25
             },
             {
               "name" : "geom",
               "type" : "esriFieldTypeGeometry",
-              "isNullable" : true,
-              "length" : 0,
-              "precision" : 0,
-              "scale" : 0,
+              "alias" : "geom",
               "geometryDef" : {
                 "avgNumPoints" : 0,
                 "geometryType" : "esriGeometryPolygon",
@@ -444,27 +398,14 @@
                 "hasZ" : false,
                 "spatialReference" : {
                   "wkid" : 102100,
-                  "latestWkid" : 3857,
-                  "xyTolerance" : 0.001,
-                  "zTolerance" : 0.001,
-                  "mTolerance" : 0.001,
-                  "falseX" : -20037700,
-                  "falseY" : -30241100,
-                  "xyUnits" : 10000,
-                  "falseZ" : -100000,
-                  "zUnits" : 10000,
-                  "falseM" : -100000,
-                  "mUnits" : 10000
+                  "latestWkid" : 3857
                 }
               }
             },
             {
               "name" : "oid",
               "type" : "esriFieldTypeInteger",
-              "isNullable" : true,
-              "length" : 0,
-              "precision" : 0,
-              "scale" : 0
+              "alias" : "oid"
             }
           ],
           "spatialStorageType" : 8
@@ -475,6 +416,7 @@
       "htmlPopupEnabled" : true,
       "selectable" : true,
       "featureCacheType" : "Session",
+      "displayFilters" : [],
       "displayFiltersType" : "ByScale",
       "featureBlendingMode" : "Alpha",
       "labelClasses" : [
@@ -526,8 +468,7 @@
                   "visible" : true,
                   "splitAfter" : true
                 }
-              ],
-              "trimStackingSeparators" : true
+              ]
             },
             "lineFeatureType" : "General",
             "linePlacementMethod" : "OffsetCurvedFromLine",
@@ -747,39 +688,6 @@
       "type" : "CIMBinaryReference",
       "uRI" : "CIMPATH=Metadata/4075db63627214f834d442a7b40b14ff.xml",
       "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20221014</CreaDate><CreaTime>18283400</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri></metadata>\r\n"
-    }
-  ],
-  "elevationSurfaceLayerDefinitions" : [
-    {
-      "type" : "CIMElevationSurfaceLayer",
-      "name" : "Ground",
-      "uRI" : "CIMPATH=65805ba43aee40c183f4c03d1f8df385.json",
-      "useSourceMetadata" : true,
-      "description" : "Ground",
-      "expanded" : true,
-      "layerType" : "Operational",
-      "showLegends" : false,
-      "visibility" : true,
-      "displayCacheType" : "Permanent",
-      "maxDisplayCacheAge" : 5,
-      "showPopups" : true,
-      "serviceLayerID" : -1,
-      "refreshRate" : -1,
-      "refreshRateUnit" : "esriTimeUnitsSeconds",
-      "blendingMode" : "Alpha",
-      "allowDrapingOnIntegratedMesh" : true,
-      "elevationMode" : "BaseGlobeSurface",
-      "verticalExaggeration" : 1,
-      "color" : {
-        "type" : "CIMRGBColor",
-        "values" : [
-          255,
-          255,
-          255,
-          100
-        ]
-      },
-      "surfaceTINShadingMode" : "Smooth"
     }
   ]
 }

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/replace_route/rfc_based_5day_max_inundation_extent.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/replace_route/rfc_based_5day_max_inundation_extent.yml
@@ -1,5 +1,5 @@
 service: rfc_based_5day_max_inundation_extent
-summary: RFC Based 5-Day Maximum Inundation Forecast
+summary: RFC Based 5-Day Maximum Inundation Forecast (EXPERIMENTAL)
 description: 'Depicts maximum inundation extent over the next 5 days derived from the official River Forecast Center 
   (RFC) forecast routed downstream through the National Water Model (NWM) stream network. Maximum streamflows are 
   available downstream of RFC forecast points whose forecast reaches action status or greater. Updated hourly.'


### PR DESCRIPTION
Added/edited the following labels to the three public FIM layers - mapx and yml files:

ana_inundation_extent:
"Inundation Extent (EXPERIMENTAL)"

mrf_gfs_5day_max_inundation_extent:
"5 Days - Inundation Extent (EXPERIMENTAL)"

rfc_based_5day_max_inundation_extent:
"5 Days - Inundation Extent (EXPERIMENTAL)"
