### PR TITLE
added new cloudwatch group and logging for viz pipeline

### DIFF
--- a/Core/CloudWatch/main.tf
+++ b/Core/CloudWatch/main.tf
@@ -1,0 +1,29 @@
+###############
+## Variables ##
+###############
+
+variable "environment" {
+  description = "Hydrovis environment"
+  type        = string
+}
+
+variable "account_id" {
+  type        = string
+}
+
+variable "region" {
+  description = "Hydrovis region"
+  type        = string
+}
+
+##########################
+## CloudWatch Log Group ##
+##########################
+
+resource "aws_cloudwatch_log_group" "viz_processing_pipeline_log_group" {
+  name = "hv-vpp-${var.environment}-${var.region}-viz-processing-pipeline"
+}
+
+output "viz_processing_pipeline_log_group" {
+  value = aws_cloudwatch_log_group.viz_processing_pipeline_log_group
+}

--- a/Core/LAMBDA/viz_functions/viz_initialize_pipeline/lambda_function.py
+++ b/Core/LAMBDA/viz_functions/viz_initialize_pipeline/lambda_function.py
@@ -122,6 +122,7 @@ def lambda_handler(event, context):
                 short_config = short_config.replace("analysis_assim", "ana").replace("short_range", "srf").replace("medium_range", "mrf").replace("replace_route", "rnr")
                 short_invoke = pipeline.invocation_type.replace("manual", "man").replace("eventbridge", "bdg")
                 pipeline_name = f"{short_invoke}_{short_config}_{ref_time_short}_{datetime.datetime.now().strftime('%d%H%M')}"
+                pipeline_run['logging_info'] = {'Timestamp': int(time.time())*1000}
             
                 client.start_execution(
                     stateMachineArn = step_function_arn,

--- a/Core/StepFunctions/main.tf
+++ b/Core/StepFunctions/main.tf
@@ -73,6 +73,10 @@ variable "fifteen_minute_trigger" {
   })
 }
 
+variable "viz_processing_pipeline_log_group" {
+  type        = string
+}
+
 #########################################
 ##     Replace Route Step Function     ##
 #########################################
@@ -154,6 +158,7 @@ resource "aws_sfn_state_machine" "viz_pipeline_step_function" {
         publish_service_arn  = var.publish_service_arn
         schism_fim_processing_step_function_arn = aws_sfn_state_machine.schism_fim_processing_step_function.arn
         hand_fim_processing_step_function_arn = aws_sfn_state_machine.hand_fim_processing_step_function.arn
+        viz_processing_pipeline_log_group = var.viz_processing_pipeline_log_group
     })
 }
 

--- a/Core/StepFunctions/viz_processing_pipeline.json.tftpl
+++ b/Core/StepFunctions/viz_processing_pipeline.json.tftpl
@@ -1,7 +1,33 @@
 {
   "Comment": "A description of my state machine",
-  "StartAt": "Python Max Flow Processing",
+  "StartAt": "CreateLogStream",
   "States": {
+    "CreateLogStream": {
+      "Type": "Task",
+      "Next": "Step Function Initialized Log",
+      "Parameters": {
+        "LogGroupName": "${viz_processing_pipeline_log_group}",
+        "LogStreamName.$": "$$.Execution.Name"
+      },
+      "Resource": "arn:aws:states:::aws-sdk:cloudwatchlogs:createLogStream",
+      "ResultPath": null
+    },
+    "Step Function Initialized Log": {
+      "Type": "Task",
+      "Next": "Python Max Flow Processing",
+      "Parameters": {
+        "LogEvents": [
+          {
+            "Message.$": "States.Format('\\{\"{}\": 1, \"reference_time\": {}, \"step_finish\": {}, \"pipeline_step\": \"data_prep\"\\}', $.configuration, $.reference_time, $$.State.EnteredTime)",
+            "Timestamp.$": "$.logging_info.Timestamp"
+          }
+        ],
+        "LogGroupName": "${viz_processing_pipeline_log_group}",
+        "LogStreamName.$": "$$.Execution.Name"
+      },
+      "Resource": "arn:aws:states:::aws-sdk:cloudwatchlogs:putLogEvents",
+      "ResultPath": null
+    },
     "Python Max Flow Processing": {
       "Type": "Map",
       "ItemProcessor": {
@@ -47,14 +73,39 @@
           }
         }
       },
-      "Next": "Input Data Groups",
+      "Next": "Python Max Flow Finished Log",
       "ItemsPath": "$.configuration_data_flow.lambda_max_flows",
       "ResultPath": null,
       "ItemSelector": {
         "lambda_max_flow.$": "$$.Map.Item.Value",
         "reference_time.$": "$.reference_time",
         "sql_rename_dict.$": "$.sql_rename_dict"
-      }
+      },
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "Data Prep Failure Log",
+          "ResultPath": "$.error"
+        }
+      ]
+    },
+    "Python Max Flow Finished Log": {
+      "Type": "Task",
+      "Next": "Input Data Groups",
+      "Parameters": {
+        "LogEvents": [
+          {
+            "Message.$": "States.Format('\\{\"{}\": 2, \"reference_time\": {}, \"step_finish\": {}, \"pipeline_step\": \"data_prep\"\\}', $.configuration, $.reference_time, $$.State.EnteredTime)",
+            "Timestamp.$": "$.logging_info.Timestamp"
+          }
+        ],
+        "LogGroupName": "${viz_processing_pipeline_log_group}",
+        "LogStreamName.$": "$$.Execution.Name"
+      },
+      "Resource": "arn:aws:states:::aws-sdk:cloudwatchlogs:putLogEvents",
+      "ResultPath": null
     },
     "Input Data Groups": {
       "Type": "Map",
@@ -215,7 +266,32 @@
         "reference_time.$": "$.reference_time",
         "sql_rename_dict.$": "$.sql_rename_dict"
       },
-      "Next": "DB Max Flows Processing"
+      "Next": "DB Ingest Finished Log",
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "Data Prep Failure Log",
+          "ResultPath": "$.error"
+        }
+      ]
+    },
+    "DB Ingest Finished Log": {
+      "Type": "Task",
+      "Next": "DB Max Flows Processing",
+      "Parameters": {
+        "LogEvents": [
+          {
+            "Message.$": "States.Format('\\{\"{}\": 3, \"reference_time\": {}, \"step_finish\": {}, \"pipeline_step\": \"data_prep\"\\}', $.configuration, $.reference_time, $$.State.EnteredTime)",
+            "Timestamp.$": "$.logging_info.Timestamp"
+          }
+        ],
+        "LogGroupName": "${viz_processing_pipeline_log_group}",
+        "LogStreamName.$": "$$.Execution.Name"
+      },
+      "Resource": "arn:aws:states:::aws-sdk:cloudwatchlogs:putLogEvents",
+      "ResultPath": null
     },
     "DB Max Flows Processing": {
       "Type": "Map",
@@ -268,7 +344,51 @@
         "sql_rename_dict.$": "$.sql_rename_dict"
       },
       "MaxConcurrency": 5,
-      "Next": "Product Processing"
+      "Next": "DB Max Flows Finished Log",
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "Data Prep Failure Log",
+          "ResultPath": "$.error"
+        }
+      ]
+    },
+    "DB Max Flows Finished Log": {
+      "Type": "Task",
+      "Next": "Product Processing",
+      "Parameters": {
+        "LogEvents": [
+          {
+            "Message.$": "States.Format('\\{\"{}\": 4, \"reference_time\": {}, \"step_finish\": {}, \"pipeline_step\": \"data_prep\"\\}', $.configuration, $.reference_time, $$.State.EnteredTime)",
+            "Timestamp.$": "$.logging_info.Timestamp"
+          }
+        ],
+        "LogGroupName": "${viz_processing_pipeline_log_group}",
+        "LogStreamName.$": "$$.Execution.Name"
+      },
+      "Resource": "arn:aws:states:::aws-sdk:cloudwatchlogs:putLogEvents",
+      "ResultPath": null
+    },
+    "Data Prep Failure Log": {
+      "Type": "Task",
+      "Parameters": {
+        "LogEvents": [
+          {
+            "Message.$": "States.Format('\\{\"{}\": -9999, \"reference_time\": {}, \"step_finish\": {}, \"pipeline_step\": \"data_prep\", \"error\": {}\\}', $.product.product, $.reference_time, $$.State.EnteredTime, $.error.Cause)",
+            "Timestamp.$": "$.logging_info.Timestamp"
+          }
+        ],
+        "LogGroupName": "${viz_processing_pipeline_log_group}",
+        "LogStreamName.$": "$$.Execution.Name"
+      },
+      "Resource": "arn:aws:states:::aws-sdk:cloudwatchlogs:putLogEvents",
+      "ResultPath": null,
+      "Next": "Fail (1)"
+    },
+    "Fail (1)": {
+      "Type": "Fail"
     },
     "Product Processing": {
       "Type": "Map",
@@ -297,7 +417,7 @@
                 "Next": "Raster Processing"
               }
             ],
-            "Default": "Product Postprocessing"
+            "Default": "Product Processing Finished Log"
           },
           "Raster Processing": {
             "Type": "Task",
@@ -329,7 +449,16 @@
               }
             ],
             "Next": "Map",
-            "OutputPath": "$.Payload"
+            "OutputPath": "$.Payload",
+            "Catch": [
+              {
+                "ErrorEquals": [
+                  "States.ALL"
+                ],
+                "ResultPath": "$.error",
+                "Next": "Product Processing Failure Log"
+              }
+            ]
           },
           "Map": {
             "Type": "Map",
@@ -367,16 +496,26 @@
               "output_raster.$": "$$.Map.Item.Value",
               "output_bucket.$": "$.output_rasters.output_bucket"
             },
-            "ResultPath": null
+            "ResultPath": null,
+            "Catch": [
+              {
+                "ErrorEquals": [
+                  "States.ALL"
+                ],
+                "Next": "Product Processing Failure Log",
+                "ResultPath": "$.error"
+              }
+            ]
           },
           "Clean Up State Input": {
             "Type": "Pass",
-            "Next": "Product Postprocessing",
+            "Next": "Product Processing Finished Log",
             "Parameters": {
               "job_type.$": "$.job_type",
               "reference_time.$": "$.reference_time",
               "product.$": "$.product",
-              "sql_rename_dict.$": "$.sql_rename_dict"
+              "sql_rename_dict.$": "$.sql_rename_dict",
+              "logging_info.$": "$.logging_info"
             }
           },
           "Product Postprocessing": {
@@ -451,7 +590,7 @@
                 }
               }
             },
-            "Next": "Parallelize Summaries",
+            "Next": "Product Postprocessing Finished Log",
             "ItemsPath": "$.product.postprocess_sql",
             "ItemSelector": {
               "product.$": "$.product",
@@ -460,11 +599,52 @@
               "sql_rename_dict.$": "$.sql_rename_dict",
               "postprocess_sql.$": "$$.Map.Item.Value"
             },
+            "ResultPath": null,
+            "Catch": [
+              {
+                "ErrorEquals": [
+                  "States.ALL"
+                ],
+                "Next": "Product Processing Failure Log",
+                "ResultPath": "$.error"
+              }
+            ]
+          },
+          "Product Processing Failure Log": {
+            "Type": "Task",
+            "Parameters": {
+              "LogEvents": [
+                {
+                  "Message.$": "States.Format('\\{\"{}\": -9999, \"reference_time\": {}, \"step_finish\": {}, \"pipeline_step\": \"product_processing\", \"error\": {}\\}', $.product.product, $.reference_time, $$.State.EnteredTime, $.error.Cause)",
+                  "Timestamp.$": "$.logging_info.Timestamp"
+                }
+              ],
+              "LogGroupName": "${viz_processing_pipeline_log_group}",
+              "LogStreamName.$": "$$.Execution.Name"
+            },
+            "Resource": "arn:aws:states:::aws-sdk:cloudwatchlogs:putLogEvents",
+            "ResultPath": null,
+            "End": true
+          },
+          "Product Postprocessing Finished Log": {
+            "Type": "Task",
+            "Next": "Parallelize Summaries",
+            "Parameters": {
+              "LogEvents": [
+                {
+                  "Message.$": "States.Format('\\{\"{}\": 2, \"reference_time\": {}, \"step_finish\": {}, \"pipeline_step\": \"product_processing\"\\}', $.product.product, $.reference_time, $$.State.EnteredTime)",
+                  "Timestamp.$": "$.logging_info.Timestamp"
+                }
+              ],
+              "LogGroupName": "${viz_processing_pipeline_log_group}",
+              "LogStreamName.$": "$$.Execution.Name"
+            },
+            "Resource": "arn:aws:states:::aws-sdk:cloudwatchlogs:putLogEvents",
             "ResultPath": null
           },
           "FIM Config Processing": {
             "Type": "Map",
-            "Next": "Product Postprocessing",
+            "Next": "Product Processing Finished Log",
             "Iterator": {
               "StartAt": "Fim Config Preprocessing",
               "States": {
@@ -736,11 +916,36 @@
               "job_type.$": "$.job_type",
               "sql_rename_dict.$": "$.sql_rename_dict"
             },
+            "ResultPath": null,
+            "Catch": [
+              {
+                "ErrorEquals": [
+                  "States.ALL"
+                ],
+                "Next": "Product Processing Failure Log",
+                "ResultPath": "$.error"
+              }
+            ]
+          },
+          "Product Processing Finished Log": {
+            "Type": "Task",
+            "Next": "Product Postprocessing",
+            "Parameters": {
+              "LogEvents": [
+                {
+                  "Message.$": "States.Format('\\{\"{}\": 1, \"reference_time\": {}, \"step_finish\": {}, \"pipeline_step\": \"product_processing\"\\}', $.product.product, $.reference_time, $$.State.EnteredTime)",
+                  "Timestamp.$": "$.logging_info.Timestamp"
+                }
+              ],
+              "LogGroupName": "${viz_processing_pipeline_log_group}",
+              "LogStreamName.$": "$$.Execution.Name"
+            },
+            "Resource": "arn:aws:states:::aws-sdk:cloudwatchlogs:putLogEvents",
             "ResultPath": null
           },
           "Parallelize Summaries": {
             "Type": "Map",
-            "Next": "Parallel",
+            "Next": "Product Summaries Finished Log",
             "Iterator": {
               "StartAt": "Postprocess SQL - Summary",
               "States": {
@@ -816,11 +1021,36 @@
               "sql_rename_dict.$": "$.sql_rename_dict",
               "postprocess_summary.$": "$$.Map.Item.Value"
             },
+            "ResultPath": null,
+            "Catch": [
+              {
+                "ErrorEquals": [
+                  "States.ALL"
+                ],
+                "Next": "Product Processing Failure Log",
+                "ResultPath": "$.error"
+              }
+            ]
+          },
+          "Product Summaries Finished Log": {
+            "Type": "Task",
+            "Next": "Parallel",
+            "Parameters": {
+              "LogEvents": [
+                {
+                  "Message.$": "States.Format('\\{\"{}\": 3, \"reference_time\": {}, \"step_finish\": {}, \"pipeline_step\": \"product_processing\"\\}', $.product.product, $.reference_time, $$.State.EnteredTime)",
+                  "Timestamp.$": "$.logging_info.Timestamp"
+                }
+              ],
+              "LogGroupName": "${viz_processing_pipeline_log_group}",
+              "LogStreamName.$": "$$.Execution.Name"
+            },
+            "Resource": "arn:aws:states:::aws-sdk:cloudwatchlogs:putLogEvents",
             "ResultPath": null
           },
           "Parallel": {
             "Type": "Parallel",
-            "Next": "Auto vs. Past Event Run",
+            "Next": "Updating EGIS Data Finished Log",
             "Branches": [
               {
                 "StartAt": "Update EGIS Data - Unstage DB Tables",
@@ -924,6 +1154,31 @@
                 }
               }
             ],
+            "ResultPath": null,
+            "Catch": [
+              {
+                "ErrorEquals": [
+                  "States.ALL"
+                ],
+                "Next": "Product Processing Failure Log",
+                "ResultPath": "$.error"
+              }
+            ]
+          },
+          "Updating EGIS Data Finished Log": {
+            "Type": "Task",
+            "Next": "Auto vs. Past Event Run",
+            "Parameters": {
+              "LogEvents": [
+                {
+                  "Message.$": "States.Format('\\{\"{}\": 4, \"reference_time\": {}, \"step_finish\": {}, \"pipeline_step\": \"product_processing\"\\}', $.product.product, $.reference_time, $$.State.EnteredTime)",
+                  "Timestamp.$": "$.logging_info.Timestamp"
+                }
+              ],
+              "LogGroupName": "${viz_processing_pipeline_log_group}",
+              "LogStreamName.$": "$$.Execution.Name"
+            },
+            "Resource": "arn:aws:states:::aws-sdk:cloudwatchlogs:putLogEvents",
             "ResultPath": null
           },
           "Auto vs. Past Event Run": {
@@ -973,7 +1228,7 @@
                 }
               }
             },
-            "Next": "Pass",
+            "Next": "Services Publishing Finished Log",
             "ItemsPath": "$.product.services",
             "ItemSelector": {
               "product.$": "$.product",
@@ -981,7 +1236,32 @@
               "job_type.$": "$.job_type",
               "sql_rename_dict.$": "$.sql_rename_dict",
               "service.$": "$$.Map.Item.Value"
-            }
+            },
+            "Catch": [
+              {
+                "ErrorEquals": [
+                  "States.ALL"
+                ],
+                "Next": "Product Processing Failure Log",
+                "ResultPath": "$.error"
+              }
+            ]
+          },
+          "Services Publishing Finished Log": {
+            "Type": "Task",
+            "Next": "Pass",
+            "Parameters": {
+              "LogEvents": [
+                {
+                  "Message.$": "States.Format('\\{\"{}\": 5, \"reference_time\": {}, \"step_finish\": {}, \"pipeline_step\": \"product_processing\"\\}', $.product.product, $.reference_time, $$.State.EnteredTime)",
+                  "Timestamp.$": "$.logging_info.Timestamp"
+                }
+              ],
+              "LogGroupName": "${viz_processing_pipeline_log_group}",
+              "LogStreamName.$": "$$.Execution.Name"
+            },
+            "Resource": "arn:aws:states:::aws-sdk:cloudwatchlogs:putLogEvents",
+            "ResultPath": null
           },
           "Pass": {
             "Type": "Pass",
@@ -997,7 +1277,8 @@
         "product.$": "$$.Map.Item.Value",
         "reference_time.$": "$.reference_time",
         "job_type.$": "$.job_type",
-        "sql_rename_dict.$": "$.sql_rename_dict"
+        "sql_rename_dict.$": "$.sql_rename_dict",
+        "logging_info.$": "$.logging_info"
       },
       "ItemsPath": "$.pipeline_products",
       "MaxConcurrency": 15,

--- a/Core/StepFunctions/viz_processing_pipeline.json.tftpl
+++ b/Core/StepFunctions/viz_processing_pipeline.json.tftpl
@@ -1032,9 +1032,20 @@
               }
             ]
           },
+          "Auto vs. Past Event Run": {
+            "Type": "Choice",
+            "Choices": [
+              {
+                "Variable": "$.job_type",
+                "StringEquals": "past_event",
+                "Next": "Pass"
+              }
+            ],
+            "Default": "Parallel"
+          },
           "Product Summaries Finished Log": {
             "Type": "Task",
-            "Next": "Parallel",
+            "Next": "Auto vs. Past Event Run",
             "Parameters": {
               "LogEvents": [
                 {
@@ -1167,7 +1178,7 @@
           },
           "Updating EGIS Data Finished Log": {
             "Type": "Task",
-            "Next": "Auto vs. Past Event Run",
+            "Next": "Service Publishing",
             "Parameters": {
               "LogEvents": [
                 {
@@ -1180,17 +1191,6 @@
             },
             "Resource": "arn:aws:states:::aws-sdk:cloudwatchlogs:putLogEvents",
             "ResultPath": null
-          },
-          "Auto vs. Past Event Run": {
-            "Type": "Choice",
-            "Choices": [
-              {
-                "Variable": "$.job_type",
-                "StringEquals": "past_event",
-                "Next": "Pass"
-              }
-            ],
-            "Default": "Service Publishing"
           },
           "Service Publishing": {
             "Type": "Map",
@@ -1245,7 +1245,8 @@
                 "Next": "Product Processing Failure Log",
                 "ResultPath": "$.error"
               }
-            ]
+            ],
+            "ResultPath": null
           },
           "Services Publishing Finished Log": {
             "Type": "Task",

--- a/Core/StepFunctions/viz_processing_pipeline.json.tftpl
+++ b/Core/StepFunctions/viz_processing_pipeline.json.tftpl
@@ -385,9 +385,9 @@
       },
       "Resource": "arn:aws:states:::aws-sdk:cloudwatchlogs:putLogEvents",
       "ResultPath": null,
-      "Next": "Fail (1)"
+      "Next": "Data Prep Failure"
     },
-    "Fail (1)": {
+    "Data Prep Failure": {
       "Type": "Fail"
     },
     "Product Processing": {
@@ -623,8 +623,11 @@
               "LogStreamName.$": "$$.Execution.Name"
             },
             "Resource": "arn:aws:states:::aws-sdk:cloudwatchlogs:putLogEvents",
-            "ResultPath": null,
-            "End": true
+            "End": true,
+            "ResultSelector": {
+              "success": false
+            },
+            "OutputPath": "$.success"
           },
           "Product Postprocessing Finished Log": {
             "Type": "Task",
@@ -1267,10 +1270,10 @@
           "Pass": {
             "Type": "Pass",
             "End": true,
-            "ResultPath": null,
             "Result": {
-              "ValueEnteredInForm": ""
-            }
+              "success": true
+            },
+            "OutputPath": "$.success"
           }
         }
       },
@@ -1284,9 +1287,26 @@
       "ItemsPath": "$.pipeline_products",
       "MaxConcurrency": 15,
       "ResultSelector": {
-        "error.$": "$[?(@.error)]"
+        "contains_error.$": "States.ArrayContains($, false)"
       },
-      "End": true
+      "Next": "Choice"
+    },
+    "Choice": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.contains_error",
+          "BooleanEquals": true,
+          "Next": "Product Processing Failure"
+        }
+      ],
+      "Default": "Success"
+    },
+    "Product Processing Failure": {
+      "Type": "Fail"
+    },
+    "Success": {
+      "Type": "Succeed"
     }
   },
   "TimeoutSeconds": 4500

--- a/Core/main.tf
+++ b/Core/main.tf
@@ -566,6 +566,14 @@ module "egis-monitor" {
   ec2_kms_key               = module.kms.key_arns["egis"]
 }
 
+module "cloudwatch" {
+  source = "./CloudWatch"
+
+  environment                    = local.env.environment
+  account_id                     = local.env.account_id
+  region                         = local.env.region
+}
+
 ###################### STAGE 4 ###################### (Wait till all other EC2 are initialized and running)
 
 # Viz Lambda Functions
@@ -637,6 +645,7 @@ module "step-functions" {
   email_sns_topics          = module.sns.email_sns_topics
   aws_instances_to_reboot   = [module.rnr.ec2.id]
   fifteen_minute_trigger    = module.eventbridge.fifteen_minute_eventbridge
+  viz_processing_pipeline_log_group = module.cloudwatch.viz_processing_pipeline_log_group.name
 }
 
 # Event Bridge

--- a/Source/Grafana/Dashboards/viz_pipeline_health.json
+++ b/Source/Grafana/Dashboards/viz_pipeline_health.json
@@ -123,7 +123,7 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 20,
+        "w": 24,
         "x": 0,
         "y": 3
       },
@@ -647,31 +647,6 @@
         "uid": "grafana"
       },
       "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 20,
-        "y": 3
-      },
-      "id": 17,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "1 - Step Function Initialized\n<br>\n2 - Python Based Max Flows Finished\n<br>\n3 - Model Data Ingest Finished\n<br>\n4 - Database Based Max Flows Finished",
-        "mode": "markdown"
-      },
-      "pluginVersion": "9.4.7",
-      "title": "Configuration Data Prep Legend",
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "grafana"
-      },
-      "gridPos": {
         "h": 2,
         "w": 24,
         "x": 0,
@@ -1003,7 +978,7 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 20,
+        "w": 17,
         "x": 0,
         "y": 11
       },
@@ -1803,8 +1778,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 4,
-        "x": 20,
+        "w": 3,
+        "x": 17,
         "y": 11
       },
       "id": 20,
@@ -2300,6 +2275,31 @@
         }
       ],
       "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 20,
+        "y": 11
+      },
+      "id": 17,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "1 - Step Function Initialized\n<br>\n2 - Python Based Max Flows Finished\n<br>\n3 - Model Data Ingest Finished\n<br>\n4 - Database Based Max Flows Finished",
+        "mode": "markdown"
+      },
+      "pluginVersion": "9.4.7",
+      "title": "Configuration Data Prep Legend",
+      "type": "text"
     },
     {
       "datasource": {
@@ -4102,7 +4102,7 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 1145
+                "value": 1441
               },
               {
                 "id": "thresholds",
@@ -4126,7 +4126,7 @@
       },
       "gridPos": {
         "h": 6,
-        "w": 20,
+        "w": 24,
         "x": 0,
         "y": 30
       },
@@ -4665,31 +4665,6 @@
         "uid": "grafana"
       },
       "gridPos": {
-        "h": 6,
-        "w": 4,
-        "x": 20,
-        "y": 30
-      },
-      "id": 25,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "1 - Product Processing Finished\n<br>\n2 - Product Postprocessing Finished\n<br>\n3 - Product Summaries Finished\n<br>\n4 - Updating EGIS/Final Finished\n<br>\n5 - Publishing Service Finished",
-        "mode": "markdown"
-      },
-      "pluginVersion": "9.4.7",
-      "title": "Configuration Data Prep Legend",
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "grafana"
-      },
-      "gridPos": {
         "h": 2,
         "w": 24,
         "x": 0,
@@ -4840,12 +4815,24 @@
                 "value": 51
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "logging_status"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 227
+              }
+            ]
           }
         ]
       },
       "gridPos": {
         "h": 6,
-        "w": 24,
+        "w": 20,
         "x": 0,
         "y": 38
       },
@@ -4861,12 +4848,7 @@
           "show": false
         },
         "showHeader": true,
-        "sortBy": [
-          {
-            "desc": true,
-            "displayName": "Reference Time"
-          }
-        ]
+        "sortBy": []
       },
       "pluginVersion": "9.4.7",
       "targets": [
@@ -5543,6 +5525,31 @@
         }
       ],
       "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 20,
+        "y": 38
+      },
+      "id": 25,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "1 - Product Processing Finished\n<br>\n2 - Product Postprocessing Finished\n<br>\n3 - Product Summaries Finished\n<br>\n4 - Updating EGIS/Final Finished\n<br>\n5 - Publishing Service Finished",
+        "mode": "markdown"
+      },
+      "pluginVersion": "9.4.7",
+      "title": "Configuration Data Prep Legend",
+      "type": "text"
     },
     {
       "datasource": {
@@ -15337,6 +15344,6 @@
   "timezone": "browser",
   "title": "HydroVIS Pipeline Health",
   "uid": "AWSStepFn",
-  "version": 64,
+  "version": 67,
   "weekStart": ""
 }

--- a/Source/Grafana/Dashboards/viz_pipeline_health.json
+++ b/Source/Grafana/Dashboards/viz_pipeline_health.json
@@ -159,9 +159,9 @@
           "label": "",
           "logGroups": [
             {
-              "accountId": "799732994462",
-              "arn": "arn:aws:logs:us-east-2:799732994462:log-group:pipeline_monitoring_test:*",
-              "name": "pipeline_monitoring_test"
+              "accountId": "${account_id}",
+              "arn": "${viz_processing_pipeline_log_group_arn}:*",
+              "name": "${viz_processing_pipeline_log_group_name}"
             }
           ],
           "matchExact": true,
@@ -1010,9 +1010,9 @@
           "label": "",
           "logGroups": [
             {
-              "accountId": "799732994462",
-              "arn": "arn:aws:logs:us-east-2:799732994462:log-group:pipeline_monitoring_test:*",
-              "name": "pipeline_monitoring_test"
+              "accountId": "${account_id}",
+              "arn": "${viz_processing_pipeline_log_group_arn}:*",
+              "name": "${viz_processing_pipeline_log_group_name}"
             }
           ],
           "matchExact": true,
@@ -4162,9 +4162,9 @@
           "label": "",
           "logGroups": [
             {
-              "accountId": "799732994462",
-              "arn": "arn:aws:logs:us-east-2:799732994462:log-group:pipeline_monitoring_test:*",
-              "name": "pipeline_monitoring_test"
+              "accountId": "${account_id}",
+              "arn": "${viz_processing_pipeline_log_group_arn}:*",
+              "name": "${viz_processing_pipeline_log_group_name}"
             }
           ],
           "matchExact": true,
@@ -4864,9 +4864,9 @@
           "label": "",
           "logGroups": [
             {
-              "accountId": "799732994462",
-              "arn": "arn:aws:logs:us-east-2:799732994462:log-group:pipeline_monitoring_test:*",
-              "name": "pipeline_monitoring_test"
+              "accountId": "${account_id}",
+              "arn": "${viz_processing_pipeline_log_group_arn}:*",
+              "name": "${viz_processing_pipeline_log_group_name}"
             }
           ],
           "matchExact": true,
@@ -15287,8 +15287,8 @@
       {
         "current": {
           "selected": false,
-          "text": "arn:aws:states:us-east-2:799732994462:stateMachine:hv-vpp-uat-execute-replace-route",
-          "value": "arn:aws:states:us-east-2:799732994462:stateMachine:hv-vpp-uat-execute-replace-route"
+          "text": [],
+          "value": []
         },
         "datasource": {
           "uid": "$datasource"
@@ -15297,7 +15297,7 @@
         "hide": 0,
         "includeAll": false,
         "label": "StateMachineArn",
-        "multi": false,
+        "multi": true,
         "name": "stateMachineArn",
         "options": [],
         "query": "dimension_values($region,AWS/States,ExecutionsFailed,StateMachineArn)",

--- a/Source/Grafana/Dashboards/viz_pipeline_health.json
+++ b/Source/Grafana/Dashboards/viz_pipeline_health.json
@@ -1,0 +1,15342 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Visualize HydroVIS Pipeline Health",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": 10824,
+  "graphTooltip": 0,
+  "id": 15,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 31,
+      "panels": [],
+      "title": "Data Prep Health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 46,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "<center style=\"color:black;background-color:white\"><h1>Data Prep Errors</h1></center>",
+        "mode": "html"
+      },
+      "pluginVersion": "9.4.7",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "cloudwatch",
+        "uid": "kWlGwSB4k"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "mode": "gradient",
+              "type": "color-background"
+            },
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-red",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Reference Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 199
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Error Message"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 1069
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 20,
+        "x": 0,
+        "y": 3
+      },
+      "id": 29,
+      "options": {
+        "footer": {
+          "countRows": false,
+          "enablePagination": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Reference Time"
+          }
+        ]
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "kWlGwSB4k"
+          },
+          "dimensions": {},
+          "expression": "parse @message '{*, \"reference_time\": *, \"step_finish\": *, \"pipeline_step\": *, \"error\": {\"errorMessage\":\"*\",\"errorType\":\"*\",\"requestId\":\"*\",*}}' as logging_status, reference_time, step_finish, pipeline_step, errorMessage, errorType, requestId, remaning_message\n| filter pipeline_step = '\"data_prep\"'",
+          "id": "",
+          "label": "",
+          "logGroups": [
+            {
+              "accountId": "799732994462",
+              "arn": "arn:aws:logs:us-east-2:799732994462:log-group:pipeline_monitoring_test:*",
+              "name": "pipeline_monitoring_test"
+            }
+          ],
+          "matchExact": true,
+          "metricEditorMode": 0,
+          "metricName": "",
+          "metricQueryType": 1,
+          "namespace": "",
+          "period": "",
+          "queryMode": "Logs",
+          "refId": "A",
+          "region": "default",
+          "sql": {
+            "select": {
+              "name": "AVG",
+              "type": "function"
+            }
+          },
+          "statistic": "Average",
+          "statsGroups": []
+        }
+      ],
+      "title": "Data Prep Errors",
+      "transformations": [
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "reference_time"
+              },
+              {
+                "destinationType": "time",
+                "targetField": "step_finish"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "AnA Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "MRF NBM Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "RFC": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "Reference Time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "RnR": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "errorMessage": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "forcing_analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "logging_status": {
+                "aggregations": [
+                  "count"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_alaska_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_coastal_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "reference_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "groupby"
+              },
+              "replace_route": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc_max_forecast": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "step_finish": {
+                "aggregations": [
+                  "count"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "@timestamp": false,
+              "Time": true,
+              "analysis_assim_coastal (last)": true,
+              "analysis_assim_coastal (max)": true,
+              "analysis_assim_coastal_hawaii (last)": true,
+              "analysis_assim_coastal_hawaii (max)": true,
+              "analysis_assim_coastal_puertorico (last)": true,
+              "analysis_assim_coastal_puertorico (max)": true,
+              "forcing_analysis_assim (last)": true,
+              "forcing_analysis_assim (max)": true,
+              "forcing_analysis_assim_alaska (last)": true,
+              "forcing_analysis_assim_alaska (max)": true,
+              "forcing_analysis_assim_hawaii (last)": true,
+              "forcing_analysis_assim_hawaii (max)": true,
+              "forcing_analysis_assim_puertorico (last)": true,
+              "forcing_analysis_assim_puertorico (max)": true,
+              "forcing_medium_range (last)": true,
+              "forcing_medium_range (max)": true,
+              "forcing_medium_range_alaska (last)": true,
+              "forcing_medium_range_alaska (max)": true,
+              "forcing_medium_range_blend (last)": true,
+              "forcing_medium_range_blend (max)": true,
+              "forcing_medium_range_blend_alaska (last)": true,
+              "forcing_medium_range_blend_alaska (max)": true,
+              "forcing_short_range (last)": true,
+              "forcing_short_range (max)": true,
+              "forcing_short_range_alaska (last)": true,
+              "forcing_short_range_alaska (max)": true,
+              "forcing_short_range_hawaii (last)": true,
+              "forcing_short_range_hawaii (max)": true,
+              "forcing_short_range_puertorico (last)": true,
+              "forcing_short_range_puertorico (max)": true,
+              "logging_status": true,
+              "medium_range_blend_coastal (last)": true,
+              "medium_range_blend_coastal (max)": true,
+              "medium_range_coastal_mem1 (last)": true,
+              "medium_range_coastal_mem1 (max)": true,
+              "message": true,
+              "pipeline_name": true,
+              "short_range_coastal (last)": true,
+              "short_range_coastal (max)": true,
+              "short_range_coastal_hawaii (last)": true,
+              "short_range_coastal_hawaii (max)": true,
+              "short_range_coastal_puertorico (last)": true,
+              "short_range_coastal_puertorico (max)": true,
+              "short_range_puertorico (max)": false
+            },
+            "indexByName": {
+              "analysis_assim (max)": 1,
+              "analysis_assim_alaska (max)": 2,
+              "analysis_assim_coastal (max)": 15,
+              "analysis_assim_coastal_hawaii (max)": 16,
+              "analysis_assim_coastal_puertorico (max)": 17,
+              "analysis_assim_hawaii (max)": 3,
+              "analysis_assim_puertorico (max)": 4,
+              "forcing_analysis_assim (max)": 23,
+              "forcing_analysis_assim_alaska (max)": 24,
+              "forcing_analysis_assim_hawaii (max)": 25,
+              "forcing_analysis_assim_puertorico (max)": 26,
+              "forcing_medium_range (max)": 31,
+              "forcing_medium_range_alaska (max)": 32,
+              "forcing_medium_range_blend (max)": 33,
+              "forcing_medium_range_blend_alaska (max)": 34,
+              "forcing_short_range (max)": 27,
+              "forcing_short_range_alaska (max)": 28,
+              "forcing_short_range_hawaii (max)": 29,
+              "forcing_short_range_puertorico (max)": 30,
+              "medium_range_alaska_mem1 (max)": 12,
+              "medium_range_blend (max)": 13,
+              "medium_range_blend_alaska (max)": 14,
+              "medium_range_blend_coastal (max)": 22,
+              "medium_range_coastal_mem1 (max)": 21,
+              "medium_range_mem1 (max)": 11,
+              "reference_time": 0,
+              "replace_route (max)": 10,
+              "rfc (max)": 9,
+              "short_range (max)": 5,
+              "short_range_alaska (max)": 6,
+              "short_range_coastal (max)": 18,
+              "short_range_coastal_hawaii (max)": 19,
+              "short_range_coastal_puertorico (max)": 20,
+              "short_range_hawaii (max)": 7,
+              "short_range_puertorico (max)": 8
+            },
+            "renameByName": {
+              "@timestamp": "Log Time",
+              "analysis_assim (last)": "AnA",
+              "analysis_assim (max)": "AnA",
+              "analysis_assim_alaska (last)": "AnA AK",
+              "analysis_assim_alaska (max)": "AnA AK",
+              "analysis_assim_coastal": "AnA Coastal",
+              "analysis_assim_coastal (last)": "C AnA",
+              "analysis_assim_coastal (max)": "C AnA",
+              "analysis_assim_coastal_hawaii (last)": "C AnA HI",
+              "analysis_assim_coastal_hawaii (max)": "C AnA HI",
+              "analysis_assim_coastal_puertorico (last)": "C AnA PRVI",
+              "analysis_assim_coastal_puertorico (max)": "C AnA PRVI",
+              "analysis_assim_hawaii (last)": "AnA HI",
+              "analysis_assim_hawaii (max)": "AnA HI",
+              "analysis_assim_puertorico (last)": "AnA PRVI",
+              "analysis_assim_puertorico (max)": "AnA PRVI",
+              "errorMessage": "Error Message",
+              "forcing_analysis_assim (last)": "F AnA",
+              "forcing_analysis_assim (max)": "F AnA",
+              "forcing_analysis_assim_alaska (last)": "F AnA AK",
+              "forcing_analysis_assim_alaska (max)": "F AnA AK",
+              "forcing_analysis_assim_hawaii (last)": "F AnA HI",
+              "forcing_analysis_assim_hawaii (max)": "F AnA HI",
+              "forcing_analysis_assim_puertorico (last)": "F AnA PRVI",
+              "forcing_analysis_assim_puertorico (max)": "F AnA PRVI",
+              "forcing_medium_range (last)": "F MRF GFS",
+              "forcing_medium_range (max)": "F MRF GFS",
+              "forcing_medium_range_alaska (last)": "F MRF GFS AK",
+              "forcing_medium_range_alaska (max)": "F MRF GFS AK",
+              "forcing_medium_range_blend (last)": "F MRF NBM",
+              "forcing_medium_range_blend (max)": "F MRF NBM",
+              "forcing_medium_range_blend_alaska (last)": "F MRF NBM AK",
+              "forcing_medium_range_blend_alaska (max)": "F MRF NBM AK",
+              "forcing_short_range (last)": "F SRF",
+              "forcing_short_range (max)": "F SRF",
+              "forcing_short_range_alaska (last)": "F SRF AK",
+              "forcing_short_range_alaska (max)": "F SRF AK",
+              "forcing_short_range_hawaii (last)": "F SRF HI",
+              "forcing_short_range_hawaii (max)": "F SRF HI",
+              "forcing_short_range_puertorico (last)": "F SRF PRVI",
+              "forcing_short_range_puertorico (max)": "F SRF PRVI",
+              "logging_status": "",
+              "logging_status (count)": "Number of Affect Services",
+              "medium_range_alaska_mem1 (last)": "MRF GFS AK",
+              "medium_range_alaska_mem1 (max)": "MRF GFS AK",
+              "medium_range_blend (last)": "MRF NBM",
+              "medium_range_blend (max)": "MRF NBM",
+              "medium_range_blend_alaska (last)": "MRF NBM AK",
+              "medium_range_blend_alaska (max)": "MRF NBM AK",
+              "medium_range_blend_coastal": "MRF NBM Coastal",
+              "medium_range_blend_coastal (last)": "C MRF NBM",
+              "medium_range_blend_coastal (max)": "C MRF NBM",
+              "medium_range_coastal_mem1 (last)": "C MRF GFS",
+              "medium_range_coastal_mem1 (max)": "C MRF GFS",
+              "medium_range_mem1 (last)": "MRF GFS",
+              "medium_range_mem1 (max)": "MRF GFS",
+              "reference_time": "Reference Time",
+              "replace_route": "RnR",
+              "replace_route (last)": "RnR",
+              "replace_route (max)": "RnR",
+              "rfc": "RFC",
+              "rfc (last)": "RFC",
+              "rfc (max)": "RFC",
+              "rfc_max_forecast (max)": "RFC Max Forecast",
+              "short_range (last)": "SRF",
+              "short_range (max)": "SRF",
+              "short_range_alaska (last)": "SRF AK",
+              "short_range_alaska (max)": "SRF AK",
+              "short_range_coastal (last)": "C SRF",
+              "short_range_coastal (max)": "C SRF",
+              "short_range_coastal_hawaii (last)": "C SRF HI",
+              "short_range_coastal_hawaii (max)": "C SRF HI",
+              "short_range_coastal_puertorico (last)": "C SRF PRVI",
+              "short_range_coastal_puertorico (max)": "C SRF PRVI",
+              "short_range_hawaii (last)": "SRF HI",
+              "short_range_hawaii (max)": "SRF HI",
+              "short_range_puertorico (last)": "SRF PRVI",
+              "short_range_puertorico (max)": "SRF PRVI",
+              "step_finish": "Step Finish Time",
+              "step_finish (count)": "Affected Services"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 20,
+        "y": 3
+      },
+      "id": 17,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "1 - Step Function Initialized\n<br>\n2 - Python Based Max Flows Finished\n<br>\n3 - Model Data Ingest Finished\n<br>\n4 - Database Based Max Flows Finished",
+        "mode": "markdown"
+      },
+      "pluginVersion": "9.4.7",
+      "title": "Configuration Data Prep Legend",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 48,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "<center style=\"color:black;background-color:white\"><h1>Data Prep Pipeline Health</h1></center>",
+        "mode": "html"
+      },
+      "pluginVersion": "9.4.7",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "cloudwatch",
+        "uid": "kWlGwSB4k"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "mode": "basic",
+              "type": "color-background"
+            },
+            "filterable": false,
+            "inspect": false,
+            "width": 20
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#dcdcdc",
+                "value": null
+              },
+              {
+                "color": "#c6dbef",
+                "value": 1
+              },
+              {
+                "color": "#6baed6",
+                "value": 2
+              },
+              {
+                "color": "#2171b5",
+                "value": 3
+              },
+              {
+                "color": "dark-green",
+                "value": 4
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "reference_time"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "transparent",
+                      "value": null
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AnA HI"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 68
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AnA PRVI"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 83
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AnA AK"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 69
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SRF AK"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 68
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MRF NBM AK"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 110
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MRF GFS"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 79
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MRF NBM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 83
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SRF PRVI"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 81
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SRF HI"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 65
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Reference Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 170
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MRF GFS AK"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 104
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "message"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 156
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "step_finish"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 215
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RnR (max)"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 94
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AnA Coastal (max)"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 101
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RFC"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 50
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RnR"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 52
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AnA Coastal"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 96
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MRF NBM Coastal"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 140
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "logging_status"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 377
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 20,
+        "x": 0,
+        "y": 11
+      },
+      "id": 15,
+      "options": {
+        "footer": {
+          "countRows": false,
+          "enablePagination": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "kWlGwSB4k"
+          },
+          "dimensions": {},
+          "expression": "parse @message '{*, \"reference_time\": *, \"step_finish\": *, \"pipeline_step\": *}' as logging_status, reference_time, step_finish, pipeline_step\n| filter pipeline_step = '\"data_prep\"'",
+          "hide": false,
+          "id": "",
+          "label": "",
+          "logGroups": [
+            {
+              "accountId": "799732994462",
+              "arn": "arn:aws:logs:us-east-2:799732994462:log-group:pipeline_monitoring_test:*",
+              "name": "pipeline_monitoring_test"
+            }
+          ],
+          "matchExact": true,
+          "metricEditorMode": 0,
+          "metricName": "",
+          "metricQueryType": 0,
+          "namespace": "",
+          "period": "",
+          "queryMode": "Logs",
+          "refId": "max-values",
+          "region": "$region",
+          "sqlExpression": "",
+          "statistic": "Average",
+          "statsGroups": []
+        }
+      ],
+      "title": "Channel Configuration Data Prep",
+      "transformations": [
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"rfc\": *"
+                  }
+                },
+                "fieldName": "logging_status"
+              }
+            ],
+            "match": "any",
+            "type": "exclude"
+          }
+        },
+        {
+          "id": "extractFields",
+          "options": {
+            "format": "auto",
+            "jsonPaths": [
+              {
+                "path": ""
+              }
+            ],
+            "keepTime": false,
+            "replace": false,
+            "source": "logging_status"
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "reference_time"
+              },
+              {
+                "destinationType": "time",
+                "targetField": "step_finish"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "AnA Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "MRF NBM Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "RFC": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "Reference Time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "RnR": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "analysis_assim_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "analysis_assim_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "forcing_analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "forcing_analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "forcing_analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "forcing_medium_range": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "forcing_medium_range_alaska": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "forcing_medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "forcing_medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "forcing_short_range": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "forcing_short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "forcing_short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "forcing_short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_alaska_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_coastal_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "reference_time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "replace_route": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "short_range_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "short_range_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              }
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "@timestamp": false,
+              "Time": true,
+              "analysis_assim_coastal (last)": true,
+              "analysis_assim_coastal (max)": true,
+              "analysis_assim_coastal_hawaii (last)": true,
+              "analysis_assim_coastal_hawaii (max)": true,
+              "analysis_assim_coastal_puertorico (last)": true,
+              "analysis_assim_coastal_puertorico (max)": true,
+              "forcing_analysis_assim (last)": true,
+              "forcing_analysis_assim (max)": true,
+              "forcing_analysis_assim_alaska (last)": true,
+              "forcing_analysis_assim_alaska (max)": true,
+              "forcing_analysis_assim_hawaii (last)": true,
+              "forcing_analysis_assim_hawaii (max)": true,
+              "forcing_analysis_assim_puertorico (last)": true,
+              "forcing_analysis_assim_puertorico (max)": true,
+              "forcing_medium_range (last)": true,
+              "forcing_medium_range (max)": true,
+              "forcing_medium_range_alaska (last)": true,
+              "forcing_medium_range_alaska (max)": true,
+              "forcing_medium_range_blend (last)": true,
+              "forcing_medium_range_blend (max)": true,
+              "forcing_medium_range_blend_alaska (last)": true,
+              "forcing_medium_range_blend_alaska (max)": true,
+              "forcing_short_range (last)": true,
+              "forcing_short_range (max)": true,
+              "forcing_short_range_alaska (last)": true,
+              "forcing_short_range_alaska (max)": true,
+              "forcing_short_range_hawaii (last)": true,
+              "forcing_short_range_hawaii (max)": true,
+              "forcing_short_range_puertorico (last)": true,
+              "forcing_short_range_puertorico (max)": true,
+              "logging_status": true,
+              "medium_range_blend_coastal (last)": true,
+              "medium_range_blend_coastal (max)": true,
+              "medium_range_coastal_mem1 (last)": true,
+              "medium_range_coastal_mem1 (max)": true,
+              "message": true,
+              "pipeline_name": true,
+              "short_range_coastal (last)": true,
+              "short_range_coastal (max)": true,
+              "short_range_coastal_hawaii (last)": true,
+              "short_range_coastal_hawaii (max)": true,
+              "short_range_coastal_puertorico (last)": true,
+              "short_range_coastal_puertorico (max)": true,
+              "short_range_puertorico (max)": false
+            },
+            "indexByName": {
+              "analysis_assim (max)": 1,
+              "analysis_assim_alaska (max)": 2,
+              "analysis_assim_coastal (max)": 15,
+              "analysis_assim_coastal_hawaii (max)": 16,
+              "analysis_assim_coastal_puertorico (max)": 17,
+              "analysis_assim_hawaii (max)": 3,
+              "analysis_assim_puertorico (max)": 4,
+              "forcing_analysis_assim (max)": 23,
+              "forcing_analysis_assim_alaska (max)": 24,
+              "forcing_analysis_assim_hawaii (max)": 25,
+              "forcing_analysis_assim_puertorico (max)": 26,
+              "forcing_medium_range (max)": 31,
+              "forcing_medium_range_alaska (max)": 32,
+              "forcing_medium_range_blend (max)": 33,
+              "forcing_medium_range_blend_alaska (max)": 34,
+              "forcing_short_range (max)": 27,
+              "forcing_short_range_alaska (max)": 28,
+              "forcing_short_range_hawaii (max)": 29,
+              "forcing_short_range_puertorico (max)": 30,
+              "medium_range_alaska_mem1 (max)": 12,
+              "medium_range_blend (max)": 13,
+              "medium_range_blend_alaska (max)": 14,
+              "medium_range_blend_coastal (max)": 22,
+              "medium_range_coastal_mem1 (max)": 21,
+              "medium_range_mem1 (max)": 11,
+              "reference_time": 0,
+              "replace_route (max)": 10,
+              "rfc (max)": 9,
+              "short_range (max)": 5,
+              "short_range_alaska (max)": 6,
+              "short_range_coastal (max)": 18,
+              "short_range_coastal_hawaii (max)": 19,
+              "short_range_coastal_puertorico (max)": 20,
+              "short_range_hawaii (max)": 7,
+              "short_range_puertorico (max)": 8
+            },
+            "renameByName": {
+              "@timestamp": "Log Time",
+              "analysis_assim (last)": "AnA",
+              "analysis_assim (max)": "AnA",
+              "analysis_assim_alaska (last)": "AnA AK",
+              "analysis_assim_alaska (max)": "AnA AK",
+              "analysis_assim_coastal": "AnA Coastal",
+              "analysis_assim_coastal (last)": "C AnA",
+              "analysis_assim_coastal (max)": "C AnA",
+              "analysis_assim_coastal_hawaii (last)": "C AnA HI",
+              "analysis_assim_coastal_hawaii (max)": "C AnA HI",
+              "analysis_assim_coastal_puertorico (last)": "C AnA PRVI",
+              "analysis_assim_coastal_puertorico (max)": "C AnA PRVI",
+              "analysis_assim_hawaii (last)": "AnA HI",
+              "analysis_assim_hawaii (max)": "AnA HI",
+              "analysis_assim_puertorico (last)": "AnA PRVI",
+              "analysis_assim_puertorico (max)": "AnA PRVI",
+              "forcing_analysis_assim (last)": "F AnA",
+              "forcing_analysis_assim (max)": "F AnA",
+              "forcing_analysis_assim_alaska (last)": "F AnA AK",
+              "forcing_analysis_assim_alaska (max)": "F AnA AK",
+              "forcing_analysis_assim_hawaii (last)": "F AnA HI",
+              "forcing_analysis_assim_hawaii (max)": "F AnA HI",
+              "forcing_analysis_assim_puertorico (last)": "F AnA PRVI",
+              "forcing_analysis_assim_puertorico (max)": "F AnA PRVI",
+              "forcing_medium_range (last)": "F MRF GFS",
+              "forcing_medium_range (max)": "F MRF GFS",
+              "forcing_medium_range_alaska (last)": "F MRF GFS AK",
+              "forcing_medium_range_alaska (max)": "F MRF GFS AK",
+              "forcing_medium_range_blend (last)": "F MRF NBM",
+              "forcing_medium_range_blend (max)": "F MRF NBM",
+              "forcing_medium_range_blend_alaska (last)": "F MRF NBM AK",
+              "forcing_medium_range_blend_alaska (max)": "F MRF NBM AK",
+              "forcing_short_range (last)": "F SRF",
+              "forcing_short_range (max)": "F SRF",
+              "forcing_short_range_alaska (last)": "F SRF AK",
+              "forcing_short_range_alaska (max)": "F SRF AK",
+              "forcing_short_range_hawaii (last)": "F SRF HI",
+              "forcing_short_range_hawaii (max)": "F SRF HI",
+              "forcing_short_range_puertorico (last)": "F SRF PRVI",
+              "forcing_short_range_puertorico (max)": "F SRF PRVI",
+              "logging_status": "",
+              "medium_range_alaska_mem1 (last)": "MRF GFS AK",
+              "medium_range_alaska_mem1 (max)": "MRF GFS AK",
+              "medium_range_blend (last)": "MRF NBM",
+              "medium_range_blend (max)": "MRF NBM",
+              "medium_range_blend_alaska (last)": "MRF NBM AK",
+              "medium_range_blend_alaska (max)": "MRF NBM AK",
+              "medium_range_blend_coastal": "MRF NBM Coastal",
+              "medium_range_blend_coastal (last)": "C MRF NBM",
+              "medium_range_blend_coastal (max)": "C MRF NBM",
+              "medium_range_coastal_mem1 (last)": "C MRF GFS",
+              "medium_range_coastal_mem1 (max)": "C MRF GFS",
+              "medium_range_mem1 (last)": "MRF GFS",
+              "medium_range_mem1 (max)": "MRF GFS",
+              "reference_time": "Reference Time",
+              "replace_route": "RnR",
+              "replace_route (last)": "RnR",
+              "replace_route (max)": "RnR",
+              "rfc": "RFC",
+              "rfc (last)": "RFC",
+              "rfc (max)": "RFC",
+              "short_range (last)": "SRF",
+              "short_range (max)": "SRF",
+              "short_range_alaska (last)": "SRF AK",
+              "short_range_alaska (max)": "SRF AK",
+              "short_range_coastal (last)": "C SRF",
+              "short_range_coastal (max)": "C SRF",
+              "short_range_coastal_hawaii (last)": "C SRF HI",
+              "short_range_coastal_hawaii (max)": "C SRF HI",
+              "short_range_coastal_puertorico (last)": "C SRF PRVI",
+              "short_range_coastal_puertorico (max)": "C SRF PRVI",
+              "short_range_hawaii (last)": "SRF HI",
+              "short_range_hawaii (max)": "SRF HI",
+              "short_range_puertorico (last)": "SRF PRVI",
+              "short_range_puertorico (max)": "SRF PRVI",
+              "step_finish": "Step Finish Time"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "mode": "basic",
+              "type": "color-background"
+            },
+            "filterable": false,
+            "inspect": false,
+            "width": 20
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#dcdcdc",
+                "value": null
+              },
+              {
+                "color": "#c6dbef",
+                "value": 1
+              },
+              {
+                "color": "#6baed6",
+                "value": 2
+              },
+              {
+                "color": "#2171b5",
+                "value": 3
+              },
+              {
+                "color": "dark-green",
+                "value": 4
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "reference_time"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "transparent",
+                      "value": null
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AnA HI"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 68
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AnA PRVI"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 83
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AnA AK"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 69
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SRF AK"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 68
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MRF NBM AK"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 110
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MRF GFS"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 79
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MRF NBM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 83
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SRF PRVI"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 81
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SRF HI"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 65
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Reference Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 170
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MRF GFS AK"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 104
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "message"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 156
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "step_finish"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 215
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RnR (max)"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 94
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AnA Coastal (max)"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 101
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RFC"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 50
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RnR"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 52
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AnA Coastal"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 96
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MRF NBM Coastal"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 140
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 20,
+        "y": 11
+      },
+      "id": 20,
+      "options": {
+        "footer": {
+          "countRows": false,
+          "enablePagination": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Reference Time"
+          }
+        ]
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 15,
+          "refId": "A"
+        }
+      ],
+      "title": "Channel Configuration Data Prep",
+      "transformations": [
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"rfc\": *"
+                  }
+                },
+                "fieldName": "logging_status"
+              }
+            ],
+            "match": "any",
+            "type": "include"
+          }
+        },
+        {
+          "id": "extractFields",
+          "options": {
+            "format": "auto",
+            "jsonPaths": [
+              {
+                "path": ""
+              }
+            ],
+            "keepTime": false,
+            "replace": false,
+            "source": "logging_status"
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "reference_time"
+              },
+              {
+                "destinationType": "time",
+                "targetField": "step_finish"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "AnA Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "MRF NBM Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "RFC": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "Reference Time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "RnR": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_alaska_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_coastal_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "reference_time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "replace_route": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              }
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "@timestamp": false,
+              "Time": true,
+              "analysis_assim_coastal (last)": true,
+              "analysis_assim_coastal (max)": true,
+              "analysis_assim_coastal_hawaii (last)": true,
+              "analysis_assim_coastal_hawaii (max)": true,
+              "analysis_assim_coastal_puertorico (last)": true,
+              "analysis_assim_coastal_puertorico (max)": true,
+              "forcing_analysis_assim (last)": true,
+              "forcing_analysis_assim (max)": true,
+              "forcing_analysis_assim_alaska (last)": true,
+              "forcing_analysis_assim_alaska (max)": true,
+              "forcing_analysis_assim_hawaii (last)": true,
+              "forcing_analysis_assim_hawaii (max)": true,
+              "forcing_analysis_assim_puertorico (last)": true,
+              "forcing_analysis_assim_puertorico (max)": true,
+              "forcing_medium_range (last)": true,
+              "forcing_medium_range (max)": true,
+              "forcing_medium_range_alaska (last)": true,
+              "forcing_medium_range_alaska (max)": true,
+              "forcing_medium_range_blend (last)": true,
+              "forcing_medium_range_blend (max)": true,
+              "forcing_medium_range_blend_alaska (last)": true,
+              "forcing_medium_range_blend_alaska (max)": true,
+              "forcing_short_range (last)": true,
+              "forcing_short_range (max)": true,
+              "forcing_short_range_alaska (last)": true,
+              "forcing_short_range_alaska (max)": true,
+              "forcing_short_range_hawaii (last)": true,
+              "forcing_short_range_hawaii (max)": true,
+              "forcing_short_range_puertorico (last)": true,
+              "forcing_short_range_puertorico (max)": true,
+              "logging_status": true,
+              "medium_range_blend_coastal (last)": true,
+              "medium_range_blend_coastal (max)": true,
+              "medium_range_coastal_mem1 (last)": true,
+              "medium_range_coastal_mem1 (max)": true,
+              "message": true,
+              "pipeline_name": true,
+              "short_range_coastal (last)": true,
+              "short_range_coastal (max)": true,
+              "short_range_coastal_hawaii (last)": true,
+              "short_range_coastal_hawaii (max)": true,
+              "short_range_coastal_puertorico (last)": true,
+              "short_range_coastal_puertorico (max)": true,
+              "short_range_puertorico (max)": false
+            },
+            "indexByName": {
+              "analysis_assim (max)": 1,
+              "analysis_assim_alaska (max)": 2,
+              "analysis_assim_coastal (max)": 15,
+              "analysis_assim_coastal_hawaii (max)": 16,
+              "analysis_assim_coastal_puertorico (max)": 17,
+              "analysis_assim_hawaii (max)": 3,
+              "analysis_assim_puertorico (max)": 4,
+              "forcing_analysis_assim (max)": 23,
+              "forcing_analysis_assim_alaska (max)": 24,
+              "forcing_analysis_assim_hawaii (max)": 25,
+              "forcing_analysis_assim_puertorico (max)": 26,
+              "forcing_medium_range (max)": 31,
+              "forcing_medium_range_alaska (max)": 32,
+              "forcing_medium_range_blend (max)": 33,
+              "forcing_medium_range_blend_alaska (max)": 34,
+              "forcing_short_range (max)": 27,
+              "forcing_short_range_alaska (max)": 28,
+              "forcing_short_range_hawaii (max)": 29,
+              "forcing_short_range_puertorico (max)": 30,
+              "medium_range_alaska_mem1 (max)": 12,
+              "medium_range_blend (max)": 13,
+              "medium_range_blend_alaska (max)": 14,
+              "medium_range_blend_coastal (max)": 22,
+              "medium_range_coastal_mem1 (max)": 21,
+              "medium_range_mem1 (max)": 11,
+              "reference_time": 0,
+              "replace_route (max)": 10,
+              "rfc (max)": 9,
+              "short_range (max)": 5,
+              "short_range_alaska (max)": 6,
+              "short_range_coastal (max)": 18,
+              "short_range_coastal_hawaii (max)": 19,
+              "short_range_coastal_puertorico (max)": 20,
+              "short_range_hawaii (max)": 7,
+              "short_range_puertorico (max)": 8
+            },
+            "renameByName": {
+              "@timestamp": "Log Time",
+              "analysis_assim (last)": "AnA",
+              "analysis_assim (max)": "AnA",
+              "analysis_assim_alaska (last)": "AnA AK",
+              "analysis_assim_alaska (max)": "AnA AK",
+              "analysis_assim_coastal": "AnA Coastal",
+              "analysis_assim_coastal (last)": "C AnA",
+              "analysis_assim_coastal (max)": "C AnA",
+              "analysis_assim_coastal_hawaii (last)": "C AnA HI",
+              "analysis_assim_coastal_hawaii (max)": "C AnA HI",
+              "analysis_assim_coastal_puertorico (last)": "C AnA PRVI",
+              "analysis_assim_coastal_puertorico (max)": "C AnA PRVI",
+              "analysis_assim_hawaii (last)": "AnA HI",
+              "analysis_assim_hawaii (max)": "AnA HI",
+              "analysis_assim_puertorico (last)": "AnA PRVI",
+              "analysis_assim_puertorico (max)": "AnA PRVI",
+              "forcing_analysis_assim (last)": "F AnA",
+              "forcing_analysis_assim (max)": "F AnA",
+              "forcing_analysis_assim_alaska (last)": "F AnA AK",
+              "forcing_analysis_assim_alaska (max)": "F AnA AK",
+              "forcing_analysis_assim_hawaii (last)": "F AnA HI",
+              "forcing_analysis_assim_hawaii (max)": "F AnA HI",
+              "forcing_analysis_assim_puertorico (last)": "F AnA PRVI",
+              "forcing_analysis_assim_puertorico (max)": "F AnA PRVI",
+              "forcing_medium_range (last)": "F MRF GFS",
+              "forcing_medium_range (max)": "F MRF GFS",
+              "forcing_medium_range_alaska (last)": "F MRF GFS AK",
+              "forcing_medium_range_alaska (max)": "F MRF GFS AK",
+              "forcing_medium_range_blend (last)": "F MRF NBM",
+              "forcing_medium_range_blend (max)": "F MRF NBM",
+              "forcing_medium_range_blend_alaska (last)": "F MRF NBM AK",
+              "forcing_medium_range_blend_alaska (max)": "F MRF NBM AK",
+              "forcing_short_range (last)": "F SRF",
+              "forcing_short_range (max)": "F SRF",
+              "forcing_short_range_alaska (last)": "F SRF AK",
+              "forcing_short_range_alaska (max)": "F SRF AK",
+              "forcing_short_range_hawaii (last)": "F SRF HI",
+              "forcing_short_range_hawaii (max)": "F SRF HI",
+              "forcing_short_range_puertorico (last)": "F SRF PRVI",
+              "forcing_short_range_puertorico (max)": "F SRF PRVI",
+              "logging_status": "",
+              "medium_range_alaska_mem1 (last)": "MRF GFS AK",
+              "medium_range_alaska_mem1 (max)": "MRF GFS AK",
+              "medium_range_blend (last)": "MRF NBM",
+              "medium_range_blend (max)": "MRF NBM",
+              "medium_range_blend_alaska (last)": "MRF NBM AK",
+              "medium_range_blend_alaska (max)": "MRF NBM AK",
+              "medium_range_blend_coastal": "MRF NBM Coastal",
+              "medium_range_blend_coastal (last)": "C MRF NBM",
+              "medium_range_blend_coastal (max)": "C MRF NBM",
+              "medium_range_coastal_mem1 (last)": "C MRF GFS",
+              "medium_range_coastal_mem1 (max)": "C MRF GFS",
+              "medium_range_mem1 (last)": "MRF GFS",
+              "medium_range_mem1 (max)": "MRF GFS",
+              "reference_time": "Reference Time",
+              "replace_route": "RnR",
+              "replace_route (last)": "RnR",
+              "replace_route (max)": "RnR",
+              "rfc": "RFC",
+              "rfc (last)": "RFC",
+              "rfc (max)": "RFC",
+              "short_range (last)": "SRF",
+              "short_range (max)": "SRF",
+              "short_range_alaska (last)": "SRF AK",
+              "short_range_alaska (max)": "SRF AK",
+              "short_range_coastal (last)": "C SRF",
+              "short_range_coastal (max)": "C SRF",
+              "short_range_coastal_hawaii (last)": "C SRF HI",
+              "short_range_coastal_hawaii (max)": "C SRF HI",
+              "short_range_coastal_puertorico (last)": "C SRF PRVI",
+              "short_range_coastal_puertorico (max)": "C SRF PRVI",
+              "short_range_hawaii (last)": "SRF HI",
+              "short_range_hawaii (max)": "SRF HI",
+              "short_range_puertorico (last)": "SRF PRVI",
+              "short_range_puertorico (max)": "SRF PRVI",
+              "step_finish": "Step Finish Time"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "mode": "basic",
+              "type": "color-background"
+            },
+            "filterable": false,
+            "inspect": false,
+            "width": 20
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#dcdcdc",
+                "value": null
+              },
+              {
+                "color": "#c6dbef",
+                "value": 1
+              },
+              {
+                "color": "#6baed6",
+                "value": 2
+              },
+              {
+                "color": "#2171b5",
+                "value": 3
+              },
+              {
+                "color": "dark-green",
+                "value": 4
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "reference_time"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "transparent",
+                      "value": null
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AnA HI"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 68
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AnA PRVI"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 83
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AnA AK"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 69
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SRF AK"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 68
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MRF NBM AK"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 110
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MRF GFS"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 79
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MRF NBM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 83
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SRF PRVI"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 81
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SRF HI"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 65
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Reference Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 169
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MRF GFS AK"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 104
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "message"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 156
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "step_finish"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 215
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RnR (max)"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 94
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AnA Coastal (max)"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 101
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RFC"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 50
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RnR"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 52
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AnA Coastal"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 96
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MRF NBM Coastal"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 140
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 14,
+        "x": 0,
+        "y": 19
+      },
+      "id": 18,
+      "options": {
+        "footer": {
+          "countRows": false,
+          "enablePagination": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Reference Time"
+          }
+        ]
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 15,
+          "refId": "A"
+        }
+      ],
+      "title": "Forcing Configuration Data Prep",
+      "transformations": [
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"rfc\": *"
+                  }
+                },
+                "fieldName": "logging_status"
+              }
+            ],
+            "match": "any",
+            "type": "exclude"
+          }
+        },
+        {
+          "id": "extractFields",
+          "options": {
+            "format": "auto",
+            "jsonPaths": [
+              {
+                "path": ""
+              }
+            ],
+            "keepTime": false,
+            "replace": false,
+            "source": "logging_status"
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "reference_time"
+              },
+              {
+                "destinationType": "time",
+                "targetField": "step_finish"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "AnA Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "MRF NBM Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "RFC": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "Reference Time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "RnR": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "analysis_assim_coastal": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "analysis_assim_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "analysis_assim_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "forcing_analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_alaska_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_coastal_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "reference_time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "replace_route": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "rfc": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "short_range_coastal": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "short_range_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "short_range_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              }
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "@timestamp": false,
+              "Time": true,
+              "analysis_assim (max)": true,
+              "analysis_assim_alaska (max)": true,
+              "analysis_assim_coastal (last)": true,
+              "analysis_assim_coastal (max)": true,
+              "analysis_assim_coastal_hawaii (last)": true,
+              "analysis_assim_coastal_hawaii (max)": true,
+              "analysis_assim_coastal_puertorico (last)": true,
+              "analysis_assim_coastal_puertorico (max)": true,
+              "analysis_assim_hawaii (max)": true,
+              "analysis_assim_puertorico (max)": true,
+              "forcing_analysis_assim (last)": true,
+              "forcing_analysis_assim (max)": false,
+              "forcing_analysis_assim_alaska (last)": true,
+              "forcing_analysis_assim_alaska (max)": false,
+              "forcing_analysis_assim_hawaii (last)": true,
+              "forcing_analysis_assim_hawaii (max)": false,
+              "forcing_analysis_assim_puertorico (last)": true,
+              "forcing_analysis_assim_puertorico (max)": false,
+              "forcing_medium_range (last)": true,
+              "forcing_medium_range (max)": false,
+              "forcing_medium_range_alaska (last)": true,
+              "forcing_medium_range_alaska (max)": false,
+              "forcing_medium_range_blend (last)": true,
+              "forcing_medium_range_blend (max)": false,
+              "forcing_medium_range_blend_alaska (last)": true,
+              "forcing_medium_range_blend_alaska (max)": false,
+              "forcing_short_range (last)": true,
+              "forcing_short_range (max)": false,
+              "forcing_short_range_alaska (last)": true,
+              "forcing_short_range_alaska (max)": false,
+              "forcing_short_range_hawaii (last)": true,
+              "forcing_short_range_hawaii (max)": false,
+              "forcing_short_range_puertorico (last)": true,
+              "forcing_short_range_puertorico (max)": false,
+              "logging_status": true,
+              "medium_range_alaska_mem1 (max)": true,
+              "medium_range_blend (max)": true,
+              "medium_range_blend_alaska (max)": true,
+              "medium_range_blend_coastal (last)": true,
+              "medium_range_blend_coastal (max)": true,
+              "medium_range_coastal_mem1 (last)": true,
+              "medium_range_coastal_mem1 (max)": true,
+              "medium_range_mem1 (max)": true,
+              "message": true,
+              "pipeline_name": true,
+              "replace_route (max)": true,
+              "rfc (max)": true,
+              "short_range (max)": true,
+              "short_range_alaska (max)": true,
+              "short_range_coastal (last)": true,
+              "short_range_coastal (max)": true,
+              "short_range_coastal_hawaii (last)": true,
+              "short_range_coastal_hawaii (max)": true,
+              "short_range_coastal_puertorico (last)": true,
+              "short_range_coastal_puertorico (max)": true,
+              "short_range_hawaii (max)": true,
+              "short_range_puertorico (max)": true
+            },
+            "indexByName": {
+              "analysis_assim (max)": 1,
+              "analysis_assim_alaska (max)": 2,
+              "analysis_assim_coastal (max)": 15,
+              "analysis_assim_coastal_hawaii (max)": 16,
+              "analysis_assim_coastal_puertorico (max)": 17,
+              "analysis_assim_hawaii (max)": 3,
+              "analysis_assim_puertorico (max)": 4,
+              "forcing_analysis_assim (max)": 23,
+              "forcing_analysis_assim_alaska (max)": 24,
+              "forcing_analysis_assim_hawaii (max)": 25,
+              "forcing_analysis_assim_puertorico (max)": 26,
+              "forcing_medium_range (max)": 31,
+              "forcing_medium_range_alaska (max)": 32,
+              "forcing_medium_range_blend (max)": 33,
+              "forcing_medium_range_blend_alaska (max)": 34,
+              "forcing_short_range (max)": 27,
+              "forcing_short_range_alaska (max)": 28,
+              "forcing_short_range_hawaii (max)": 29,
+              "forcing_short_range_puertorico (max)": 30,
+              "medium_range_alaska_mem1 (max)": 12,
+              "medium_range_blend (max)": 13,
+              "medium_range_blend_alaska (max)": 14,
+              "medium_range_blend_coastal (max)": 22,
+              "medium_range_coastal_mem1 (max)": 21,
+              "medium_range_mem1 (max)": 11,
+              "reference_time": 0,
+              "replace_route (max)": 10,
+              "rfc (max)": 9,
+              "short_range (max)": 5,
+              "short_range_alaska (max)": 6,
+              "short_range_coastal (max)": 18,
+              "short_range_coastal_hawaii (max)": 19,
+              "short_range_coastal_puertorico (max)": 20,
+              "short_range_hawaii (max)": 7,
+              "short_range_puertorico (max)": 8
+            },
+            "renameByName": {
+              "@timestamp": "Log Time",
+              "analysis_assim (last)": "AnA",
+              "analysis_assim (max)": "AnA",
+              "analysis_assim_alaska (last)": "AnA AK",
+              "analysis_assim_alaska (max)": "AnA AK",
+              "analysis_assim_coastal": "AnA Coastal",
+              "analysis_assim_coastal (last)": "C AnA",
+              "analysis_assim_coastal (max)": "C AnA",
+              "analysis_assim_coastal_hawaii (last)": "C AnA HI",
+              "analysis_assim_coastal_hawaii (max)": "C AnA HI",
+              "analysis_assim_coastal_puertorico (last)": "C AnA PRVI",
+              "analysis_assim_coastal_puertorico (max)": "C AnA PRVI",
+              "analysis_assim_hawaii (last)": "AnA HI",
+              "analysis_assim_hawaii (max)": "AnA HI",
+              "analysis_assim_puertorico (last)": "AnA PRVI",
+              "analysis_assim_puertorico (max)": "AnA PRVI",
+              "forcing_analysis_assim (last)": "F AnA",
+              "forcing_analysis_assim (max)": "AnA",
+              "forcing_analysis_assim_alaska (last)": "F AnA AK",
+              "forcing_analysis_assim_alaska (max)": "AnA AK",
+              "forcing_analysis_assim_hawaii (last)": "F AnA HI",
+              "forcing_analysis_assim_hawaii (max)": "AnA HI",
+              "forcing_analysis_assim_puertorico (last)": "F AnA PRVI",
+              "forcing_analysis_assim_puertorico (max)": "AnA PRVI",
+              "forcing_medium_range (last)": "F MRF GFS",
+              "forcing_medium_range (max)": "MRF GFS",
+              "forcing_medium_range_alaska (last)": "F MRF GFS AK",
+              "forcing_medium_range_alaska (max)": "MRF GFS AK",
+              "forcing_medium_range_blend (last)": "F MRF NBM",
+              "forcing_medium_range_blend (max)": "MRF NBM",
+              "forcing_medium_range_blend_alaska (last)": "F MRF NBM AK",
+              "forcing_medium_range_blend_alaska (max)": "MRF NBM AK",
+              "forcing_short_range (last)": "F SRF",
+              "forcing_short_range (max)": "SRF",
+              "forcing_short_range_alaska (last)": "F SRF AK",
+              "forcing_short_range_alaska (max)": "SRF AK",
+              "forcing_short_range_hawaii (last)": "F SRF HI",
+              "forcing_short_range_hawaii (max)": "SRF HI",
+              "forcing_short_range_puertorico (last)": "F SRF PRVI",
+              "forcing_short_range_puertorico (max)": "SRF PRVI",
+              "logging_status": "",
+              "medium_range_alaska_mem1 (last)": "MRF GFS AK",
+              "medium_range_alaska_mem1 (max)": "MRF GFS AK",
+              "medium_range_blend (last)": "MRF NBM",
+              "medium_range_blend (max)": "MRF NBM",
+              "medium_range_blend_alaska (last)": "MRF NBM AK",
+              "medium_range_blend_alaska (max)": "MRF NBM AK",
+              "medium_range_blend_coastal": "MRF NBM Coastal",
+              "medium_range_blend_coastal (last)": "C MRF NBM",
+              "medium_range_blend_coastal (max)": "C MRF NBM",
+              "medium_range_coastal_mem1 (last)": "C MRF GFS",
+              "medium_range_coastal_mem1 (max)": "C MRF GFS",
+              "medium_range_mem1 (last)": "MRF GFS",
+              "medium_range_mem1 (max)": "MRF GFS",
+              "reference_time": "Reference Time",
+              "replace_route": "RnR",
+              "replace_route (last)": "RnR",
+              "replace_route (max)": "RnR",
+              "rfc": "RFC",
+              "rfc (last)": "RFC",
+              "rfc (max)": "RFC",
+              "short_range (last)": "SRF",
+              "short_range (max)": "SRF",
+              "short_range_alaska (last)": "SRF AK",
+              "short_range_alaska (max)": "SRF AK",
+              "short_range_coastal (last)": "C SRF",
+              "short_range_coastal (max)": "C SRF",
+              "short_range_coastal_hawaii (last)": "C SRF HI",
+              "short_range_coastal_hawaii (max)": "C SRF HI",
+              "short_range_coastal_puertorico (last)": "C SRF PRVI",
+              "short_range_coastal_puertorico (max)": "C SRF PRVI",
+              "short_range_hawaii (last)": "SRF HI",
+              "short_range_hawaii (max)": "SRF HI",
+              "short_range_puertorico (last)": "SRF PRVI",
+              "short_range_puertorico (max)": "SRF PRVI",
+              "step_finish": "Step Finish Time"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "mode": "basic",
+              "type": "color-background"
+            },
+            "filterable": false,
+            "inspect": false,
+            "width": 20
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#dcdcdc",
+                "value": null
+              },
+              {
+                "color": "#c6dbef",
+                "value": 1
+              },
+              {
+                "color": "#6baed6",
+                "value": 2
+              },
+              {
+                "color": "#2171b5",
+                "value": 3
+              },
+              {
+                "color": "dark-green",
+                "value": 4
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "reference_time"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "transparent",
+                      "value": null
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.width",
+                "value": 150
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AnA HI"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 68
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AnA PRVI"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 83
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AnA AK"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 69
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SRF AK"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 68
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MRF NBM AK"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 110
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MRF GFS"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 79
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MRF NBM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 83
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SRF PRVI"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 81
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SRF HI"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 65
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Reference Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 169
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MRF GFS AK"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 104
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "message"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 156
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "step_finish"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 215
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RnR (max)"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 94
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AnA Coastal (max)"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 101
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RFC"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 50
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "RnR"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 52
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "AnA Coastal"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 96
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MRF NBM Coastal"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 140
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "C AnA"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 67
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "C AnA HI"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 74
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "C AnA PRVI"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 95
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "C SRF"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 61
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "C SRF HI"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 77
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "C SRF PRVI"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 96
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "C MRF GFS"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 95
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "C MRF NBM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 99
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "logging_status"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 341
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 10,
+        "x": 14,
+        "y": 19
+      },
+      "id": 23,
+      "options": {
+        "footer": {
+          "countRows": false,
+          "enablePagination": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Reference Time"
+          }
+        ]
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 15,
+          "refId": "A"
+        }
+      ],
+      "title": "Coastal Configuration Data Prep",
+      "transformations": [
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"rfc\": *"
+                  }
+                },
+                "fieldName": "logging_status"
+              }
+            ],
+            "match": "all",
+            "type": "exclude"
+          }
+        },
+        {
+          "id": "extractFields",
+          "options": {
+            "format": "auto",
+            "jsonPaths": [
+              {
+                "path": ""
+              }
+            ],
+            "keepTime": false,
+            "replace": false,
+            "source": "logging_status"
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "reference_time"
+              },
+              {
+                "destinationType": "time",
+                "targetField": "step_finish"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "AnA Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "MRF NBM Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "RFC": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "Reference Time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "RnR": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "analysis_assim_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "forcing_analysis_assim": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "forcing_analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "forcing_analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "forcing_analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "forcing_medium_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "forcing_short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "forcing_short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "forcing_short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_alaska_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_coastal_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "reference_time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "replace_route": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "rfc": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "short_range_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              }
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "@timestamp": false,
+              "Time": true,
+              "analysis_assim (max)": true,
+              "analysis_assim_alaska (max)": true,
+              "analysis_assim_coastal (last)": true,
+              "analysis_assim_coastal (max)": false,
+              "analysis_assim_coastal_hawaii (last)": true,
+              "analysis_assim_coastal_hawaii (max)": false,
+              "analysis_assim_coastal_puertorico (last)": true,
+              "analysis_assim_coastal_puertorico (max)": false,
+              "analysis_assim_hawaii (max)": true,
+              "analysis_assim_puertorico (max)": true,
+              "forcing_analysis_assim (last)": true,
+              "forcing_analysis_assim (max)": true,
+              "forcing_analysis_assim_alaska (last)": true,
+              "forcing_analysis_assim_alaska (max)": true,
+              "forcing_analysis_assim_hawaii (last)": true,
+              "forcing_analysis_assim_hawaii (max)": true,
+              "forcing_analysis_assim_puertorico (last)": true,
+              "forcing_analysis_assim_puertorico (max)": true,
+              "forcing_medium_range (last)": true,
+              "forcing_medium_range (max)": true,
+              "forcing_medium_range_alaska (last)": true,
+              "forcing_medium_range_alaska (max)": true,
+              "forcing_medium_range_blend (last)": true,
+              "forcing_medium_range_blend (max)": true,
+              "forcing_medium_range_blend_alaska (last)": true,
+              "forcing_medium_range_blend_alaska (max)": true,
+              "forcing_short_range (last)": true,
+              "forcing_short_range (max)": true,
+              "forcing_short_range_alaska (last)": true,
+              "forcing_short_range_alaska (max)": true,
+              "forcing_short_range_hawaii (last)": true,
+              "forcing_short_range_hawaii (max)": true,
+              "forcing_short_range_puertorico (last)": true,
+              "forcing_short_range_puertorico (max)": true,
+              "logging_status": true,
+              "medium_range_alaska_mem1 (max)": true,
+              "medium_range_blend (max)": true,
+              "medium_range_blend_alaska (max)": true,
+              "medium_range_blend_coastal (last)": true,
+              "medium_range_blend_coastal (max)": false,
+              "medium_range_coastal_mem1 (last)": true,
+              "medium_range_coastal_mem1 (max)": false,
+              "medium_range_mem1 (max)": true,
+              "message": true,
+              "pipeline_name": true,
+              "replace_route (max)": true,
+              "rfc (max)": true,
+              "short_range (max)": true,
+              "short_range_alaska (max)": true,
+              "short_range_coastal (last)": true,
+              "short_range_coastal (max)": false,
+              "short_range_coastal_hawaii (last)": true,
+              "short_range_coastal_hawaii (max)": false,
+              "short_range_coastal_puertorico (last)": true,
+              "short_range_coastal_puertorico (max)": false,
+              "short_range_hawaii (max)": true,
+              "short_range_puertorico (max)": true
+            },
+            "indexByName": {
+              "analysis_assim (max)": 1,
+              "analysis_assim_alaska (max)": 2,
+              "analysis_assim_coastal (max)": 15,
+              "analysis_assim_coastal_hawaii (max)": 16,
+              "analysis_assim_coastal_puertorico (max)": 17,
+              "analysis_assim_hawaii (max)": 3,
+              "analysis_assim_puertorico (max)": 4,
+              "forcing_analysis_assim (max)": 23,
+              "forcing_analysis_assim_alaska (max)": 24,
+              "forcing_analysis_assim_hawaii (max)": 25,
+              "forcing_analysis_assim_puertorico (max)": 26,
+              "forcing_medium_range (max)": 31,
+              "forcing_medium_range_alaska (max)": 32,
+              "forcing_medium_range_blend (max)": 33,
+              "forcing_medium_range_blend_alaska (max)": 34,
+              "forcing_short_range (max)": 27,
+              "forcing_short_range_alaska (max)": 28,
+              "forcing_short_range_hawaii (max)": 29,
+              "forcing_short_range_puertorico (max)": 30,
+              "medium_range_alaska_mem1 (max)": 12,
+              "medium_range_blend (max)": 13,
+              "medium_range_blend_alaska (max)": 14,
+              "medium_range_blend_coastal (max)": 22,
+              "medium_range_coastal_mem1 (max)": 21,
+              "medium_range_mem1 (max)": 11,
+              "reference_time": 0,
+              "replace_route (max)": 10,
+              "rfc (max)": 9,
+              "short_range (max)": 5,
+              "short_range_alaska (max)": 6,
+              "short_range_coastal (max)": 18,
+              "short_range_coastal_hawaii (max)": 19,
+              "short_range_coastal_puertorico (max)": 20,
+              "short_range_hawaii (max)": 7,
+              "short_range_puertorico (max)": 8
+            },
+            "renameByName": {
+              "@timestamp": "Log Time",
+              "analysis_assim (last)": "AnA",
+              "analysis_assim (max)": "AnA",
+              "analysis_assim_alaska (last)": "AnA AK",
+              "analysis_assim_alaska (max)": "AnA AK",
+              "analysis_assim_coastal": "AnA Coastal",
+              "analysis_assim_coastal (last)": "C AnA",
+              "analysis_assim_coastal (max)": "AnA",
+              "analysis_assim_coastal_hawaii (last)": "C AnA HI",
+              "analysis_assim_coastal_hawaii (max)": "AnA HI",
+              "analysis_assim_coastal_puertorico (last)": "C AnA PRVI",
+              "analysis_assim_coastal_puertorico (max)": "AnA PRVI",
+              "analysis_assim_hawaii (last)": "AnA HI",
+              "analysis_assim_hawaii (max)": "AnA HI",
+              "analysis_assim_puertorico (last)": "AnA PRVI",
+              "analysis_assim_puertorico (max)": "AnA PRVI",
+              "forcing_analysis_assim (last)": "F AnA",
+              "forcing_analysis_assim (max)": "F AnA",
+              "forcing_analysis_assim_alaska (last)": "F AnA AK",
+              "forcing_analysis_assim_alaska (max)": "F AnA AK",
+              "forcing_analysis_assim_hawaii (last)": "F AnA HI",
+              "forcing_analysis_assim_hawaii (max)": "F AnA HI",
+              "forcing_analysis_assim_puertorico (last)": "F AnA PRVI",
+              "forcing_analysis_assim_puertorico (max)": "F AnA PRVI",
+              "forcing_medium_range (last)": "F MRF GFS",
+              "forcing_medium_range (max)": "F MRF GFS",
+              "forcing_medium_range_alaska (last)": "F MRF GFS AK",
+              "forcing_medium_range_alaska (max)": "F MRF GFS AK",
+              "forcing_medium_range_blend (last)": "F MRF NBM",
+              "forcing_medium_range_blend (max)": "F MRF NBM",
+              "forcing_medium_range_blend_alaska (last)": "F MRF NBM AK",
+              "forcing_medium_range_blend_alaska (max)": "F MRF NBM AK",
+              "forcing_short_range (last)": "F SRF",
+              "forcing_short_range (max)": "F SRF",
+              "forcing_short_range_alaska (last)": "F SRF AK",
+              "forcing_short_range_alaska (max)": "F SRF AK",
+              "forcing_short_range_hawaii (last)": "F SRF HI",
+              "forcing_short_range_hawaii (max)": "F SRF HI",
+              "forcing_short_range_puertorico (last)": "F SRF PRVI",
+              "forcing_short_range_puertorico (max)": "F SRF PRVI",
+              "logging_status": "",
+              "medium_range_alaska_mem1 (last)": "MRF GFS AK",
+              "medium_range_alaska_mem1 (max)": "MRF GFS AK",
+              "medium_range_blend (last)": "MRF NBM",
+              "medium_range_blend (max)": "MRF NBM",
+              "medium_range_blend_alaska (last)": "MRF NBM AK",
+              "medium_range_blend_alaska (max)": "MRF NBM AK",
+              "medium_range_blend_coastal": "MRF NBM Coastal",
+              "medium_range_blend_coastal (last)": "C MRF NBM",
+              "medium_range_blend_coastal (max)": "MRF NBM",
+              "medium_range_coastal_mem1 (last)": "C MRF GFS",
+              "medium_range_coastal_mem1 (max)": "MRF GFS",
+              "medium_range_mem1 (last)": "MRF GFS",
+              "medium_range_mem1 (max)": "MRF GFS",
+              "reference_time": "Reference Time",
+              "replace_route": "RnR",
+              "replace_route (last)": "RnR",
+              "replace_route (max)": "RnR",
+              "rfc": "RFC",
+              "rfc (last)": "RFC",
+              "rfc (max)": "RFC",
+              "short_range (last)": "SRF",
+              "short_range (max)": "SRF",
+              "short_range_alaska (last)": "SRF AK",
+              "short_range_alaska (max)": "SRF AK",
+              "short_range_coastal (last)": "C SRF",
+              "short_range_coastal (max)": "SRF",
+              "short_range_coastal_hawaii (last)": "C SRF HI",
+              "short_range_coastal_hawaii (max)": "SRF HI",
+              "short_range_coastal_puertorico (last)": "C SRF PRVI",
+              "short_range_coastal_puertorico (max)": "SRF PRVI",
+              "short_range_hawaii (last)": "SRF HI",
+              "short_range_hawaii (max)": "SRF HI",
+              "short_range_puertorico (last)": "SRF PRVI",
+              "short_range_puertorico (max)": "SRF PRVI",
+              "step_finish": "Step Finish Time"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 33,
+      "panels": [],
+      "title": "Product Processing Health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 28
+      },
+      "id": 47,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "<center style=\"color:black;background-color:white\"><h1>Product Processing Errors</h1></center>",
+        "mode": "html"
+      },
+      "pluginVersion": "9.4.7",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "cloudwatch",
+        "uid": "kWlGwSB4k"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "mode": "gradient",
+              "type": "color-background"
+            },
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-red",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Reference Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 199
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "transparent",
+                      "value": null
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Error Message"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 1145
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "transparent",
+                      "value": null
+                    },
+                    {
+                      "color": "transparent",
+                      "value": 80
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 20,
+        "x": 0,
+        "y": 30
+      },
+      "id": 27,
+      "options": {
+        "footer": {
+          "countRows": false,
+          "enablePagination": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Reference Time"
+          }
+        ]
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "kWlGwSB4k"
+          },
+          "dimensions": {},
+          "expression": "parse @message '{*, \"reference_time\": *, \"step_finish\": *, \"pipeline_step\": *, \"error\": {\"errorMessage\":\"*\",\"errorType\":\"*\",\"requestId\":\"*\",*}}' as logging_status, reference_time, step_finish, pipeline_step, errorMessage, errorType, requestId, remaning_message\n| filter pipeline_step = '\"product_processing\"'",
+          "id": "",
+          "label": "",
+          "logGroups": [
+            {
+              "accountId": "799732994462",
+              "arn": "arn:aws:logs:us-east-2:799732994462:log-group:pipeline_monitoring_test:*",
+              "name": "pipeline_monitoring_test"
+            }
+          ],
+          "matchExact": true,
+          "metricEditorMode": 0,
+          "metricName": "",
+          "metricQueryType": 1,
+          "namespace": "",
+          "period": "",
+          "queryMode": "Logs",
+          "refId": "A",
+          "region": "default",
+          "sql": {
+            "select": {
+              "name": "AVG",
+              "type": "function"
+            }
+          },
+          "statistic": "Average",
+          "statsGroups": []
+        }
+      ],
+      "title": "Product Processing Errors",
+      "transformations": [
+        {
+          "disabled": true,
+          "id": "extractFields",
+          "options": {
+            "format": "auto",
+            "jsonPaths": [
+              {
+                "path": ""
+              }
+            ],
+            "keepTime": false,
+            "replace": false,
+            "source": "logging_status"
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "reference_time"
+              },
+              {
+                "destinationType": "time",
+                "targetField": "step_finish"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "AnA Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "MRF NBM Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "RFC": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "Reference Time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "RnR": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "errorMessage": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "forcing_analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "logging_status": {
+                "aggregations": [
+                  "count"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_alaska_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_coastal_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "reference_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "groupby"
+              },
+              "replace_route": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc_max_forecast": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "step_finish": {
+                "aggregations": [
+                  "count"
+                ]
+              }
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "@timestamp": false,
+              "Time": true,
+              "analysis_assim_coastal (last)": true,
+              "analysis_assim_coastal (max)": true,
+              "analysis_assim_coastal_hawaii (last)": true,
+              "analysis_assim_coastal_hawaii (max)": true,
+              "analysis_assim_coastal_puertorico (last)": true,
+              "analysis_assim_coastal_puertorico (max)": true,
+              "forcing_analysis_assim (last)": true,
+              "forcing_analysis_assim (max)": true,
+              "forcing_analysis_assim_alaska (last)": true,
+              "forcing_analysis_assim_alaska (max)": true,
+              "forcing_analysis_assim_hawaii (last)": true,
+              "forcing_analysis_assim_hawaii (max)": true,
+              "forcing_analysis_assim_puertorico (last)": true,
+              "forcing_analysis_assim_puertorico (max)": true,
+              "forcing_medium_range (last)": true,
+              "forcing_medium_range (max)": true,
+              "forcing_medium_range_alaska (last)": true,
+              "forcing_medium_range_alaska (max)": true,
+              "forcing_medium_range_blend (last)": true,
+              "forcing_medium_range_blend (max)": true,
+              "forcing_medium_range_blend_alaska (last)": true,
+              "forcing_medium_range_blend_alaska (max)": true,
+              "forcing_short_range (last)": true,
+              "forcing_short_range (max)": true,
+              "forcing_short_range_alaska (last)": true,
+              "forcing_short_range_alaska (max)": true,
+              "forcing_short_range_hawaii (last)": true,
+              "forcing_short_range_hawaii (max)": true,
+              "forcing_short_range_puertorico (last)": true,
+              "forcing_short_range_puertorico (max)": true,
+              "logging_status": true,
+              "medium_range_blend_coastal (last)": true,
+              "medium_range_blend_coastal (max)": true,
+              "medium_range_coastal_mem1 (last)": true,
+              "medium_range_coastal_mem1 (max)": true,
+              "message": true,
+              "pipeline_name": true,
+              "short_range_coastal (last)": true,
+              "short_range_coastal (max)": true,
+              "short_range_coastal_hawaii (last)": true,
+              "short_range_coastal_hawaii (max)": true,
+              "short_range_coastal_puertorico (last)": true,
+              "short_range_coastal_puertorico (max)": true,
+              "short_range_puertorico (max)": false
+            },
+            "indexByName": {
+              "analysis_assim (max)": 1,
+              "analysis_assim_alaska (max)": 2,
+              "analysis_assim_coastal (max)": 15,
+              "analysis_assim_coastal_hawaii (max)": 16,
+              "analysis_assim_coastal_puertorico (max)": 17,
+              "analysis_assim_hawaii (max)": 3,
+              "analysis_assim_puertorico (max)": 4,
+              "forcing_analysis_assim (max)": 23,
+              "forcing_analysis_assim_alaska (max)": 24,
+              "forcing_analysis_assim_hawaii (max)": 25,
+              "forcing_analysis_assim_puertorico (max)": 26,
+              "forcing_medium_range (max)": 31,
+              "forcing_medium_range_alaska (max)": 32,
+              "forcing_medium_range_blend (max)": 33,
+              "forcing_medium_range_blend_alaska (max)": 34,
+              "forcing_short_range (max)": 27,
+              "forcing_short_range_alaska (max)": 28,
+              "forcing_short_range_hawaii (max)": 29,
+              "forcing_short_range_puertorico (max)": 30,
+              "medium_range_alaska_mem1 (max)": 12,
+              "medium_range_blend (max)": 13,
+              "medium_range_blend_alaska (max)": 14,
+              "medium_range_blend_coastal (max)": 22,
+              "medium_range_coastal_mem1 (max)": 21,
+              "medium_range_mem1 (max)": 11,
+              "reference_time": 0,
+              "replace_route (max)": 10,
+              "rfc (max)": 9,
+              "short_range (max)": 5,
+              "short_range_alaska (max)": 6,
+              "short_range_coastal (max)": 18,
+              "short_range_coastal_hawaii (max)": 19,
+              "short_range_coastal_puertorico (max)": 20,
+              "short_range_hawaii (max)": 7,
+              "short_range_puertorico (max)": 8
+            },
+            "renameByName": {
+              "@timestamp": "Log Time",
+              "analysis_assim (last)": "AnA",
+              "analysis_assim (max)": "AnA",
+              "analysis_assim_alaska (last)": "AnA AK",
+              "analysis_assim_alaska (max)": "AnA AK",
+              "analysis_assim_coastal": "AnA Coastal",
+              "analysis_assim_coastal (last)": "C AnA",
+              "analysis_assim_coastal (max)": "C AnA",
+              "analysis_assim_coastal_hawaii (last)": "C AnA HI",
+              "analysis_assim_coastal_hawaii (max)": "C AnA HI",
+              "analysis_assim_coastal_puertorico (last)": "C AnA PRVI",
+              "analysis_assim_coastal_puertorico (max)": "C AnA PRVI",
+              "analysis_assim_hawaii (last)": "AnA HI",
+              "analysis_assim_hawaii (max)": "AnA HI",
+              "analysis_assim_puertorico (last)": "AnA PRVI",
+              "analysis_assim_puertorico (max)": "AnA PRVI",
+              "errorMessage": "Error Message",
+              "forcing_analysis_assim (last)": "F AnA",
+              "forcing_analysis_assim (max)": "F AnA",
+              "forcing_analysis_assim_alaska (last)": "F AnA AK",
+              "forcing_analysis_assim_alaska (max)": "F AnA AK",
+              "forcing_analysis_assim_hawaii (last)": "F AnA HI",
+              "forcing_analysis_assim_hawaii (max)": "F AnA HI",
+              "forcing_analysis_assim_puertorico (last)": "F AnA PRVI",
+              "forcing_analysis_assim_puertorico (max)": "F AnA PRVI",
+              "forcing_medium_range (last)": "F MRF GFS",
+              "forcing_medium_range (max)": "F MRF GFS",
+              "forcing_medium_range_alaska (last)": "F MRF GFS AK",
+              "forcing_medium_range_alaska (max)": "F MRF GFS AK",
+              "forcing_medium_range_blend (last)": "F MRF NBM",
+              "forcing_medium_range_blend (max)": "F MRF NBM",
+              "forcing_medium_range_blend_alaska (last)": "F MRF NBM AK",
+              "forcing_medium_range_blend_alaska (max)": "F MRF NBM AK",
+              "forcing_short_range (last)": "F SRF",
+              "forcing_short_range (max)": "F SRF",
+              "forcing_short_range_alaska (last)": "F SRF AK",
+              "forcing_short_range_alaska (max)": "F SRF AK",
+              "forcing_short_range_hawaii (last)": "F SRF HI",
+              "forcing_short_range_hawaii (max)": "F SRF HI",
+              "forcing_short_range_puertorico (last)": "F SRF PRVI",
+              "forcing_short_range_puertorico (max)": "F SRF PRVI",
+              "logging_status": "",
+              "logging_status (count)": "Number of Affect Services",
+              "medium_range_alaska_mem1 (last)": "MRF GFS AK",
+              "medium_range_alaska_mem1 (max)": "MRF GFS AK",
+              "medium_range_blend (last)": "MRF NBM",
+              "medium_range_blend (max)": "MRF NBM",
+              "medium_range_blend_alaska (last)": "MRF NBM AK",
+              "medium_range_blend_alaska (max)": "MRF NBM AK",
+              "medium_range_blend_coastal": "MRF NBM Coastal",
+              "medium_range_blend_coastal (last)": "C MRF NBM",
+              "medium_range_blend_coastal (max)": "C MRF NBM",
+              "medium_range_coastal_mem1 (last)": "C MRF GFS",
+              "medium_range_coastal_mem1 (max)": "C MRF GFS",
+              "medium_range_mem1 (last)": "MRF GFS",
+              "medium_range_mem1 (max)": "MRF GFS",
+              "reference_time": "Reference Time",
+              "replace_route": "RnR",
+              "replace_route (last)": "RnR",
+              "replace_route (max)": "RnR",
+              "rfc": "RFC",
+              "rfc (last)": "RFC",
+              "rfc (max)": "RFC",
+              "rfc_max_forecast (max)": "RFC Max Forecast",
+              "short_range (last)": "SRF",
+              "short_range (max)": "SRF",
+              "short_range_alaska (last)": "SRF AK",
+              "short_range_alaska (max)": "SRF AK",
+              "short_range_coastal (last)": "C SRF",
+              "short_range_coastal (max)": "C SRF",
+              "short_range_coastal_hawaii (last)": "C SRF HI",
+              "short_range_coastal_hawaii (max)": "C SRF HI",
+              "short_range_coastal_puertorico (last)": "C SRF PRVI",
+              "short_range_coastal_puertorico (max)": "C SRF PRVI",
+              "short_range_hawaii (last)": "SRF HI",
+              "short_range_hawaii (max)": "SRF HI",
+              "short_range_puertorico (last)": "SRF PRVI",
+              "short_range_puertorico (max)": "SRF PRVI",
+              "step_finish": "Step Finish Time",
+              "step_finish (count)": "Affected Services"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 4,
+        "x": 20,
+        "y": 30
+      },
+      "id": 25,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "1 - Product Processing Finished\n<br>\n2 - Product Postprocessing Finished\n<br>\n3 - Product Summaries Finished\n<br>\n4 - Updating EGIS/Final Finished\n<br>\n5 - Publishing Service Finished",
+        "mode": "markdown"
+      },
+      "pluginVersion": "9.4.7",
+      "title": "Configuration Data Prep Legend",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 36
+      },
+      "id": 42,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "<center style=\"color:black;background-color:white\"><h1>AnA Product Processing Health</h1></center>",
+        "mode": "html"
+      },
+      "pluginVersion": "9.4.7",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "cloudwatch",
+        "uid": "kWlGwSB4k"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "mode": "basic",
+              "type": "color-background"
+            },
+            "filterable": false,
+            "inspect": false,
+            "width": 75
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#dcdcdc",
+                "value": null
+              },
+              {
+                "color": "#d0e1f2",
+                "value": 1
+              },
+              {
+                "color": "#94c4df",
+                "value": 2
+              },
+              {
+                "color": "#4a98c9",
+                "value": 3
+              },
+              {
+                "color": "#1764ab",
+                "value": 4
+              },
+              {
+                "color": "dark-green",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Reference Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 165
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "transparent",
+                      "value": null
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Coastal FIM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 96
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Accum Precip"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 110
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Streamflow"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 93
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "FIM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 52
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "HFM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 51
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 38
+      },
+      "id": 39,
+      "options": {
+        "footer": {
+          "countRows": false,
+          "enablePagination": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Reference Time"
+          }
+        ]
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "kWlGwSB4k"
+          },
+          "dimensions": {},
+          "expression": "parse @message '{*, \"reference_time\": *, \"step_finish\": *, \"pipeline_step\": *}' as logging_status, reference_time, step_finish, pipeline_step\n| filter pipeline_step = '\"product_processing\"'",
+          "hide": false,
+          "id": "",
+          "label": "",
+          "logGroups": [
+            {
+              "accountId": "799732994462",
+              "arn": "arn:aws:logs:us-east-2:799732994462:log-group:pipeline_monitoring_test:*",
+              "name": "pipeline_monitoring_test"
+            }
+          ],
+          "matchExact": true,
+          "metricEditorMode": 0,
+          "metricName": "",
+          "metricQueryType": 0,
+          "namespace": "",
+          "period": "",
+          "queryMode": "Logs",
+          "refId": "max-values",
+          "region": "$region",
+          "sqlExpression": "",
+          "statistic": "Average",
+          "statsGroups": []
+        }
+      ],
+      "title": "AnA CONUS Product Processing",
+      "transformations": [
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"ana_*"
+                  }
+                },
+                "fieldName": "logging_status"
+              }
+            ],
+            "match": "any",
+            "type": "include"
+          }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"*_hi\\\"\"*"
+                  }
+                },
+                "fieldName": "logging_status"
+              },
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"*_prvi\\\"\"*"
+                  }
+                },
+                "fieldName": "logging_status"
+              },
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"*_ak\\\"\"*"
+                  }
+                },
+                "fieldName": "logging_status"
+              }
+            ],
+            "match": "any",
+            "type": "exclude"
+          }
+        },
+        {
+          "id": "extractFields",
+          "options": {
+            "format": "auto",
+            "jsonPaths": [
+              {
+                "path": ""
+              }
+            ],
+            "keepTime": false,
+            "replace": false,
+            "source": "logging_status"
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "reference_time"
+              },
+              {
+                "destinationType": "time",
+                "targetField": "step_finish"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "AnA Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "MRF NBM Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "RFC": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "Reference Time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "RnR": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_coastal_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_coastal_inundation_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_coastal_inundation_prvi": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "ana_for_rnr_ingest": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "ana_high_flow_magnitude": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_high_flow_magnitude_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_high_flow_magnitude_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_inundation_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_inundation_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_past_72hr_accum_precip": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_past_72hr_accum_precip_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_alaska_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_coastal_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_gfs_10day_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_nbm_10day_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "reference_time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "replace_route": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc_based_5day_max_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc_based_5day_max_streamflow": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_15hr_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_high_water_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_max_high_flow_magnitude": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_max_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_peak_flow_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_rapid_onset_flooding": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_rate_of_change": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              }
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "@timestamp": false,
+              "Time": true,
+              "ana_coastal_inundation_hi (max)": false,
+              "ana_coastal_inundation_prvi (max)": true,
+              "analysis_assim_coastal (last)": true,
+              "analysis_assim_coastal (max)": true,
+              "analysis_assim_coastal_hawaii (last)": true,
+              "analysis_assim_coastal_hawaii (max)": true,
+              "analysis_assim_coastal_puertorico (last)": true,
+              "analysis_assim_coastal_puertorico (max)": true,
+              "forcing_analysis_assim (last)": true,
+              "forcing_analysis_assim (max)": true,
+              "forcing_analysis_assim_alaska (last)": true,
+              "forcing_analysis_assim_alaska (max)": true,
+              "forcing_analysis_assim_hawaii (last)": true,
+              "forcing_analysis_assim_hawaii (max)": true,
+              "forcing_analysis_assim_puertorico (last)": true,
+              "forcing_analysis_assim_puertorico (max)": true,
+              "forcing_medium_range (last)": true,
+              "forcing_medium_range (max)": true,
+              "forcing_medium_range_alaska (last)": true,
+              "forcing_medium_range_alaska (max)": true,
+              "forcing_medium_range_blend (last)": true,
+              "forcing_medium_range_blend (max)": true,
+              "forcing_medium_range_blend_alaska (last)": true,
+              "forcing_medium_range_blend_alaska (max)": true,
+              "forcing_short_range (last)": true,
+              "forcing_short_range (max)": true,
+              "forcing_short_range_alaska (last)": true,
+              "forcing_short_range_alaska (max)": true,
+              "forcing_short_range_hawaii (last)": true,
+              "forcing_short_range_hawaii (max)": true,
+              "forcing_short_range_puertorico (last)": true,
+              "forcing_short_range_puertorico (max)": true,
+              "logging_status": true,
+              "medium_range_blend_coastal (last)": true,
+              "medium_range_blend_coastal (max)": true,
+              "medium_range_coastal_mem1 (last)": true,
+              "medium_range_coastal_mem1 (max)": true,
+              "message": true,
+              "pipeline_name": true,
+              "short_range_coastal (last)": true,
+              "short_range_coastal (max)": true,
+              "short_range_coastal_hawaii (last)": true,
+              "short_range_coastal_hawaii (max)": true,
+              "short_range_coastal_puertorico (last)": true,
+              "short_range_coastal_puertorico (max)": true,
+              "short_range_puertorico (max)": false
+            },
+            "indexByName": {
+              "ana_coastal_inundation (max)": 1,
+              "ana_high_flow_magnitude (max)": 3,
+              "ana_past_72hr_accum_precip (max)": 4,
+              "ana_streamflow (max)": 2,
+              "reference_time": 0
+            },
+            "renameByName": {
+              "@timestamp": "Log Time",
+              "ana_coastal_inundation (max)": "Coastal FIM",
+              "ana_coastal_inundation_hi (max)": "Coastal FIM",
+              "ana_coastal_inundation_prvi (max)": "AnA Coastal Inundation PRVI",
+              "ana_high_flow_magnitude (max)": "HFM",
+              "ana_high_flow_magnitude_hi (max)": "HFM",
+              "ana_inundation_hi (max)": "FIM",
+              "ana_past_72hr_accum_precip (max)": "Accum Precip",
+              "ana_past_72hr_accum_precip_hi (max)": "Accum Precip",
+              "ana_streamflow (max)": "Streamflow",
+              "ana_streamflow_hi (max)": "Streamflow",
+              "analysis_assim (last)": "AnA",
+              "analysis_assim (max)": "AnA",
+              "analysis_assim_alaska (last)": "AnA AK",
+              "analysis_assim_alaska (max)": "AnA AK",
+              "analysis_assim_coastal": "AnA Coastal",
+              "analysis_assim_coastal (last)": "C AnA",
+              "analysis_assim_coastal (max)": "C AnA",
+              "analysis_assim_coastal_hawaii (last)": "C AnA HI",
+              "analysis_assim_coastal_hawaii (max)": "C AnA HI",
+              "analysis_assim_coastal_puertorico (last)": "C AnA PRVI",
+              "analysis_assim_coastal_puertorico (max)": "C AnA PRVI",
+              "analysis_assim_hawaii (last)": "AnA HI",
+              "analysis_assim_hawaii (max)": "AnA HI",
+              "analysis_assim_puertorico (last)": "AnA PRVI",
+              "analysis_assim_puertorico (max)": "AnA PRVI",
+              "forcing_analysis_assim (last)": "F AnA",
+              "forcing_analysis_assim (max)": "F AnA",
+              "forcing_analysis_assim_alaska (last)": "F AnA AK",
+              "forcing_analysis_assim_alaska (max)": "F AnA AK",
+              "forcing_analysis_assim_hawaii (last)": "F AnA HI",
+              "forcing_analysis_assim_hawaii (max)": "F AnA HI",
+              "forcing_analysis_assim_puertorico (last)": "F AnA PRVI",
+              "forcing_analysis_assim_puertorico (max)": "F AnA PRVI",
+              "forcing_medium_range (last)": "F MRF GFS",
+              "forcing_medium_range (max)": "F MRF GFS",
+              "forcing_medium_range_alaska (last)": "F MRF GFS AK",
+              "forcing_medium_range_alaska (max)": "F MRF GFS AK",
+              "forcing_medium_range_blend (last)": "F MRF NBM",
+              "forcing_medium_range_blend (max)": "F MRF NBM",
+              "forcing_medium_range_blend_alaska (last)": "F MRF NBM AK",
+              "forcing_medium_range_blend_alaska (max)": "F MRF NBM AK",
+              "forcing_short_range (last)": "F SRF",
+              "forcing_short_range (max)": "F SRF",
+              "forcing_short_range_alaska (last)": "F SRF AK",
+              "forcing_short_range_alaska (max)": "F SRF AK",
+              "forcing_short_range_hawaii (last)": "F SRF HI",
+              "forcing_short_range_hawaii (max)": "F SRF HI",
+              "forcing_short_range_puertorico (last)": "F SRF PRVI",
+              "forcing_short_range_puertorico (max)": "F SRF PRVI",
+              "logging_status": "",
+              "medium_range_alaska_mem1 (last)": "MRF GFS AK",
+              "medium_range_alaska_mem1 (max)": "MRF GFS AK",
+              "medium_range_blend (last)": "MRF NBM",
+              "medium_range_blend (max)": "MRF NBM",
+              "medium_range_blend_alaska (last)": "MRF NBM AK",
+              "medium_range_blend_alaska (max)": "MRF NBM AK",
+              "medium_range_blend_coastal": "MRF NBM Coastal",
+              "medium_range_blend_coastal (last)": "C MRF NBM",
+              "medium_range_blend_coastal (max)": "C MRF NBM",
+              "medium_range_coastal_mem1 (last)": "C MRF GFS",
+              "medium_range_coastal_mem1 (max)": "C MRF GFS",
+              "medium_range_mem1 (last)": "MRF GFS",
+              "medium_range_mem1 (max)": "MRF GFS",
+              "reference_time": "Reference Time",
+              "replace_route": "RnR",
+              "replace_route (last)": "RnR",
+              "replace_route (max)": "RnR",
+              "rfc": "RFC",
+              "rfc (last)": "RFC",
+              "rfc (max)": "RFC",
+              "rfc_based_5day_max_streamflow (max)": "RFC Based 5 Day Max Streamflow",
+              "short_range (last)": "SRF",
+              "short_range (max)": "SRF",
+              "short_range_alaska (last)": "SRF AK",
+              "short_range_alaska (max)": "SRF AK",
+              "short_range_coastal (last)": "C SRF",
+              "short_range_coastal (max)": "C SRF",
+              "short_range_coastal_hawaii (last)": "C SRF HI",
+              "short_range_coastal_hawaii (max)": "C SRF HI",
+              "short_range_coastal_puertorico (last)": "C SRF PRVI",
+              "short_range_coastal_puertorico (max)": "C SRF PRVI",
+              "short_range_hawaii (last)": "SRF HI",
+              "short_range_hawaii (max)": "SRF HI",
+              "short_range_puertorico (last)": "SRF PRVI",
+              "short_range_puertorico (max)": "SRF PRVI",
+              "srf_15hr_peak_flow_arrival_time_ak (max)": "SRF 15 HR Peak Flow Arrival Time AK",
+              "srf_18hr_high_water_arrival_time (max)": "SRF 18 HR High Water Arrival Time",
+              "srf_18hr_max_high_flow_magnitude (max)": "SRF 18 HR Max High Flow Magnitude",
+              "srf_18hr_peak_flow_arrival_time (max)": "SRF 18 HR Peak Flow Arrival Time",
+              "srf_18hr_rapid_onset_flooding (max)": "SRF 18 HR Rapid Onset Flooding",
+              "srf_18hr_rate_of_change (max)": "SRF 18 HR Rate of Change",
+              "step_finish": "Step Finish Time"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "mode": "basic",
+              "type": "color-background"
+            },
+            "filterable": false,
+            "inspect": false,
+            "width": 75
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#dcdcdc",
+                "value": null
+              },
+              {
+                "color": "#d0e1f2",
+                "value": 1
+              },
+              {
+                "color": "#94c4df",
+                "value": 2
+              },
+              {
+                "color": "#4a98c9",
+                "value": 3
+              },
+              {
+                "color": "#1764ab",
+                "value": 4
+              },
+              {
+                "color": "dark-green",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Reference Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 165
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "transparent",
+                      "value": null
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Coastal FIM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 99
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Accum Precip"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 107
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Streamflow"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 99
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "FIM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 49
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "HFM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 48
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 44
+      },
+      "id": 38,
+      "options": {
+        "footer": {
+          "countRows": false,
+          "enablePagination": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Reference Time"
+          }
+        ]
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 39,
+          "refId": "A"
+        }
+      ],
+      "title": "AnA Alaska Product Processing",
+      "transformations": [
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"ana_*"
+                  }
+                },
+                "fieldName": "logging_status"
+              }
+            ],
+            "match": "any",
+            "type": "include"
+          }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"*_ak\\\"\"*"
+                  }
+                },
+                "fieldName": "logging_status"
+              }
+            ],
+            "match": "any",
+            "type": "include"
+          }
+        },
+        {
+          "id": "extractFields",
+          "options": {
+            "format": "auto",
+            "jsonPaths": [
+              {
+                "path": ""
+              }
+            ],
+            "keepTime": false,
+            "replace": false,
+            "source": "logging_status"
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "reference_time"
+              },
+              {
+                "destinationType": "time",
+                "targetField": "step_finish"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "AnA Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "MRF NBM Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "RFC": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "Reference Time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "RnR": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_coastal_inundation_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_coastal_inundation_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_for_rnr_ingest": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "ana_high_flow_magnitude": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_high_flow_magnitude_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_high_flow_magnitude_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_inundation_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_inundation_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_past_72hr_accum_precip_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_past_72hr_accum_precip_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_past_72hr_accum_precip_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_alaska_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_coastal_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_gfs_10day_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_nbm_10day_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "reference_time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "replace_route": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc_based_5day_max_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc_based_5day_max_streamflow": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_15hr_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_high_water_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_max_high_flow_magnitude": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_max_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_peak_flow_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_rapid_onset_flooding": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_rate_of_change": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              }
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "@timestamp": false,
+              "Time": true,
+              "ana_coastal_inundation_hi (max)": false,
+              "ana_coastal_inundation_prvi (max)": false,
+              "analysis_assim_coastal (last)": true,
+              "analysis_assim_coastal (max)": true,
+              "analysis_assim_coastal_hawaii (last)": true,
+              "analysis_assim_coastal_hawaii (max)": true,
+              "analysis_assim_coastal_puertorico (last)": true,
+              "analysis_assim_coastal_puertorico (max)": true,
+              "forcing_analysis_assim (last)": true,
+              "forcing_analysis_assim (max)": true,
+              "forcing_analysis_assim_alaska (last)": true,
+              "forcing_analysis_assim_alaska (max)": true,
+              "forcing_analysis_assim_hawaii (last)": true,
+              "forcing_analysis_assim_hawaii (max)": true,
+              "forcing_analysis_assim_puertorico (last)": true,
+              "forcing_analysis_assim_puertorico (max)": true,
+              "forcing_medium_range (last)": true,
+              "forcing_medium_range (max)": true,
+              "forcing_medium_range_alaska (last)": true,
+              "forcing_medium_range_alaska (max)": true,
+              "forcing_medium_range_blend (last)": true,
+              "forcing_medium_range_blend (max)": true,
+              "forcing_medium_range_blend_alaska (last)": true,
+              "forcing_medium_range_blend_alaska (max)": true,
+              "forcing_short_range (last)": true,
+              "forcing_short_range (max)": true,
+              "forcing_short_range_alaska (last)": true,
+              "forcing_short_range_alaska (max)": true,
+              "forcing_short_range_hawaii (last)": true,
+              "forcing_short_range_hawaii (max)": true,
+              "forcing_short_range_puertorico (last)": true,
+              "forcing_short_range_puertorico (max)": true,
+              "logging_status": true,
+              "medium_range_blend_coastal (last)": true,
+              "medium_range_blend_coastal (max)": true,
+              "medium_range_coastal_mem1 (last)": true,
+              "medium_range_coastal_mem1 (max)": true,
+              "message": true,
+              "pipeline_name": true,
+              "short_range_coastal (last)": true,
+              "short_range_coastal (max)": true,
+              "short_range_coastal_hawaii (last)": true,
+              "short_range_coastal_hawaii (max)": true,
+              "short_range_coastal_puertorico (last)": true,
+              "short_range_coastal_puertorico (max)": true,
+              "short_range_puertorico (max)": false
+            },
+            "indexByName": {
+              "ana_coastal_inundation_prvi (max)": 2,
+              "ana_high_flow_magnitude_prvi (max)": 4,
+              "ana_inundation_prvi (max)": 1,
+              "ana_past_72hr_accum_precip_prvi (max)": 5,
+              "ana_streamflow_prvi (max)": 3,
+              "reference_time": 0
+            },
+            "renameByName": {
+              "@timestamp": "Log Time",
+              "ana_coastal_inundation_hi (max)": "Coastal FIM",
+              "ana_coastal_inundation_prvi (max)": "Coastal FIM",
+              "ana_high_flow_magnitude (max)": "AnA High Flow Magnitude",
+              "ana_high_flow_magnitude_hi (max)": "HFM",
+              "ana_high_flow_magnitude_prvi (max)": "HFM",
+              "ana_inundation_hi (max)": "FIM",
+              "ana_inundation_prvi (max)": "FIM",
+              "ana_past_72hr_accum_precip_ak (max)": "Accum Precip",
+              "ana_past_72hr_accum_precip_hi (max)": "Accum Precip",
+              "ana_past_72hr_accum_precip_prvi (max)": "Accum Precip",
+              "ana_streamflow (max)": "AnA Streamflow",
+              "ana_streamflow_ak (max)": "Streamflow",
+              "ana_streamflow_hi (max)": "Streamflow",
+              "ana_streamflow_prvi (max)": "Streamflow",
+              "analysis_assim (last)": "AnA",
+              "analysis_assim (max)": "AnA",
+              "analysis_assim_alaska (last)": "AnA AK",
+              "analysis_assim_alaska (max)": "AnA AK",
+              "analysis_assim_coastal": "AnA Coastal",
+              "analysis_assim_coastal (last)": "C AnA",
+              "analysis_assim_coastal (max)": "C AnA",
+              "analysis_assim_coastal_hawaii (last)": "C AnA HI",
+              "analysis_assim_coastal_hawaii (max)": "C AnA HI",
+              "analysis_assim_coastal_puertorico (last)": "C AnA PRVI",
+              "analysis_assim_coastal_puertorico (max)": "C AnA PRVI",
+              "analysis_assim_hawaii (last)": "AnA HI",
+              "analysis_assim_hawaii (max)": "AnA HI",
+              "analysis_assim_puertorico (last)": "AnA PRVI",
+              "analysis_assim_puertorico (max)": "AnA PRVI",
+              "forcing_analysis_assim (last)": "F AnA",
+              "forcing_analysis_assim (max)": "F AnA",
+              "forcing_analysis_assim_alaska (last)": "F AnA AK",
+              "forcing_analysis_assim_alaska (max)": "F AnA AK",
+              "forcing_analysis_assim_hawaii (last)": "F AnA HI",
+              "forcing_analysis_assim_hawaii (max)": "F AnA HI",
+              "forcing_analysis_assim_puertorico (last)": "F AnA PRVI",
+              "forcing_analysis_assim_puertorico (max)": "F AnA PRVI",
+              "forcing_medium_range (last)": "F MRF GFS",
+              "forcing_medium_range (max)": "F MRF GFS",
+              "forcing_medium_range_alaska (last)": "F MRF GFS AK",
+              "forcing_medium_range_alaska (max)": "F MRF GFS AK",
+              "forcing_medium_range_blend (last)": "F MRF NBM",
+              "forcing_medium_range_blend (max)": "F MRF NBM",
+              "forcing_medium_range_blend_alaska (last)": "F MRF NBM AK",
+              "forcing_medium_range_blend_alaska (max)": "F MRF NBM AK",
+              "forcing_short_range (last)": "F SRF",
+              "forcing_short_range (max)": "F SRF",
+              "forcing_short_range_alaska (last)": "F SRF AK",
+              "forcing_short_range_alaska (max)": "F SRF AK",
+              "forcing_short_range_hawaii (last)": "F SRF HI",
+              "forcing_short_range_hawaii (max)": "F SRF HI",
+              "forcing_short_range_puertorico (last)": "F SRF PRVI",
+              "forcing_short_range_puertorico (max)": "F SRF PRVI",
+              "logging_status": "",
+              "medium_range_alaska_mem1 (last)": "MRF GFS AK",
+              "medium_range_alaska_mem1 (max)": "MRF GFS AK",
+              "medium_range_blend (last)": "MRF NBM",
+              "medium_range_blend (max)": "MRF NBM",
+              "medium_range_blend_alaska (last)": "MRF NBM AK",
+              "medium_range_blend_alaska (max)": "MRF NBM AK",
+              "medium_range_blend_coastal": "MRF NBM Coastal",
+              "medium_range_blend_coastal (last)": "C MRF NBM",
+              "medium_range_blend_coastal (max)": "C MRF NBM",
+              "medium_range_coastal_mem1 (last)": "C MRF GFS",
+              "medium_range_coastal_mem1 (max)": "C MRF GFS",
+              "medium_range_mem1 (last)": "MRF GFS",
+              "medium_range_mem1 (max)": "MRF GFS",
+              "reference_time": "Reference Time",
+              "replace_route": "RnR",
+              "replace_route (last)": "RnR",
+              "replace_route (max)": "RnR",
+              "rfc": "RFC",
+              "rfc (last)": "RFC",
+              "rfc (max)": "RFC",
+              "rfc_based_5day_max_streamflow (max)": "RFC Based 5 Day Max Streamflow",
+              "short_range (last)": "SRF",
+              "short_range (max)": "SRF",
+              "short_range_alaska (last)": "SRF AK",
+              "short_range_alaska (max)": "SRF AK",
+              "short_range_coastal (last)": "C SRF",
+              "short_range_coastal (max)": "C SRF",
+              "short_range_coastal_hawaii (last)": "C SRF HI",
+              "short_range_coastal_hawaii (max)": "C SRF HI",
+              "short_range_coastal_puertorico (last)": "C SRF PRVI",
+              "short_range_coastal_puertorico (max)": "C SRF PRVI",
+              "short_range_hawaii (last)": "SRF HI",
+              "short_range_hawaii (max)": "SRF HI",
+              "short_range_puertorico (last)": "SRF PRVI",
+              "short_range_puertorico (max)": "SRF PRVI",
+              "srf_15hr_peak_flow_arrival_time_ak (max)": "SRF 15 HR Peak Flow Arrival Time AK",
+              "srf_18hr_high_water_arrival_time (max)": "SRF 18 HR High Water Arrival Time",
+              "srf_18hr_max_high_flow_magnitude (max)": "SRF 18 HR Max High Flow Magnitude",
+              "srf_18hr_peak_flow_arrival_time (max)": "SRF 18 HR Peak Flow Arrival Time",
+              "srf_18hr_rapid_onset_flooding (max)": "SRF 18 HR Rapid Onset Flooding",
+              "srf_18hr_rate_of_change (max)": "SRF 18 HR Rate of Change",
+              "step_finish": "Step Finish Time"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "mode": "basic",
+              "type": "color-background"
+            },
+            "filterable": false,
+            "inspect": false,
+            "width": 75
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#dcdcdc",
+                "value": null
+              },
+              {
+                "color": "#d0e1f2",
+                "value": 1
+              },
+              {
+                "color": "#94c4df",
+                "value": 2
+              },
+              {
+                "color": "#4a98c9",
+                "value": 3
+              },
+              {
+                "color": "#1764ab",
+                "value": 4
+              },
+              {
+                "color": "dark-green",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Reference Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 165
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "transparent",
+                      "value": null
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Coastal FIM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 96
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Accum Precip"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 110
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Streamflow"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 93
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "FIM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 52
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "HFM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 51
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 44
+      },
+      "id": 21,
+      "options": {
+        "footer": {
+          "countRows": false,
+          "enablePagination": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Reference Time"
+          }
+        ]
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 39,
+          "refId": "A"
+        }
+      ],
+      "title": "AnA Puerto Rico Product Processing",
+      "transformations": [
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"ana_*"
+                  }
+                },
+                "fieldName": "logging_status"
+              }
+            ],
+            "match": "any",
+            "type": "include"
+          }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"*_prvi\\\"\"*"
+                  }
+                },
+                "fieldName": "logging_status"
+              }
+            ],
+            "match": "any",
+            "type": "include"
+          }
+        },
+        {
+          "id": "extractFields",
+          "options": {
+            "format": "auto",
+            "jsonPaths": [
+              {
+                "path": ""
+              }
+            ],
+            "keepTime": false,
+            "replace": false,
+            "source": "logging_status"
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "reference_time"
+              },
+              {
+                "destinationType": "time",
+                "targetField": "step_finish"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "AnA Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "MRF NBM Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "RFC": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "Reference Time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "RnR": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_coastal_inundation_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_coastal_inundation_prvi": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "ana_for_rnr_ingest": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "ana_high_flow_magnitude": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_high_flow_magnitude_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_high_flow_magnitude_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_inundation_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_inundation_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_past_72hr_accum_precip_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_alaska_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_coastal_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_gfs_10day_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_nbm_10day_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "reference_time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "replace_route": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc_based_5day_max_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc_based_5day_max_streamflow": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_15hr_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_high_water_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_max_high_flow_magnitude": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_max_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_peak_flow_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_rapid_onset_flooding": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_rate_of_change": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              }
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "@timestamp": false,
+              "Time": true,
+              "ana_coastal_inundation_hi (max)": false,
+              "ana_coastal_inundation_prvi (max)": true,
+              "analysis_assim_coastal (last)": true,
+              "analysis_assim_coastal (max)": true,
+              "analysis_assim_coastal_hawaii (last)": true,
+              "analysis_assim_coastal_hawaii (max)": true,
+              "analysis_assim_coastal_puertorico (last)": true,
+              "analysis_assim_coastal_puertorico (max)": true,
+              "forcing_analysis_assim (last)": true,
+              "forcing_analysis_assim (max)": true,
+              "forcing_analysis_assim_alaska (last)": true,
+              "forcing_analysis_assim_alaska (max)": true,
+              "forcing_analysis_assim_hawaii (last)": true,
+              "forcing_analysis_assim_hawaii (max)": true,
+              "forcing_analysis_assim_puertorico (last)": true,
+              "forcing_analysis_assim_puertorico (max)": true,
+              "forcing_medium_range (last)": true,
+              "forcing_medium_range (max)": true,
+              "forcing_medium_range_alaska (last)": true,
+              "forcing_medium_range_alaska (max)": true,
+              "forcing_medium_range_blend (last)": true,
+              "forcing_medium_range_blend (max)": true,
+              "forcing_medium_range_blend_alaska (last)": true,
+              "forcing_medium_range_blend_alaska (max)": true,
+              "forcing_short_range (last)": true,
+              "forcing_short_range (max)": true,
+              "forcing_short_range_alaska (last)": true,
+              "forcing_short_range_alaska (max)": true,
+              "forcing_short_range_hawaii (last)": true,
+              "forcing_short_range_hawaii (max)": true,
+              "forcing_short_range_puertorico (last)": true,
+              "forcing_short_range_puertorico (max)": true,
+              "logging_status": true,
+              "medium_range_blend_coastal (last)": true,
+              "medium_range_blend_coastal (max)": true,
+              "medium_range_coastal_mem1 (last)": true,
+              "medium_range_coastal_mem1 (max)": true,
+              "message": true,
+              "pipeline_name": true,
+              "short_range_coastal (last)": true,
+              "short_range_coastal (max)": true,
+              "short_range_coastal_hawaii (last)": true,
+              "short_range_coastal_hawaii (max)": true,
+              "short_range_coastal_puertorico (last)": true,
+              "short_range_coastal_puertorico (max)": true,
+              "short_range_puertorico (max)": false
+            },
+            "indexByName": {
+              "ana_high_flow_magnitude_prvi (max)": 3,
+              "ana_inundation_prvi (max)": 1,
+              "ana_streamflow_prvi (max)": 2,
+              "reference_time": 0
+            },
+            "renameByName": {
+              "@timestamp": "Log Time",
+              "ana_coastal_inundation_hi (max)": "Coastal FIM",
+              "ana_coastal_inundation_prvi (max)": "AnA Coastal Inundation PRVI",
+              "ana_high_flow_magnitude (max)": "AnA High Flow Magnitude",
+              "ana_high_flow_magnitude_hi (max)": "HFM",
+              "ana_high_flow_magnitude_prvi (max)": "HFM",
+              "ana_inundation_hi (max)": "FIM",
+              "ana_inundation_prvi (max)": "FIM",
+              "ana_past_72hr_accum_precip_hi (max)": "Accum Precip",
+              "ana_streamflow (max)": "AnA Streamflow",
+              "ana_streamflow_hi (max)": "Streamflow",
+              "ana_streamflow_prvi (max)": "Streamflow",
+              "analysis_assim (last)": "AnA",
+              "analysis_assim (max)": "AnA",
+              "analysis_assim_alaska (last)": "AnA AK",
+              "analysis_assim_alaska (max)": "AnA AK",
+              "analysis_assim_coastal": "AnA Coastal",
+              "analysis_assim_coastal (last)": "C AnA",
+              "analysis_assim_coastal (max)": "C AnA",
+              "analysis_assim_coastal_hawaii (last)": "C AnA HI",
+              "analysis_assim_coastal_hawaii (max)": "C AnA HI",
+              "analysis_assim_coastal_puertorico (last)": "C AnA PRVI",
+              "analysis_assim_coastal_puertorico (max)": "C AnA PRVI",
+              "analysis_assim_hawaii (last)": "AnA HI",
+              "analysis_assim_hawaii (max)": "AnA HI",
+              "analysis_assim_puertorico (last)": "AnA PRVI",
+              "analysis_assim_puertorico (max)": "AnA PRVI",
+              "forcing_analysis_assim (last)": "F AnA",
+              "forcing_analysis_assim (max)": "F AnA",
+              "forcing_analysis_assim_alaska (last)": "F AnA AK",
+              "forcing_analysis_assim_alaska (max)": "F AnA AK",
+              "forcing_analysis_assim_hawaii (last)": "F AnA HI",
+              "forcing_analysis_assim_hawaii (max)": "F AnA HI",
+              "forcing_analysis_assim_puertorico (last)": "F AnA PRVI",
+              "forcing_analysis_assim_puertorico (max)": "F AnA PRVI",
+              "forcing_medium_range (last)": "F MRF GFS",
+              "forcing_medium_range (max)": "F MRF GFS",
+              "forcing_medium_range_alaska (last)": "F MRF GFS AK",
+              "forcing_medium_range_alaska (max)": "F MRF GFS AK",
+              "forcing_medium_range_blend (last)": "F MRF NBM",
+              "forcing_medium_range_blend (max)": "F MRF NBM",
+              "forcing_medium_range_blend_alaska (last)": "F MRF NBM AK",
+              "forcing_medium_range_blend_alaska (max)": "F MRF NBM AK",
+              "forcing_short_range (last)": "F SRF",
+              "forcing_short_range (max)": "F SRF",
+              "forcing_short_range_alaska (last)": "F SRF AK",
+              "forcing_short_range_alaska (max)": "F SRF AK",
+              "forcing_short_range_hawaii (last)": "F SRF HI",
+              "forcing_short_range_hawaii (max)": "F SRF HI",
+              "forcing_short_range_puertorico (last)": "F SRF PRVI",
+              "forcing_short_range_puertorico (max)": "F SRF PRVI",
+              "logging_status": "",
+              "medium_range_alaska_mem1 (last)": "MRF GFS AK",
+              "medium_range_alaska_mem1 (max)": "MRF GFS AK",
+              "medium_range_blend (last)": "MRF NBM",
+              "medium_range_blend (max)": "MRF NBM",
+              "medium_range_blend_alaska (last)": "MRF NBM AK",
+              "medium_range_blend_alaska (max)": "MRF NBM AK",
+              "medium_range_blend_coastal": "MRF NBM Coastal",
+              "medium_range_blend_coastal (last)": "C MRF NBM",
+              "medium_range_blend_coastal (max)": "C MRF NBM",
+              "medium_range_coastal_mem1 (last)": "C MRF GFS",
+              "medium_range_coastal_mem1 (max)": "C MRF GFS",
+              "medium_range_mem1 (last)": "MRF GFS",
+              "medium_range_mem1 (max)": "MRF GFS",
+              "reference_time": "Reference Time",
+              "replace_route": "RnR",
+              "replace_route (last)": "RnR",
+              "replace_route (max)": "RnR",
+              "rfc": "RFC",
+              "rfc (last)": "RFC",
+              "rfc (max)": "RFC",
+              "rfc_based_5day_max_streamflow (max)": "RFC Based 5 Day Max Streamflow",
+              "short_range (last)": "SRF",
+              "short_range (max)": "SRF",
+              "short_range_alaska (last)": "SRF AK",
+              "short_range_alaska (max)": "SRF AK",
+              "short_range_coastal (last)": "C SRF",
+              "short_range_coastal (max)": "C SRF",
+              "short_range_coastal_hawaii (last)": "C SRF HI",
+              "short_range_coastal_hawaii (max)": "C SRF HI",
+              "short_range_coastal_puertorico (last)": "C SRF PRVI",
+              "short_range_coastal_puertorico (max)": "C SRF PRVI",
+              "short_range_hawaii (last)": "SRF HI",
+              "short_range_hawaii (max)": "SRF HI",
+              "short_range_puertorico (last)": "SRF PRVI",
+              "short_range_puertorico (max)": "SRF PRVI",
+              "srf_15hr_peak_flow_arrival_time_ak (max)": "SRF 15 HR Peak Flow Arrival Time AK",
+              "srf_18hr_high_water_arrival_time (max)": "SRF 18 HR High Water Arrival Time",
+              "srf_18hr_max_high_flow_magnitude (max)": "SRF 18 HR Max High Flow Magnitude",
+              "srf_18hr_peak_flow_arrival_time (max)": "SRF 18 HR Peak Flow Arrival Time",
+              "srf_18hr_rapid_onset_flooding (max)": "SRF 18 HR Rapid Onset Flooding",
+              "srf_18hr_rate_of_change (max)": "SRF 18 HR Rate of Change",
+              "step_finish": "Step Finish Time"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "mode": "basic",
+              "type": "color-background"
+            },
+            "filterable": false,
+            "inspect": false,
+            "width": 75
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#dcdcdc",
+                "value": null
+              },
+              {
+                "color": "#d0e1f2",
+                "value": 1
+              },
+              {
+                "color": "#94c4df",
+                "value": 2
+              },
+              {
+                "color": "#4a98c9",
+                "value": 3
+              },
+              {
+                "color": "#1764ab",
+                "value": 4
+              },
+              {
+                "color": "dark-green",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Reference Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 165
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "transparent",
+                      "value": null
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Coastal FIM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 96
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Accum Precip"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 110
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Streamflow"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 93
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "FIM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 52
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "HFM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 51
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 44
+      },
+      "id": 40,
+      "options": {
+        "footer": {
+          "countRows": false,
+          "enablePagination": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Reference Time"
+          }
+        ]
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 39,
+          "refId": "A"
+        }
+      ],
+      "title": "AnA Hawaii Product Processing",
+      "transformations": [
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"ana_*"
+                  }
+                },
+                "fieldName": "logging_status"
+              }
+            ],
+            "match": "any",
+            "type": "include"
+          }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"*_hi\\\"\"*"
+                  }
+                },
+                "fieldName": "logging_status"
+              }
+            ],
+            "match": "any",
+            "type": "include"
+          }
+        },
+        {
+          "id": "extractFields",
+          "options": {
+            "format": "auto",
+            "jsonPaths": [
+              {
+                "path": ""
+              }
+            ],
+            "keepTime": false,
+            "replace": false,
+            "source": "logging_status"
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "reference_time"
+              },
+              {
+                "destinationType": "time",
+                "targetField": "step_finish"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "AnA Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "MRF NBM Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "RFC": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "Reference Time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "RnR": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_coastal_inundation_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_coastal_inundation_prvi": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "ana_for_rnr_ingest": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "ana_high_flow_magnitude": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_high_flow_magnitude_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_high_flow_magnitude_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_inundation_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_inundation_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_past_72hr_accum_precip_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_alaska_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_coastal_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_gfs_10day_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_nbm_10day_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "reference_time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "replace_route": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc_based_5day_max_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc_based_5day_max_streamflow": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_15hr_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_high_water_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_max_high_flow_magnitude": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_max_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_peak_flow_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_rapid_onset_flooding": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_rate_of_change": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              }
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "@timestamp": false,
+              "Time": true,
+              "ana_coastal_inundation_hi (max)": false,
+              "ana_coastal_inundation_prvi (max)": true,
+              "analysis_assim_coastal (last)": true,
+              "analysis_assim_coastal (max)": true,
+              "analysis_assim_coastal_hawaii (last)": true,
+              "analysis_assim_coastal_hawaii (max)": true,
+              "analysis_assim_coastal_puertorico (last)": true,
+              "analysis_assim_coastal_puertorico (max)": true,
+              "forcing_analysis_assim (last)": true,
+              "forcing_analysis_assim (max)": true,
+              "forcing_analysis_assim_alaska (last)": true,
+              "forcing_analysis_assim_alaska (max)": true,
+              "forcing_analysis_assim_hawaii (last)": true,
+              "forcing_analysis_assim_hawaii (max)": true,
+              "forcing_analysis_assim_puertorico (last)": true,
+              "forcing_analysis_assim_puertorico (max)": true,
+              "forcing_medium_range (last)": true,
+              "forcing_medium_range (max)": true,
+              "forcing_medium_range_alaska (last)": true,
+              "forcing_medium_range_alaska (max)": true,
+              "forcing_medium_range_blend (last)": true,
+              "forcing_medium_range_blend (max)": true,
+              "forcing_medium_range_blend_alaska (last)": true,
+              "forcing_medium_range_blend_alaska (max)": true,
+              "forcing_short_range (last)": true,
+              "forcing_short_range (max)": true,
+              "forcing_short_range_alaska (last)": true,
+              "forcing_short_range_alaska (max)": true,
+              "forcing_short_range_hawaii (last)": true,
+              "forcing_short_range_hawaii (max)": true,
+              "forcing_short_range_puertorico (last)": true,
+              "forcing_short_range_puertorico (max)": true,
+              "logging_status": true,
+              "medium_range_blend_coastal (last)": true,
+              "medium_range_blend_coastal (max)": true,
+              "medium_range_coastal_mem1 (last)": true,
+              "medium_range_coastal_mem1 (max)": true,
+              "message": true,
+              "pipeline_name": true,
+              "short_range_coastal (last)": true,
+              "short_range_coastal (max)": true,
+              "short_range_coastal_hawaii (last)": true,
+              "short_range_coastal_hawaii (max)": true,
+              "short_range_coastal_puertorico (last)": true,
+              "short_range_coastal_puertorico (max)": true,
+              "short_range_puertorico (max)": false
+            },
+            "indexByName": {
+              "ana_coastal_inundation_hi (max)": 2,
+              "ana_high_flow_magnitude_hi (max)": 4,
+              "ana_inundation_hi (max)": 1,
+              "ana_past_72hr_accum_precip_hi (max)": 5,
+              "ana_streamflow_hi (max)": 3,
+              "reference_time": 0
+            },
+            "renameByName": {
+              "@timestamp": "Log Time",
+              "ana_coastal_inundation_hi (max)": "Coastal FIM",
+              "ana_coastal_inundation_prvi (max)": "AnA Coastal Inundation PRVI",
+              "ana_high_flow_magnitude (max)": "AnA High Flow Magnitude",
+              "ana_high_flow_magnitude_hi (max)": "HFM",
+              "ana_inundation_hi (max)": "FIM",
+              "ana_past_72hr_accum_precip_hi (max)": "Accum Precip",
+              "ana_streamflow (max)": "AnA Streamflow",
+              "ana_streamflow_hi (max)": "Streamflow",
+              "analysis_assim (last)": "AnA",
+              "analysis_assim (max)": "AnA",
+              "analysis_assim_alaska (last)": "AnA AK",
+              "analysis_assim_alaska (max)": "AnA AK",
+              "analysis_assim_coastal": "AnA Coastal",
+              "analysis_assim_coastal (last)": "C AnA",
+              "analysis_assim_coastal (max)": "C AnA",
+              "analysis_assim_coastal_hawaii (last)": "C AnA HI",
+              "analysis_assim_coastal_hawaii (max)": "C AnA HI",
+              "analysis_assim_coastal_puertorico (last)": "C AnA PRVI",
+              "analysis_assim_coastal_puertorico (max)": "C AnA PRVI",
+              "analysis_assim_hawaii (last)": "AnA HI",
+              "analysis_assim_hawaii (max)": "AnA HI",
+              "analysis_assim_puertorico (last)": "AnA PRVI",
+              "analysis_assim_puertorico (max)": "AnA PRVI",
+              "forcing_analysis_assim (last)": "F AnA",
+              "forcing_analysis_assim (max)": "F AnA",
+              "forcing_analysis_assim_alaska (last)": "F AnA AK",
+              "forcing_analysis_assim_alaska (max)": "F AnA AK",
+              "forcing_analysis_assim_hawaii (last)": "F AnA HI",
+              "forcing_analysis_assim_hawaii (max)": "F AnA HI",
+              "forcing_analysis_assim_puertorico (last)": "F AnA PRVI",
+              "forcing_analysis_assim_puertorico (max)": "F AnA PRVI",
+              "forcing_medium_range (last)": "F MRF GFS",
+              "forcing_medium_range (max)": "F MRF GFS",
+              "forcing_medium_range_alaska (last)": "F MRF GFS AK",
+              "forcing_medium_range_alaska (max)": "F MRF GFS AK",
+              "forcing_medium_range_blend (last)": "F MRF NBM",
+              "forcing_medium_range_blend (max)": "F MRF NBM",
+              "forcing_medium_range_blend_alaska (last)": "F MRF NBM AK",
+              "forcing_medium_range_blend_alaska (max)": "F MRF NBM AK",
+              "forcing_short_range (last)": "F SRF",
+              "forcing_short_range (max)": "F SRF",
+              "forcing_short_range_alaska (last)": "F SRF AK",
+              "forcing_short_range_alaska (max)": "F SRF AK",
+              "forcing_short_range_hawaii (last)": "F SRF HI",
+              "forcing_short_range_hawaii (max)": "F SRF HI",
+              "forcing_short_range_puertorico (last)": "F SRF PRVI",
+              "forcing_short_range_puertorico (max)": "F SRF PRVI",
+              "logging_status": "",
+              "medium_range_alaska_mem1 (last)": "MRF GFS AK",
+              "medium_range_alaska_mem1 (max)": "MRF GFS AK",
+              "medium_range_blend (last)": "MRF NBM",
+              "medium_range_blend (max)": "MRF NBM",
+              "medium_range_blend_alaska (last)": "MRF NBM AK",
+              "medium_range_blend_alaska (max)": "MRF NBM AK",
+              "medium_range_blend_coastal": "MRF NBM Coastal",
+              "medium_range_blend_coastal (last)": "C MRF NBM",
+              "medium_range_blend_coastal (max)": "C MRF NBM",
+              "medium_range_coastal_mem1 (last)": "C MRF GFS",
+              "medium_range_coastal_mem1 (max)": "C MRF GFS",
+              "medium_range_mem1 (last)": "MRF GFS",
+              "medium_range_mem1 (max)": "MRF GFS",
+              "reference_time": "Reference Time",
+              "replace_route": "RnR",
+              "replace_route (last)": "RnR",
+              "replace_route (max)": "RnR",
+              "rfc": "RFC",
+              "rfc (last)": "RFC",
+              "rfc (max)": "RFC",
+              "rfc_based_5day_max_streamflow (max)": "RFC Based 5 Day Max Streamflow",
+              "short_range (last)": "SRF",
+              "short_range (max)": "SRF",
+              "short_range_alaska (last)": "SRF AK",
+              "short_range_alaska (max)": "SRF AK",
+              "short_range_coastal (last)": "C SRF",
+              "short_range_coastal (max)": "C SRF",
+              "short_range_coastal_hawaii (last)": "C SRF HI",
+              "short_range_coastal_hawaii (max)": "C SRF HI",
+              "short_range_coastal_puertorico (last)": "C SRF PRVI",
+              "short_range_coastal_puertorico (max)": "C SRF PRVI",
+              "short_range_hawaii (last)": "SRF HI",
+              "short_range_hawaii (max)": "SRF HI",
+              "short_range_puertorico (last)": "SRF PRVI",
+              "short_range_puertorico (max)": "SRF PRVI",
+              "srf_15hr_peak_flow_arrival_time_ak (max)": "SRF 15 HR Peak Flow Arrival Time AK",
+              "srf_18hr_high_water_arrival_time (max)": "SRF 18 HR High Water Arrival Time",
+              "srf_18hr_max_high_flow_magnitude (max)": "SRF 18 HR Max High Flow Magnitude",
+              "srf_18hr_peak_flow_arrival_time (max)": "SRF 18 HR Peak Flow Arrival Time",
+              "srf_18hr_rapid_onset_flooding (max)": "SRF 18 HR Rapid Onset Flooding",
+              "srf_18hr_rate_of_change (max)": "SRF 18 HR Rate of Change",
+              "step_finish": "Step Finish Time"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 50
+      },
+      "id": 43,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "<center style=\"color:black;background-color:white\"><h1>SRF Product Processing Health</h1></center>",
+        "mode": "html"
+      },
+      "pluginVersion": "9.4.7",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "mode": "basic",
+              "type": "color-background"
+            },
+            "filterable": false,
+            "inspect": false,
+            "width": 75
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#dcdcdc",
+                "value": null
+              },
+              {
+                "color": "#d0e1f2",
+                "value": 1
+              },
+              {
+                "color": "#94c4df",
+                "value": 2
+              },
+              {
+                "color": "#4a98c9",
+                "value": 3
+              },
+              {
+                "color": "#1764ab",
+                "value": 4
+              },
+              {
+                "color": "dark-green",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Reference Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 165
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "transparent",
+                      "value": null
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Coastal FIM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 96
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Accum Precip"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 110
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Streamflow"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 93
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "FIM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 52
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "HFM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 51
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "id": 49,
+      "options": {
+        "footer": {
+          "countRows": false,
+          "enablePagination": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Reference Time"
+          }
+        ]
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 39,
+          "refId": "A"
+        }
+      ],
+      "title": "SRF CONUS Product Processing",
+      "transformations": [
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"srf_*"
+                  }
+                },
+                "fieldName": "logging_status"
+              }
+            ],
+            "match": "any",
+            "type": "include"
+          }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"*_hi\\\"\"*"
+                  }
+                },
+                "fieldName": "logging_status"
+              },
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"*_prvi\\\"\"*"
+                  }
+                },
+                "fieldName": "logging_status"
+              },
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"*_ak\\\"\"*"
+                  }
+                },
+                "fieldName": "logging_status"
+              }
+            ],
+            "match": "any",
+            "type": "exclude"
+          }
+        },
+        {
+          "id": "extractFields",
+          "options": {
+            "format": "auto",
+            "jsonPaths": [
+              {
+                "path": ""
+              }
+            ],
+            "keepTime": false,
+            "replace": false,
+            "source": "logging_status"
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "reference_time"
+              },
+              {
+                "destinationType": "time",
+                "targetField": "step_finish"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "AnA Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "MRF NBM Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "RFC": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "Reference Time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "RnR": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_coastal_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_coastal_inundation_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_coastal_inundation_prvi": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "ana_for_rnr_ingest": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "ana_high_flow_magnitude": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_high_flow_magnitude_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_high_flow_magnitude_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_inundation_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_inundation_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_past_72hr_accum_precip": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_past_72hr_accum_precip_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_alaska_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_coastal_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_gfs_10day_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_nbm_10day_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "reference_time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "replace_route": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc_based_5day_max_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc_based_5day_max_streamflow": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_15hr_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_accum_precip": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_high_water_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_max_coastal_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_max_high_flow_magnitude": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_max_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_peak_flow_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_rapid_onset_flooding": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_rate_of_change": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              }
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "@timestamp": false,
+              "Time": true,
+              "ana_coastal_inundation_hi (max)": false,
+              "ana_coastal_inundation_prvi (max)": true,
+              "analysis_assim_coastal (last)": true,
+              "analysis_assim_coastal (max)": true,
+              "analysis_assim_coastal_hawaii (last)": true,
+              "analysis_assim_coastal_hawaii (max)": true,
+              "analysis_assim_coastal_puertorico (last)": true,
+              "analysis_assim_coastal_puertorico (max)": true,
+              "forcing_analysis_assim (last)": true,
+              "forcing_analysis_assim (max)": true,
+              "forcing_analysis_assim_alaska (last)": true,
+              "forcing_analysis_assim_alaska (max)": true,
+              "forcing_analysis_assim_hawaii (last)": true,
+              "forcing_analysis_assim_hawaii (max)": true,
+              "forcing_analysis_assim_puertorico (last)": true,
+              "forcing_analysis_assim_puertorico (max)": true,
+              "forcing_medium_range (last)": true,
+              "forcing_medium_range (max)": true,
+              "forcing_medium_range_alaska (last)": true,
+              "forcing_medium_range_alaska (max)": true,
+              "forcing_medium_range_blend (last)": true,
+              "forcing_medium_range_blend (max)": true,
+              "forcing_medium_range_blend_alaska (last)": true,
+              "forcing_medium_range_blend_alaska (max)": true,
+              "forcing_short_range (last)": true,
+              "forcing_short_range (max)": true,
+              "forcing_short_range_alaska (last)": true,
+              "forcing_short_range_alaska (max)": true,
+              "forcing_short_range_hawaii (last)": true,
+              "forcing_short_range_hawaii (max)": true,
+              "forcing_short_range_puertorico (last)": true,
+              "forcing_short_range_puertorico (max)": true,
+              "logging_status": true,
+              "medium_range_blend_coastal (last)": true,
+              "medium_range_blend_coastal (max)": true,
+              "medium_range_coastal_mem1 (last)": true,
+              "medium_range_coastal_mem1 (max)": true,
+              "message": true,
+              "pipeline_name": true,
+              "short_range_coastal (last)": true,
+              "short_range_coastal (max)": true,
+              "short_range_coastal_hawaii (last)": true,
+              "short_range_coastal_hawaii (max)": true,
+              "short_range_coastal_puertorico (last)": true,
+              "short_range_coastal_puertorico (max)": true,
+              "short_range_puertorico (max)": false
+            },
+            "indexByName": {
+              "ana_coastal_inundation (max)": 1,
+              "ana_high_flow_magnitude (max)": 3,
+              "ana_past_72hr_accum_precip (max)": 4,
+              "ana_streamflow (max)": 2,
+              "reference_time": 0
+            },
+            "renameByName": {
+              "@timestamp": "Log Time",
+              "ana_coastal_inundation (max)": "Coastal FIM",
+              "ana_coastal_inundation_hi (max)": "Coastal FIM",
+              "ana_coastal_inundation_prvi (max)": "AnA Coastal Inundation PRVI",
+              "ana_high_flow_magnitude (max)": "HFM",
+              "ana_high_flow_magnitude_hi (max)": "HFM",
+              "ana_inundation_hi (max)": "FIM",
+              "ana_past_72hr_accum_precip (max)": "Accum Precip",
+              "ana_past_72hr_accum_precip_hi (max)": "Accum Precip",
+              "ana_streamflow (max)": "Streamflow",
+              "ana_streamflow_hi (max)": "Streamflow",
+              "analysis_assim (last)": "AnA",
+              "analysis_assim (max)": "AnA",
+              "analysis_assim_alaska (last)": "AnA AK",
+              "analysis_assim_alaska (max)": "AnA AK",
+              "analysis_assim_coastal": "AnA Coastal",
+              "analysis_assim_coastal (last)": "C AnA",
+              "analysis_assim_coastal (max)": "C AnA",
+              "analysis_assim_coastal_hawaii (last)": "C AnA HI",
+              "analysis_assim_coastal_hawaii (max)": "C AnA HI",
+              "analysis_assim_coastal_puertorico (last)": "C AnA PRVI",
+              "analysis_assim_coastal_puertorico (max)": "C AnA PRVI",
+              "analysis_assim_hawaii (last)": "AnA HI",
+              "analysis_assim_hawaii (max)": "AnA HI",
+              "analysis_assim_puertorico (last)": "AnA PRVI",
+              "analysis_assim_puertorico (max)": "AnA PRVI",
+              "forcing_analysis_assim (last)": "F AnA",
+              "forcing_analysis_assim (max)": "F AnA",
+              "forcing_analysis_assim_alaska (last)": "F AnA AK",
+              "forcing_analysis_assim_alaska (max)": "F AnA AK",
+              "forcing_analysis_assim_hawaii (last)": "F AnA HI",
+              "forcing_analysis_assim_hawaii (max)": "F AnA HI",
+              "forcing_analysis_assim_puertorico (last)": "F AnA PRVI",
+              "forcing_analysis_assim_puertorico (max)": "F AnA PRVI",
+              "forcing_medium_range (last)": "F MRF GFS",
+              "forcing_medium_range (max)": "F MRF GFS",
+              "forcing_medium_range_alaska (last)": "F MRF GFS AK",
+              "forcing_medium_range_alaska (max)": "F MRF GFS AK",
+              "forcing_medium_range_blend (last)": "F MRF NBM",
+              "forcing_medium_range_blend (max)": "F MRF NBM",
+              "forcing_medium_range_blend_alaska (last)": "F MRF NBM AK",
+              "forcing_medium_range_blend_alaska (max)": "F MRF NBM AK",
+              "forcing_short_range (last)": "F SRF",
+              "forcing_short_range (max)": "F SRF",
+              "forcing_short_range_alaska (last)": "F SRF AK",
+              "forcing_short_range_alaska (max)": "F SRF AK",
+              "forcing_short_range_hawaii (last)": "F SRF HI",
+              "forcing_short_range_hawaii (max)": "F SRF HI",
+              "forcing_short_range_puertorico (last)": "F SRF PRVI",
+              "forcing_short_range_puertorico (max)": "F SRF PRVI",
+              "logging_status": "",
+              "medium_range_alaska_mem1 (last)": "MRF GFS AK",
+              "medium_range_alaska_mem1 (max)": "MRF GFS AK",
+              "medium_range_blend (last)": "MRF NBM",
+              "medium_range_blend (max)": "MRF NBM",
+              "medium_range_blend_alaska (last)": "MRF NBM AK",
+              "medium_range_blend_alaska (max)": "MRF NBM AK",
+              "medium_range_blend_coastal": "MRF NBM Coastal",
+              "medium_range_blend_coastal (last)": "C MRF NBM",
+              "medium_range_blend_coastal (max)": "C MRF NBM",
+              "medium_range_coastal_mem1 (last)": "C MRF GFS",
+              "medium_range_coastal_mem1 (max)": "C MRF GFS",
+              "medium_range_mem1 (last)": "MRF GFS",
+              "medium_range_mem1 (max)": "MRF GFS",
+              "reference_time": "Reference Time",
+              "replace_route": "RnR",
+              "replace_route (last)": "RnR",
+              "replace_route (max)": "RnR",
+              "rfc": "RFC",
+              "rfc (last)": "RFC",
+              "rfc (max)": "RFC",
+              "rfc_based_5day_max_streamflow (max)": "RFC Based 5 Day Max Streamflow",
+              "short_range (last)": "SRF",
+              "short_range (max)": "SRF",
+              "short_range_alaska (last)": "SRF AK",
+              "short_range_alaska (max)": "SRF AK",
+              "short_range_coastal (last)": "C SRF",
+              "short_range_coastal (max)": "C SRF",
+              "short_range_coastal_hawaii (last)": "C SRF HI",
+              "short_range_coastal_hawaii (max)": "C SRF HI",
+              "short_range_coastal_puertorico (last)": "C SRF PRVI",
+              "short_range_coastal_puertorico (max)": "C SRF PRVI",
+              "short_range_hawaii (last)": "SRF HI",
+              "short_range_hawaii (max)": "SRF HI",
+              "short_range_puertorico (last)": "SRF PRVI",
+              "short_range_puertorico (max)": "SRF PRVI",
+              "srf_15hr_peak_flow_arrival_time_ak (max)": "SRF 15 HR Peak Flow Arrival Time AK",
+              "srf_18hr_accum_precip (max)": "Accum Precip",
+              "srf_18hr_high_water_arrival_time (max)": "HWAT",
+              "srf_18hr_max_coastal_inundation (max)": "Coastal FIM",
+              "srf_18hr_max_high_flow_magnitude (max)": "HFM",
+              "srf_18hr_max_inundation (max)": "FIM",
+              "srf_18hr_peak_flow_arrival_time (max)": "PFAT",
+              "srf_18hr_rapid_onset_flooding (max)": "ROF",
+              "srf_18hr_rate_of_change (max)": "ROC",
+              "step_finish": "Step Finish Time"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "mode": "basic",
+              "type": "color-background"
+            },
+            "filterable": false,
+            "inspect": false,
+            "width": 75
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#dcdcdc",
+                "value": null
+              },
+              {
+                "color": "#d0e1f2",
+                "value": 1
+              },
+              {
+                "color": "#94c4df",
+                "value": 2
+              },
+              {
+                "color": "#4a98c9",
+                "value": 3
+              },
+              {
+                "color": "#1764ab",
+                "value": 4
+              },
+              {
+                "color": "dark-green",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Reference Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 165
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "transparent",
+                      "value": null
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Coastal FIM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 99
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Accum Precip"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 115
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Streamflow"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 99
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "FIM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 49
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "HFM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 48
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 58
+      },
+      "id": 50,
+      "options": {
+        "footer": {
+          "countRows": false,
+          "enablePagination": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Reference Time"
+          }
+        ]
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 39,
+          "refId": "A"
+        }
+      ],
+      "title": "SRF Alaska Product Processing",
+      "transformations": [
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"srf_*"
+                  }
+                },
+                "fieldName": "logging_status"
+              }
+            ],
+            "match": "any",
+            "type": "include"
+          }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"*_ak\\\"\"*"
+                  }
+                },
+                "fieldName": "logging_status"
+              }
+            ],
+            "match": "any",
+            "type": "include"
+          }
+        },
+        {
+          "id": "extractFields",
+          "options": {
+            "format": "auto",
+            "jsonPaths": [
+              {
+                "path": ""
+              }
+            ],
+            "keepTime": false,
+            "replace": false,
+            "source": "logging_status"
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "reference_time"
+              },
+              {
+                "destinationType": "time",
+                "targetField": "step_finish"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "AnA Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "MRF NBM Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "RFC": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "Reference Time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "RnR": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_coastal_inundation_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_coastal_inundation_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_for_rnr_ingest": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "ana_high_flow_magnitude": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_high_flow_magnitude_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_high_flow_magnitude_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_inundation_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_inundation_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_past_72hr_accum_precip_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_past_72hr_accum_precip_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_past_72hr_accum_precip_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_alaska_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_coastal_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_gfs_10day_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_nbm_10day_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "reference_time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "replace_route": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc_based_5day_max_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc_based_5day_max_streamflow": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_15hr_accum_precip_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_15hr_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_high_water_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_max_high_flow_magnitude": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_max_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_peak_flow_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_rapid_onset_flooding": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_rate_of_change": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              }
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "@timestamp": false,
+              "Time": true,
+              "ana_coastal_inundation_hi (max)": false,
+              "ana_coastal_inundation_prvi (max)": false,
+              "analysis_assim_coastal (last)": true,
+              "analysis_assim_coastal (max)": true,
+              "analysis_assim_coastal_hawaii (last)": true,
+              "analysis_assim_coastal_hawaii (max)": true,
+              "analysis_assim_coastal_puertorico (last)": true,
+              "analysis_assim_coastal_puertorico (max)": true,
+              "forcing_analysis_assim (last)": true,
+              "forcing_analysis_assim (max)": true,
+              "forcing_analysis_assim_alaska (last)": true,
+              "forcing_analysis_assim_alaska (max)": true,
+              "forcing_analysis_assim_hawaii (last)": true,
+              "forcing_analysis_assim_hawaii (max)": true,
+              "forcing_analysis_assim_puertorico (last)": true,
+              "forcing_analysis_assim_puertorico (max)": true,
+              "forcing_medium_range (last)": true,
+              "forcing_medium_range (max)": true,
+              "forcing_medium_range_alaska (last)": true,
+              "forcing_medium_range_alaska (max)": true,
+              "forcing_medium_range_blend (last)": true,
+              "forcing_medium_range_blend (max)": true,
+              "forcing_medium_range_blend_alaska (last)": true,
+              "forcing_medium_range_blend_alaska (max)": true,
+              "forcing_short_range (last)": true,
+              "forcing_short_range (max)": true,
+              "forcing_short_range_alaska (last)": true,
+              "forcing_short_range_alaska (max)": true,
+              "forcing_short_range_hawaii (last)": true,
+              "forcing_short_range_hawaii (max)": true,
+              "forcing_short_range_puertorico (last)": true,
+              "forcing_short_range_puertorico (max)": true,
+              "logging_status": true,
+              "medium_range_blend_coastal (last)": true,
+              "medium_range_blend_coastal (max)": true,
+              "medium_range_coastal_mem1 (last)": true,
+              "medium_range_coastal_mem1 (max)": true,
+              "message": true,
+              "pipeline_name": true,
+              "short_range_coastal (last)": true,
+              "short_range_coastal (max)": true,
+              "short_range_coastal_hawaii (last)": true,
+              "short_range_coastal_hawaii (max)": true,
+              "short_range_coastal_puertorico (last)": true,
+              "short_range_coastal_puertorico (max)": true,
+              "short_range_puertorico (max)": false
+            },
+            "indexByName": {
+              "reference_time": 0,
+              "srf_15hr_accum_precip_ak (max)": 2,
+              "srf_15hr_peak_flow_arrival_time_ak (max)": 1
+            },
+            "renameByName": {
+              "@timestamp": "Log Time",
+              "ana_coastal_inundation_hi (max)": "Coastal FIM",
+              "ana_coastal_inundation_prvi (max)": "Coastal FIM",
+              "ana_high_flow_magnitude (max)": "AnA High Flow Magnitude",
+              "ana_high_flow_magnitude_hi (max)": "HFM",
+              "ana_high_flow_magnitude_prvi (max)": "HFM",
+              "ana_inundation_hi (max)": "FIM",
+              "ana_inundation_prvi (max)": "FIM",
+              "ana_past_72hr_accum_precip_ak (max)": "Accum Precip",
+              "ana_past_72hr_accum_precip_hi (max)": "Accum Precip",
+              "ana_past_72hr_accum_precip_prvi (max)": "Accum Precip",
+              "ana_streamflow (max)": "AnA Streamflow",
+              "ana_streamflow_ak (max)": "Streamflow",
+              "ana_streamflow_hi (max)": "Streamflow",
+              "ana_streamflow_prvi (max)": "Streamflow",
+              "analysis_assim (last)": "AnA",
+              "analysis_assim (max)": "AnA",
+              "analysis_assim_alaska (last)": "AnA AK",
+              "analysis_assim_alaska (max)": "AnA AK",
+              "analysis_assim_coastal": "AnA Coastal",
+              "analysis_assim_coastal (last)": "C AnA",
+              "analysis_assim_coastal (max)": "C AnA",
+              "analysis_assim_coastal_hawaii (last)": "C AnA HI",
+              "analysis_assim_coastal_hawaii (max)": "C AnA HI",
+              "analysis_assim_coastal_puertorico (last)": "C AnA PRVI",
+              "analysis_assim_coastal_puertorico (max)": "C AnA PRVI",
+              "analysis_assim_hawaii (last)": "AnA HI",
+              "analysis_assim_hawaii (max)": "AnA HI",
+              "analysis_assim_puertorico (last)": "AnA PRVI",
+              "analysis_assim_puertorico (max)": "AnA PRVI",
+              "forcing_analysis_assim (last)": "F AnA",
+              "forcing_analysis_assim (max)": "F AnA",
+              "forcing_analysis_assim_alaska (last)": "F AnA AK",
+              "forcing_analysis_assim_alaska (max)": "F AnA AK",
+              "forcing_analysis_assim_hawaii (last)": "F AnA HI",
+              "forcing_analysis_assim_hawaii (max)": "F AnA HI",
+              "forcing_analysis_assim_puertorico (last)": "F AnA PRVI",
+              "forcing_analysis_assim_puertorico (max)": "F AnA PRVI",
+              "forcing_medium_range (last)": "F MRF GFS",
+              "forcing_medium_range (max)": "F MRF GFS",
+              "forcing_medium_range_alaska (last)": "F MRF GFS AK",
+              "forcing_medium_range_alaska (max)": "F MRF GFS AK",
+              "forcing_medium_range_blend (last)": "F MRF NBM",
+              "forcing_medium_range_blend (max)": "F MRF NBM",
+              "forcing_medium_range_blend_alaska (last)": "F MRF NBM AK",
+              "forcing_medium_range_blend_alaska (max)": "F MRF NBM AK",
+              "forcing_short_range (last)": "F SRF",
+              "forcing_short_range (max)": "F SRF",
+              "forcing_short_range_alaska (last)": "F SRF AK",
+              "forcing_short_range_alaska (max)": "F SRF AK",
+              "forcing_short_range_hawaii (last)": "F SRF HI",
+              "forcing_short_range_hawaii (max)": "F SRF HI",
+              "forcing_short_range_puertorico (last)": "F SRF PRVI",
+              "forcing_short_range_puertorico (max)": "F SRF PRVI",
+              "logging_status": "",
+              "medium_range_alaska_mem1 (last)": "MRF GFS AK",
+              "medium_range_alaska_mem1 (max)": "MRF GFS AK",
+              "medium_range_blend (last)": "MRF NBM",
+              "medium_range_blend (max)": "MRF NBM",
+              "medium_range_blend_alaska (last)": "MRF NBM AK",
+              "medium_range_blend_alaska (max)": "MRF NBM AK",
+              "medium_range_blend_coastal": "MRF NBM Coastal",
+              "medium_range_blend_coastal (last)": "C MRF NBM",
+              "medium_range_blend_coastal (max)": "C MRF NBM",
+              "medium_range_coastal_mem1 (last)": "C MRF GFS",
+              "medium_range_coastal_mem1 (max)": "C MRF GFS",
+              "medium_range_mem1 (last)": "MRF GFS",
+              "medium_range_mem1 (max)": "MRF GFS",
+              "reference_time": "Reference Time",
+              "replace_route": "RnR",
+              "replace_route (last)": "RnR",
+              "replace_route (max)": "RnR",
+              "rfc": "RFC",
+              "rfc (last)": "RFC",
+              "rfc (max)": "RFC",
+              "rfc_based_5day_max_streamflow (max)": "RFC Based 5 Day Max Streamflow",
+              "short_range (last)": "SRF",
+              "short_range (max)": "SRF",
+              "short_range_alaska (last)": "SRF AK",
+              "short_range_alaska (max)": "SRF AK",
+              "short_range_coastal (last)": "C SRF",
+              "short_range_coastal (max)": "C SRF",
+              "short_range_coastal_hawaii (last)": "C SRF HI",
+              "short_range_coastal_hawaii (max)": "C SRF HI",
+              "short_range_coastal_puertorico (last)": "C SRF PRVI",
+              "short_range_coastal_puertorico (max)": "C SRF PRVI",
+              "short_range_hawaii (last)": "SRF HI",
+              "short_range_hawaii (max)": "SRF HI",
+              "short_range_puertorico (last)": "SRF PRVI",
+              "short_range_puertorico (max)": "SRF PRVI",
+              "srf_15hr_accum_precip_ak (max)": "Accum Precip",
+              "srf_15hr_peak_flow_arrival_time_ak (max)": "PFAT",
+              "srf_18hr_high_water_arrival_time (max)": "SRF 18 HR High Water Arrival Time",
+              "srf_18hr_max_high_flow_magnitude (max)": "SRF 18 HR Max High Flow Magnitude",
+              "srf_18hr_peak_flow_arrival_time (max)": "SRF 18 HR Peak Flow Arrival Time",
+              "srf_18hr_rapid_onset_flooding (max)": "SRF 18 HR Rapid Onset Flooding",
+              "srf_18hr_rate_of_change (max)": "SRF 18 HR Rate of Change",
+              "step_finish": "Step Finish Time"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "mode": "basic",
+              "type": "color-background"
+            },
+            "filterable": false,
+            "inspect": false,
+            "width": 75
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#dcdcdc",
+                "value": null
+              },
+              {
+                "color": "#d0e1f2",
+                "value": 1
+              },
+              {
+                "color": "#94c4df",
+                "value": 2
+              },
+              {
+                "color": "#4a98c9",
+                "value": 3
+              },
+              {
+                "color": "#1764ab",
+                "value": 4
+              },
+              {
+                "color": "dark-green",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Reference Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 165
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "transparent",
+                      "value": null
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Coastal FIM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 99
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Accum Precip"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 115
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Streamflow"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 99
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "FIM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 49
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "HFM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 48
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 58
+      },
+      "id": 54,
+      "options": {
+        "footer": {
+          "countRows": false,
+          "enablePagination": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Reference Time"
+          }
+        ]
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 39,
+          "refId": "A"
+        }
+      ],
+      "title": "SRF Puerto Rico Product Processing",
+      "transformations": [
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"srf_*"
+                  }
+                },
+                "fieldName": "logging_status"
+              }
+            ],
+            "match": "any",
+            "type": "include"
+          }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"*_prvi\\\"\"*"
+                  }
+                },
+                "fieldName": "logging_status"
+              }
+            ],
+            "match": "any",
+            "type": "include"
+          }
+        },
+        {
+          "id": "extractFields",
+          "options": {
+            "format": "auto",
+            "jsonPaths": [
+              {
+                "path": ""
+              }
+            ],
+            "keepTime": false,
+            "replace": false,
+            "source": "logging_status"
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "reference_time"
+              },
+              {
+                "destinationType": "time",
+                "targetField": "step_finish"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "AnA Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "MRF NBM Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "RFC": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "Reference Time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "RnR": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_coastal_inundation_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_coastal_inundation_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_for_rnr_ingest": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "ana_high_flow_magnitude": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_high_flow_magnitude_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_high_flow_magnitude_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_inundation_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_inundation_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_past_72hr_accum_precip_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_past_72hr_accum_precip_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_past_72hr_accum_precip_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_alaska_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_coastal_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_gfs_10day_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_nbm_10day_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "reference_time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "replace_route": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc_based_5day_max_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc_based_5day_max_streamflow": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_15hr_accum_precip_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_15hr_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_high_water_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_max_high_flow_magnitude": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_max_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_peak_flow_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_rapid_onset_flooding": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_rate_of_change": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              }
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "@timestamp": false,
+              "Time": true,
+              "ana_coastal_inundation_hi (max)": false,
+              "ana_coastal_inundation_prvi (max)": false,
+              "analysis_assim_coastal (last)": true,
+              "analysis_assim_coastal (max)": true,
+              "analysis_assim_coastal_hawaii (last)": true,
+              "analysis_assim_coastal_hawaii (max)": true,
+              "analysis_assim_coastal_puertorico (last)": true,
+              "analysis_assim_coastal_puertorico (max)": true,
+              "forcing_analysis_assim (last)": true,
+              "forcing_analysis_assim (max)": true,
+              "forcing_analysis_assim_alaska (last)": true,
+              "forcing_analysis_assim_alaska (max)": true,
+              "forcing_analysis_assim_hawaii (last)": true,
+              "forcing_analysis_assim_hawaii (max)": true,
+              "forcing_analysis_assim_puertorico (last)": true,
+              "forcing_analysis_assim_puertorico (max)": true,
+              "forcing_medium_range (last)": true,
+              "forcing_medium_range (max)": true,
+              "forcing_medium_range_alaska (last)": true,
+              "forcing_medium_range_alaska (max)": true,
+              "forcing_medium_range_blend (last)": true,
+              "forcing_medium_range_blend (max)": true,
+              "forcing_medium_range_blend_alaska (last)": true,
+              "forcing_medium_range_blend_alaska (max)": true,
+              "forcing_short_range (last)": true,
+              "forcing_short_range (max)": true,
+              "forcing_short_range_alaska (last)": true,
+              "forcing_short_range_alaska (max)": true,
+              "forcing_short_range_hawaii (last)": true,
+              "forcing_short_range_hawaii (max)": true,
+              "forcing_short_range_puertorico (last)": true,
+              "forcing_short_range_puertorico (max)": true,
+              "logging_status": true,
+              "medium_range_blend_coastal (last)": true,
+              "medium_range_blend_coastal (max)": true,
+              "medium_range_coastal_mem1 (last)": true,
+              "medium_range_coastal_mem1 (max)": true,
+              "message": true,
+              "pipeline_name": true,
+              "short_range_coastal (last)": true,
+              "short_range_coastal (max)": true,
+              "short_range_coastal_hawaii (last)": true,
+              "short_range_coastal_hawaii (max)": true,
+              "short_range_coastal_puertorico (last)": true,
+              "short_range_coastal_puertorico (max)": true,
+              "short_range_puertorico (max)": false
+            },
+            "indexByName": {
+              "reference_time": 0,
+              "srf_15hr_accum_precip_ak (max)": 2,
+              "srf_15hr_peak_flow_arrival_time_ak (max)": 1
+            },
+            "renameByName": {
+              "@timestamp": "Log Time",
+              "ana_coastal_inundation_hi (max)": "Coastal FIM",
+              "ana_coastal_inundation_prvi (max)": "Coastal FIM",
+              "ana_high_flow_magnitude (max)": "AnA High Flow Magnitude",
+              "ana_high_flow_magnitude_hi (max)": "HFM",
+              "ana_high_flow_magnitude_prvi (max)": "HFM",
+              "ana_inundation_hi (max)": "FIM",
+              "ana_inundation_prvi (max)": "FIM",
+              "ana_past_72hr_accum_precip_ak (max)": "Accum Precip",
+              "ana_past_72hr_accum_precip_hi (max)": "Accum Precip",
+              "ana_past_72hr_accum_precip_prvi (max)": "Accum Precip",
+              "ana_streamflow (max)": "AnA Streamflow",
+              "ana_streamflow_ak (max)": "Streamflow",
+              "ana_streamflow_hi (max)": "Streamflow",
+              "ana_streamflow_prvi (max)": "Streamflow",
+              "analysis_assim (last)": "AnA",
+              "analysis_assim (max)": "AnA",
+              "analysis_assim_alaska (last)": "AnA AK",
+              "analysis_assim_alaska (max)": "AnA AK",
+              "analysis_assim_coastal": "AnA Coastal",
+              "analysis_assim_coastal (last)": "C AnA",
+              "analysis_assim_coastal (max)": "C AnA",
+              "analysis_assim_coastal_hawaii (last)": "C AnA HI",
+              "analysis_assim_coastal_hawaii (max)": "C AnA HI",
+              "analysis_assim_coastal_puertorico (last)": "C AnA PRVI",
+              "analysis_assim_coastal_puertorico (max)": "C AnA PRVI",
+              "analysis_assim_hawaii (last)": "AnA HI",
+              "analysis_assim_hawaii (max)": "AnA HI",
+              "analysis_assim_puertorico (last)": "AnA PRVI",
+              "analysis_assim_puertorico (max)": "AnA PRVI",
+              "forcing_analysis_assim (last)": "F AnA",
+              "forcing_analysis_assim (max)": "F AnA",
+              "forcing_analysis_assim_alaska (last)": "F AnA AK",
+              "forcing_analysis_assim_alaska (max)": "F AnA AK",
+              "forcing_analysis_assim_hawaii (last)": "F AnA HI",
+              "forcing_analysis_assim_hawaii (max)": "F AnA HI",
+              "forcing_analysis_assim_puertorico (last)": "F AnA PRVI",
+              "forcing_analysis_assim_puertorico (max)": "F AnA PRVI",
+              "forcing_medium_range (last)": "F MRF GFS",
+              "forcing_medium_range (max)": "F MRF GFS",
+              "forcing_medium_range_alaska (last)": "F MRF GFS AK",
+              "forcing_medium_range_alaska (max)": "F MRF GFS AK",
+              "forcing_medium_range_blend (last)": "F MRF NBM",
+              "forcing_medium_range_blend (max)": "F MRF NBM",
+              "forcing_medium_range_blend_alaska (last)": "F MRF NBM AK",
+              "forcing_medium_range_blend_alaska (max)": "F MRF NBM AK",
+              "forcing_short_range (last)": "F SRF",
+              "forcing_short_range (max)": "F SRF",
+              "forcing_short_range_alaska (last)": "F SRF AK",
+              "forcing_short_range_alaska (max)": "F SRF AK",
+              "forcing_short_range_hawaii (last)": "F SRF HI",
+              "forcing_short_range_hawaii (max)": "F SRF HI",
+              "forcing_short_range_puertorico (last)": "F SRF PRVI",
+              "forcing_short_range_puertorico (max)": "F SRF PRVI",
+              "logging_status": "",
+              "medium_range_alaska_mem1 (last)": "MRF GFS AK",
+              "medium_range_alaska_mem1 (max)": "MRF GFS AK",
+              "medium_range_blend (last)": "MRF NBM",
+              "medium_range_blend (max)": "MRF NBM",
+              "medium_range_blend_alaska (last)": "MRF NBM AK",
+              "medium_range_blend_alaska (max)": "MRF NBM AK",
+              "medium_range_blend_coastal": "MRF NBM Coastal",
+              "medium_range_blend_coastal (last)": "C MRF NBM",
+              "medium_range_blend_coastal (max)": "C MRF NBM",
+              "medium_range_coastal_mem1 (last)": "C MRF GFS",
+              "medium_range_coastal_mem1 (max)": "C MRF GFS",
+              "medium_range_mem1 (last)": "MRF GFS",
+              "medium_range_mem1 (max)": "MRF GFS",
+              "reference_time": "Reference Time",
+              "replace_route": "RnR",
+              "replace_route (last)": "RnR",
+              "replace_route (max)": "RnR",
+              "rfc": "RFC",
+              "rfc (last)": "RFC",
+              "rfc (max)": "RFC",
+              "rfc_based_5day_max_streamflow (max)": "RFC Based 5 Day Max Streamflow",
+              "short_range (last)": "SRF",
+              "short_range (max)": "SRF",
+              "short_range_alaska (last)": "SRF AK",
+              "short_range_alaska (max)": "SRF AK",
+              "short_range_coastal (last)": "C SRF",
+              "short_range_coastal (max)": "C SRF",
+              "short_range_coastal_hawaii (last)": "C SRF HI",
+              "short_range_coastal_hawaii (max)": "C SRF HI",
+              "short_range_coastal_puertorico (last)": "C SRF PRVI",
+              "short_range_coastal_puertorico (max)": "C SRF PRVI",
+              "short_range_hawaii (last)": "SRF HI",
+              "short_range_hawaii (max)": "SRF HI",
+              "short_range_puertorico (last)": "SRF PRVI",
+              "short_range_puertorico (max)": "SRF PRVI",
+              "srf_15hr_accum_precip_ak (max)": "Accum Precip",
+              "srf_15hr_peak_flow_arrival_time_ak (max)": "PFAT",
+              "srf_18hr_high_water_arrival_time (max)": "SRF 18 HR High Water Arrival Time",
+              "srf_18hr_max_high_flow_magnitude (max)": "SRF 18 HR Max High Flow Magnitude",
+              "srf_18hr_peak_flow_arrival_time (max)": "SRF 18 HR Peak Flow Arrival Time",
+              "srf_18hr_rapid_onset_flooding (max)": "SRF 18 HR Rapid Onset Flooding",
+              "srf_18hr_rate_of_change (max)": "SRF 18 HR Rate of Change",
+              "step_finish": "Step Finish Time"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "mode": "basic",
+              "type": "color-background"
+            },
+            "filterable": false,
+            "inspect": false,
+            "width": 75
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#dcdcdc",
+                "value": null
+              },
+              {
+                "color": "#d0e1f2",
+                "value": 1
+              },
+              {
+                "color": "#94c4df",
+                "value": 2
+              },
+              {
+                "color": "#4a98c9",
+                "value": 3
+              },
+              {
+                "color": "#1764ab",
+                "value": 4
+              },
+              {
+                "color": "dark-green",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Reference Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 165
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "transparent",
+                      "value": null
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Coastal FIM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 96
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Accum Precip"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 110
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Streamflow"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 93
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "FIM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 52
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "HFM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 51
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 58
+      },
+      "id": 52,
+      "options": {
+        "footer": {
+          "countRows": false,
+          "enablePagination": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Reference Time"
+          }
+        ]
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 39,
+          "refId": "A"
+        }
+      ],
+      "title": "SRF Hawaii Product Processing",
+      "transformations": [
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"srf_*"
+                  }
+                },
+                "fieldName": "logging_status"
+              }
+            ],
+            "match": "any",
+            "type": "include"
+          }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"*_hi\\\"\"*"
+                  }
+                },
+                "fieldName": "logging_status"
+              }
+            ],
+            "match": "any",
+            "type": "include"
+          }
+        },
+        {
+          "id": "extractFields",
+          "options": {
+            "format": "auto",
+            "jsonPaths": [
+              {
+                "path": ""
+              }
+            ],
+            "keepTime": false,
+            "replace": false,
+            "source": "logging_status"
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "reference_time"
+              },
+              {
+                "destinationType": "time",
+                "targetField": "step_finish"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "AnA Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "MRF NBM Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "RFC": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "Reference Time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "RnR": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_coastal_inundation_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_coastal_inundation_prvi": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "ana_for_rnr_ingest": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "ana_high_flow_magnitude": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_high_flow_magnitude_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_high_flow_magnitude_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_inundation_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_inundation_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_past_72hr_accum_precip_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_alaska_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_coastal_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_gfs_10day_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_nbm_10day_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "reference_time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "replace_route": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc_based_5day_max_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc_based_5day_max_streamflow": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_15hr_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_high_water_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_max_high_flow_magnitude": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_max_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_peak_flow_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_rapid_onset_flooding": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_rate_of_change": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              }
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "@timestamp": false,
+              "Time": true,
+              "ana_coastal_inundation_hi (max)": false,
+              "ana_coastal_inundation_prvi (max)": true,
+              "analysis_assim_coastal (last)": true,
+              "analysis_assim_coastal (max)": true,
+              "analysis_assim_coastal_hawaii (last)": true,
+              "analysis_assim_coastal_hawaii (max)": true,
+              "analysis_assim_coastal_puertorico (last)": true,
+              "analysis_assim_coastal_puertorico (max)": true,
+              "forcing_analysis_assim (last)": true,
+              "forcing_analysis_assim (max)": true,
+              "forcing_analysis_assim_alaska (last)": true,
+              "forcing_analysis_assim_alaska (max)": true,
+              "forcing_analysis_assim_hawaii (last)": true,
+              "forcing_analysis_assim_hawaii (max)": true,
+              "forcing_analysis_assim_puertorico (last)": true,
+              "forcing_analysis_assim_puertorico (max)": true,
+              "forcing_medium_range (last)": true,
+              "forcing_medium_range (max)": true,
+              "forcing_medium_range_alaska (last)": true,
+              "forcing_medium_range_alaska (max)": true,
+              "forcing_medium_range_blend (last)": true,
+              "forcing_medium_range_blend (max)": true,
+              "forcing_medium_range_blend_alaska (last)": true,
+              "forcing_medium_range_blend_alaska (max)": true,
+              "forcing_short_range (last)": true,
+              "forcing_short_range (max)": true,
+              "forcing_short_range_alaska (last)": true,
+              "forcing_short_range_alaska (max)": true,
+              "forcing_short_range_hawaii (last)": true,
+              "forcing_short_range_hawaii (max)": true,
+              "forcing_short_range_puertorico (last)": true,
+              "forcing_short_range_puertorico (max)": true,
+              "logging_status": true,
+              "medium_range_blend_coastal (last)": true,
+              "medium_range_blend_coastal (max)": true,
+              "medium_range_coastal_mem1 (last)": true,
+              "medium_range_coastal_mem1 (max)": true,
+              "message": true,
+              "pipeline_name": true,
+              "short_range_coastal (last)": true,
+              "short_range_coastal (max)": true,
+              "short_range_coastal_hawaii (last)": true,
+              "short_range_coastal_hawaii (max)": true,
+              "short_range_coastal_puertorico (last)": true,
+              "short_range_coastal_puertorico (max)": true,
+              "short_range_puertorico (max)": false
+            },
+            "indexByName": {
+              "ana_coastal_inundation_hi (max)": 2,
+              "ana_high_flow_magnitude_hi (max)": 4,
+              "ana_inundation_hi (max)": 1,
+              "ana_past_72hr_accum_precip_hi (max)": 5,
+              "ana_streamflow_hi (max)": 3,
+              "reference_time": 0
+            },
+            "renameByName": {
+              "@timestamp": "Log Time",
+              "ana_coastal_inundation_hi (max)": "Coastal FIM",
+              "ana_coastal_inundation_prvi (max)": "AnA Coastal Inundation PRVI",
+              "ana_high_flow_magnitude (max)": "AnA High Flow Magnitude",
+              "ana_high_flow_magnitude_hi (max)": "HFM",
+              "ana_inundation_hi (max)": "FIM",
+              "ana_past_72hr_accum_precip_hi (max)": "Accum Precip",
+              "ana_streamflow (max)": "AnA Streamflow",
+              "ana_streamflow_hi (max)": "Streamflow",
+              "analysis_assim (last)": "AnA",
+              "analysis_assim (max)": "AnA",
+              "analysis_assim_alaska (last)": "AnA AK",
+              "analysis_assim_alaska (max)": "AnA AK",
+              "analysis_assim_coastal": "AnA Coastal",
+              "analysis_assim_coastal (last)": "C AnA",
+              "analysis_assim_coastal (max)": "C AnA",
+              "analysis_assim_coastal_hawaii (last)": "C AnA HI",
+              "analysis_assim_coastal_hawaii (max)": "C AnA HI",
+              "analysis_assim_coastal_puertorico (last)": "C AnA PRVI",
+              "analysis_assim_coastal_puertorico (max)": "C AnA PRVI",
+              "analysis_assim_hawaii (last)": "AnA HI",
+              "analysis_assim_hawaii (max)": "AnA HI",
+              "analysis_assim_puertorico (last)": "AnA PRVI",
+              "analysis_assim_puertorico (max)": "AnA PRVI",
+              "forcing_analysis_assim (last)": "F AnA",
+              "forcing_analysis_assim (max)": "F AnA",
+              "forcing_analysis_assim_alaska (last)": "F AnA AK",
+              "forcing_analysis_assim_alaska (max)": "F AnA AK",
+              "forcing_analysis_assim_hawaii (last)": "F AnA HI",
+              "forcing_analysis_assim_hawaii (max)": "F AnA HI",
+              "forcing_analysis_assim_puertorico (last)": "F AnA PRVI",
+              "forcing_analysis_assim_puertorico (max)": "F AnA PRVI",
+              "forcing_medium_range (last)": "F MRF GFS",
+              "forcing_medium_range (max)": "F MRF GFS",
+              "forcing_medium_range_alaska (last)": "F MRF GFS AK",
+              "forcing_medium_range_alaska (max)": "F MRF GFS AK",
+              "forcing_medium_range_blend (last)": "F MRF NBM",
+              "forcing_medium_range_blend (max)": "F MRF NBM",
+              "forcing_medium_range_blend_alaska (last)": "F MRF NBM AK",
+              "forcing_medium_range_blend_alaska (max)": "F MRF NBM AK",
+              "forcing_short_range (last)": "F SRF",
+              "forcing_short_range (max)": "F SRF",
+              "forcing_short_range_alaska (last)": "F SRF AK",
+              "forcing_short_range_alaska (max)": "F SRF AK",
+              "forcing_short_range_hawaii (last)": "F SRF HI",
+              "forcing_short_range_hawaii (max)": "F SRF HI",
+              "forcing_short_range_puertorico (last)": "F SRF PRVI",
+              "forcing_short_range_puertorico (max)": "F SRF PRVI",
+              "logging_status": "",
+              "medium_range_alaska_mem1 (last)": "MRF GFS AK",
+              "medium_range_alaska_mem1 (max)": "MRF GFS AK",
+              "medium_range_blend (last)": "MRF NBM",
+              "medium_range_blend (max)": "MRF NBM",
+              "medium_range_blend_alaska (last)": "MRF NBM AK",
+              "medium_range_blend_alaska (max)": "MRF NBM AK",
+              "medium_range_blend_coastal": "MRF NBM Coastal",
+              "medium_range_blend_coastal (last)": "C MRF NBM",
+              "medium_range_blend_coastal (max)": "C MRF NBM",
+              "medium_range_coastal_mem1 (last)": "C MRF GFS",
+              "medium_range_coastal_mem1 (max)": "C MRF GFS",
+              "medium_range_mem1 (last)": "MRF GFS",
+              "medium_range_mem1 (max)": "MRF GFS",
+              "reference_time": "Reference Time",
+              "replace_route": "RnR",
+              "replace_route (last)": "RnR",
+              "replace_route (max)": "RnR",
+              "rfc": "RFC",
+              "rfc (last)": "RFC",
+              "rfc (max)": "RFC",
+              "rfc_based_5day_max_streamflow (max)": "RFC Based 5 Day Max Streamflow",
+              "short_range (last)": "SRF",
+              "short_range (max)": "SRF",
+              "short_range_alaska (last)": "SRF AK",
+              "short_range_alaska (max)": "SRF AK",
+              "short_range_coastal (last)": "C SRF",
+              "short_range_coastal (max)": "C SRF",
+              "short_range_coastal_hawaii (last)": "C SRF HI",
+              "short_range_coastal_hawaii (max)": "C SRF HI",
+              "short_range_coastal_puertorico (last)": "C SRF PRVI",
+              "short_range_coastal_puertorico (max)": "C SRF PRVI",
+              "short_range_hawaii (last)": "SRF HI",
+              "short_range_hawaii (max)": "SRF HI",
+              "short_range_puertorico (last)": "SRF PRVI",
+              "short_range_puertorico (max)": "SRF PRVI",
+              "srf_15hr_peak_flow_arrival_time_ak (max)": "SRF 15 HR Peak Flow Arrival Time AK",
+              "srf_18hr_high_water_arrival_time (max)": "SRF 18 HR High Water Arrival Time",
+              "srf_18hr_max_high_flow_magnitude (max)": "SRF 18 HR Max High Flow Magnitude",
+              "srf_18hr_peak_flow_arrival_time (max)": "SRF 18 HR Peak Flow Arrival Time",
+              "srf_18hr_rapid_onset_flooding (max)": "SRF 18 HR Rapid Onset Flooding",
+              "srf_18hr_rate_of_change (max)": "SRF 18 HR Rate of Change",
+              "step_finish": "Step Finish Time"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 64
+      },
+      "id": 45,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "<center style=\"color:black;background-color:white\"><h1>MRF GFS Product Processing Health</h1></center>",
+        "mode": "html"
+      },
+      "pluginVersion": "9.4.7",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "mode": "basic",
+              "type": "color-background"
+            },
+            "filterable": false,
+            "inspect": false,
+            "width": 75
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#dcdcdc",
+                "value": null
+              },
+              {
+                "color": "#d0e1f2",
+                "value": 1
+              },
+              {
+                "color": "#94c4df",
+                "value": 2
+              },
+              {
+                "color": "#4a98c9",
+                "value": 3
+              },
+              {
+                "color": "#1764ab",
+                "value": 4
+              },
+              {
+                "color": "dark-green",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Reference Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 165
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "transparent",
+                      "value": null
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Coastal FIM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 96
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Accum Precip"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 110
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Streamflow"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 93
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "FIM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 52
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "HFM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 51
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 66
+      },
+      "id": 53,
+      "options": {
+        "footer": {
+          "countRows": false,
+          "enablePagination": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Reference Time"
+          }
+        ]
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 39,
+          "refId": "A"
+        }
+      ],
+      "title": "MRF GFS CONUS Product Processing",
+      "transformations": [
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"mrf_gfs_*"
+                  }
+                },
+                "fieldName": "logging_status"
+              }
+            ],
+            "match": "any",
+            "type": "include"
+          }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"*_hi\\\"\"*"
+                  }
+                },
+                "fieldName": "logging_status"
+              },
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"*_prvi\\\"\"*"
+                  }
+                },
+                "fieldName": "logging_status"
+              },
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"*_ak\\\"\"*"
+                  }
+                },
+                "fieldName": "logging_status"
+              }
+            ],
+            "match": "any",
+            "type": "exclude"
+          }
+        },
+        {
+          "id": "extractFields",
+          "options": {
+            "format": "auto",
+            "jsonPaths": [
+              {
+                "path": ""
+              }
+            ],
+            "keepTime": false,
+            "replace": false,
+            "source": "logging_status"
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "reference_time"
+              },
+              {
+                "destinationType": "time",
+                "targetField": "step_finish"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "AnA Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "MRF NBM Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "RFC": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "Reference Time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "RnR": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_coastal_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_coastal_inundation_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_coastal_inundation_prvi": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "ana_for_rnr_ingest": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "ana_high_flow_magnitude": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_high_flow_magnitude_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_high_flow_magnitude_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_inundation_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_inundation_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_past_72hr_accum_precip": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_past_72hr_accum_precip_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_alaska_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_coastal_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_gfs_10day_accum_precip": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_gfs_10day_high_water_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_gfs_10day_max_high_flow_magnitude": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_gfs_10day_max_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_gfs_10day_peak_flow_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_gfs_10day_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_gfs_10day_rapid_onset_flooding": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_nbm_10day_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "reference_time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "replace_route": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc_based_5day_max_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc_based_5day_max_streamflow": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_15hr_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_accum_precip": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_high_water_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_max_coastal_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_max_high_flow_magnitude": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_max_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_peak_flow_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_rapid_onset_flooding": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_rate_of_change": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              }
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "@timestamp": false,
+              "Time": true,
+              "ana_coastal_inundation_hi (max)": false,
+              "ana_coastal_inundation_prvi (max)": true,
+              "analysis_assim_coastal (last)": true,
+              "analysis_assim_coastal (max)": true,
+              "analysis_assim_coastal_hawaii (last)": true,
+              "analysis_assim_coastal_hawaii (max)": true,
+              "analysis_assim_coastal_puertorico (last)": true,
+              "analysis_assim_coastal_puertorico (max)": true,
+              "forcing_analysis_assim (last)": true,
+              "forcing_analysis_assim (max)": true,
+              "forcing_analysis_assim_alaska (last)": true,
+              "forcing_analysis_assim_alaska (max)": true,
+              "forcing_analysis_assim_hawaii (last)": true,
+              "forcing_analysis_assim_hawaii (max)": true,
+              "forcing_analysis_assim_puertorico (last)": true,
+              "forcing_analysis_assim_puertorico (max)": true,
+              "forcing_medium_range (last)": true,
+              "forcing_medium_range (max)": true,
+              "forcing_medium_range_alaska (last)": true,
+              "forcing_medium_range_alaska (max)": true,
+              "forcing_medium_range_blend (last)": true,
+              "forcing_medium_range_blend (max)": true,
+              "forcing_medium_range_blend_alaska (last)": true,
+              "forcing_medium_range_blend_alaska (max)": true,
+              "forcing_short_range (last)": true,
+              "forcing_short_range (max)": true,
+              "forcing_short_range_alaska (last)": true,
+              "forcing_short_range_alaska (max)": true,
+              "forcing_short_range_hawaii (last)": true,
+              "forcing_short_range_hawaii (max)": true,
+              "forcing_short_range_puertorico (last)": true,
+              "forcing_short_range_puertorico (max)": true,
+              "logging_status": true,
+              "medium_range_blend_coastal (last)": true,
+              "medium_range_blend_coastal (max)": true,
+              "medium_range_coastal_mem1 (last)": true,
+              "medium_range_coastal_mem1 (max)": true,
+              "message": true,
+              "pipeline_name": true,
+              "short_range_coastal (last)": true,
+              "short_range_coastal (max)": true,
+              "short_range_coastal_hawaii (last)": true,
+              "short_range_coastal_hawaii (max)": true,
+              "short_range_coastal_puertorico (last)": true,
+              "short_range_coastal_puertorico (max)": true,
+              "short_range_puertorico (max)": false
+            },
+            "indexByName": {
+              "mrf_gfs_10day_accum_precip (max)": 6,
+              "mrf_gfs_10day_high_water_arrival_time (max)": 5,
+              "mrf_gfs_10day_max_high_flow_magnitude (max)": 2,
+              "mrf_gfs_10day_max_inundation (max)": 1,
+              "mrf_gfs_10day_peak_flow_arrival_time (max)": 4,
+              "mrf_gfs_10day_rapid_onset_flooding (max)": 3,
+              "reference_time": 0
+            },
+            "renameByName": {
+              "@timestamp": "Log Time",
+              "ana_coastal_inundation (max)": "Coastal FIM",
+              "ana_coastal_inundation_hi (max)": "Coastal FIM",
+              "ana_coastal_inundation_prvi (max)": "AnA Coastal Inundation PRVI",
+              "ana_high_flow_magnitude (max)": "HFM",
+              "ana_high_flow_magnitude_hi (max)": "HFM",
+              "ana_inundation_hi (max)": "FIM",
+              "ana_past_72hr_accum_precip (max)": "Accum Precip",
+              "ana_past_72hr_accum_precip_hi (max)": "Accum Precip",
+              "ana_streamflow (max)": "Streamflow",
+              "ana_streamflow_hi (max)": "Streamflow",
+              "analysis_assim (last)": "AnA",
+              "analysis_assim (max)": "AnA",
+              "analysis_assim_alaska (last)": "AnA AK",
+              "analysis_assim_alaska (max)": "AnA AK",
+              "analysis_assim_coastal": "AnA Coastal",
+              "analysis_assim_coastal (last)": "C AnA",
+              "analysis_assim_coastal (max)": "C AnA",
+              "analysis_assim_coastal_hawaii (last)": "C AnA HI",
+              "analysis_assim_coastal_hawaii (max)": "C AnA HI",
+              "analysis_assim_coastal_puertorico (last)": "C AnA PRVI",
+              "analysis_assim_coastal_puertorico (max)": "C AnA PRVI",
+              "analysis_assim_hawaii (last)": "AnA HI",
+              "analysis_assim_hawaii (max)": "AnA HI",
+              "analysis_assim_puertorico (last)": "AnA PRVI",
+              "analysis_assim_puertorico (max)": "AnA PRVI",
+              "forcing_analysis_assim (last)": "F AnA",
+              "forcing_analysis_assim (max)": "F AnA",
+              "forcing_analysis_assim_alaska (last)": "F AnA AK",
+              "forcing_analysis_assim_alaska (max)": "F AnA AK",
+              "forcing_analysis_assim_hawaii (last)": "F AnA HI",
+              "forcing_analysis_assim_hawaii (max)": "F AnA HI",
+              "forcing_analysis_assim_puertorico (last)": "F AnA PRVI",
+              "forcing_analysis_assim_puertorico (max)": "F AnA PRVI",
+              "forcing_medium_range (last)": "F MRF GFS",
+              "forcing_medium_range (max)": "F MRF GFS",
+              "forcing_medium_range_alaska (last)": "F MRF GFS AK",
+              "forcing_medium_range_alaska (max)": "F MRF GFS AK",
+              "forcing_medium_range_blend (last)": "F MRF NBM",
+              "forcing_medium_range_blend (max)": "F MRF NBM",
+              "forcing_medium_range_blend_alaska (last)": "F MRF NBM AK",
+              "forcing_medium_range_blend_alaska (max)": "F MRF NBM AK",
+              "forcing_short_range (last)": "F SRF",
+              "forcing_short_range (max)": "F SRF",
+              "forcing_short_range_alaska (last)": "F SRF AK",
+              "forcing_short_range_alaska (max)": "F SRF AK",
+              "forcing_short_range_hawaii (last)": "F SRF HI",
+              "forcing_short_range_hawaii (max)": "F SRF HI",
+              "forcing_short_range_puertorico (last)": "F SRF PRVI",
+              "forcing_short_range_puertorico (max)": "F SRF PRVI",
+              "logging_status": "",
+              "medium_range_alaska_mem1 (last)": "MRF GFS AK",
+              "medium_range_alaska_mem1 (max)": "MRF GFS AK",
+              "medium_range_blend (last)": "MRF NBM",
+              "medium_range_blend (max)": "MRF NBM",
+              "medium_range_blend_alaska (last)": "MRF NBM AK",
+              "medium_range_blend_alaska (max)": "MRF NBM AK",
+              "medium_range_blend_coastal": "MRF NBM Coastal",
+              "medium_range_blend_coastal (last)": "C MRF NBM",
+              "medium_range_blend_coastal (max)": "C MRF NBM",
+              "medium_range_coastal_mem1 (last)": "C MRF GFS",
+              "medium_range_coastal_mem1 (max)": "C MRF GFS",
+              "medium_range_mem1 (last)": "MRF GFS",
+              "medium_range_mem1 (max)": "MRF GFS",
+              "mrf_gfs_10day_accum_precip (max)": "Accum Precip",
+              "mrf_gfs_10day_high_water_arrival_time (max)": "HWAT",
+              "mrf_gfs_10day_max_high_flow_magnitude (max)": "HFM",
+              "mrf_gfs_10day_max_inundation (max)": "FIM",
+              "mrf_gfs_10day_peak_flow_arrival_time (max)": "PFAT",
+              "mrf_gfs_10day_rapid_onset_flooding (max)": "ROF",
+              "reference_time": "Reference Time",
+              "replace_route": "RnR",
+              "replace_route (last)": "RnR",
+              "replace_route (max)": "RnR",
+              "rfc": "RFC",
+              "rfc (last)": "RFC",
+              "rfc (max)": "RFC",
+              "rfc_based_5day_max_streamflow (max)": "RFC Based 5 Day Max Streamflow",
+              "short_range (last)": "SRF",
+              "short_range (max)": "SRF",
+              "short_range_alaska (last)": "SRF AK",
+              "short_range_alaska (max)": "SRF AK",
+              "short_range_coastal (last)": "C SRF",
+              "short_range_coastal (max)": "C SRF",
+              "short_range_coastal_hawaii (last)": "C SRF HI",
+              "short_range_coastal_hawaii (max)": "C SRF HI",
+              "short_range_coastal_puertorico (last)": "C SRF PRVI",
+              "short_range_coastal_puertorico (max)": "C SRF PRVI",
+              "short_range_hawaii (last)": "SRF HI",
+              "short_range_hawaii (max)": "SRF HI",
+              "short_range_puertorico (last)": "SRF PRVI",
+              "short_range_puertorico (max)": "SRF PRVI",
+              "srf_15hr_peak_flow_arrival_time_ak (max)": "SRF 15 HR Peak Flow Arrival Time AK",
+              "srf_18hr_accum_precip (max)": "Accum Precip",
+              "srf_18hr_high_water_arrival_time (max)": "HWAT",
+              "srf_18hr_max_coastal_inundation (max)": "Coastal FIM",
+              "srf_18hr_max_high_flow_magnitude (max)": "HFM",
+              "srf_18hr_max_inundation (max)": "FIM",
+              "srf_18hr_peak_flow_arrival_time (max)": "PFAT",
+              "srf_18hr_rapid_onset_flooding (max)": "ROF",
+              "srf_18hr_rate_of_change (max)": "ROC",
+              "step_finish": "Step Finish Time"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "mode": "basic",
+              "type": "color-background"
+            },
+            "filterable": false,
+            "inspect": false,
+            "width": 75
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#dcdcdc",
+                "value": null
+              },
+              {
+                "color": "#d0e1f2",
+                "value": 1
+              },
+              {
+                "color": "#94c4df",
+                "value": 2
+              },
+              {
+                "color": "#4a98c9",
+                "value": 3
+              },
+              {
+                "color": "#1764ab",
+                "value": 4
+              },
+              {
+                "color": "dark-green",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Reference Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 165
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "transparent",
+                      "value": null
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Coastal FIM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 99
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Accum Precip"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 115
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Streamflow"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 99
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "FIM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 49
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "HFM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 48
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 71
+      },
+      "id": 55,
+      "options": {
+        "footer": {
+          "countRows": false,
+          "enablePagination": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Reference Time"
+          }
+        ]
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 39,
+          "refId": "A"
+        }
+      ],
+      "title": "MRF GFS Alaska Product Processing",
+      "transformations": [
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"mrf_gfs_*"
+                  }
+                },
+                "fieldName": "logging_status"
+              }
+            ],
+            "match": "any",
+            "type": "include"
+          }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"*_ak\\\"\"*"
+                  }
+                },
+                "fieldName": "logging_status"
+              }
+            ],
+            "match": "any",
+            "type": "include"
+          }
+        },
+        {
+          "id": "extractFields",
+          "options": {
+            "format": "auto",
+            "jsonPaths": [
+              {
+                "path": ""
+              }
+            ],
+            "keepTime": false,
+            "replace": false,
+            "source": "logging_status"
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "reference_time"
+              },
+              {
+                "destinationType": "time",
+                "targetField": "step_finish"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "AnA Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "MRF NBM Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "RFC": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "Reference Time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "RnR": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_coastal_inundation_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_coastal_inundation_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_for_rnr_ingest": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "ana_high_flow_magnitude": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_high_flow_magnitude_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_high_flow_magnitude_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_inundation_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_inundation_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_past_72hr_accum_precip_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_past_72hr_accum_precip_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_past_72hr_accum_precip_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_alaska_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_coastal_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_gfs_10day_accum_precip_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_gfs_10day_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_nbm_10day_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "reference_time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "replace_route": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc_based_5day_max_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc_based_5day_max_streamflow": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_15hr_accum_precip_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_15hr_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_high_water_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_max_high_flow_magnitude": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_max_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_peak_flow_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_rapid_onset_flooding": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_rate_of_change": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              }
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "@timestamp": false,
+              "Time": true,
+              "ana_coastal_inundation_hi (max)": false,
+              "ana_coastal_inundation_prvi (max)": false,
+              "analysis_assim_coastal (last)": true,
+              "analysis_assim_coastal (max)": true,
+              "analysis_assim_coastal_hawaii (last)": true,
+              "analysis_assim_coastal_hawaii (max)": true,
+              "analysis_assim_coastal_puertorico (last)": true,
+              "analysis_assim_coastal_puertorico (max)": true,
+              "forcing_analysis_assim (last)": true,
+              "forcing_analysis_assim (max)": true,
+              "forcing_analysis_assim_alaska (last)": true,
+              "forcing_analysis_assim_alaska (max)": true,
+              "forcing_analysis_assim_hawaii (last)": true,
+              "forcing_analysis_assim_hawaii (max)": true,
+              "forcing_analysis_assim_puertorico (last)": true,
+              "forcing_analysis_assim_puertorico (max)": true,
+              "forcing_medium_range (last)": true,
+              "forcing_medium_range (max)": true,
+              "forcing_medium_range_alaska (last)": true,
+              "forcing_medium_range_alaska (max)": true,
+              "forcing_medium_range_blend (last)": true,
+              "forcing_medium_range_blend (max)": true,
+              "forcing_medium_range_blend_alaska (last)": true,
+              "forcing_medium_range_blend_alaska (max)": true,
+              "forcing_short_range (last)": true,
+              "forcing_short_range (max)": true,
+              "forcing_short_range_alaska (last)": true,
+              "forcing_short_range_alaska (max)": true,
+              "forcing_short_range_hawaii (last)": true,
+              "forcing_short_range_hawaii (max)": true,
+              "forcing_short_range_puertorico (last)": true,
+              "forcing_short_range_puertorico (max)": true,
+              "logging_status": true,
+              "medium_range_blend_coastal (last)": true,
+              "medium_range_blend_coastal (max)": true,
+              "medium_range_coastal_mem1 (last)": true,
+              "medium_range_coastal_mem1 (max)": true,
+              "message": true,
+              "pipeline_name": true,
+              "short_range_coastal (last)": true,
+              "short_range_coastal (max)": true,
+              "short_range_coastal_hawaii (last)": true,
+              "short_range_coastal_hawaii (max)": true,
+              "short_range_coastal_puertorico (last)": true,
+              "short_range_coastal_puertorico (max)": true,
+              "short_range_puertorico (max)": false
+            },
+            "indexByName": {
+              "mrf_gfs_10day_accum_precip_ak (max)": 2,
+              "mrf_gfs_10day_peak_flow_arrival_time_ak (max)": 1,
+              "reference_time": 0
+            },
+            "renameByName": {
+              "@timestamp": "Log Time",
+              "ana_coastal_inundation_hi (max)": "Coastal FIM",
+              "ana_coastal_inundation_prvi (max)": "Coastal FIM",
+              "ana_high_flow_magnitude (max)": "AnA High Flow Magnitude",
+              "ana_high_flow_magnitude_hi (max)": "HFM",
+              "ana_high_flow_magnitude_prvi (max)": "HFM",
+              "ana_inundation_hi (max)": "FIM",
+              "ana_inundation_prvi (max)": "FIM",
+              "ana_past_72hr_accum_precip_ak (max)": "Accum Precip",
+              "ana_past_72hr_accum_precip_hi (max)": "Accum Precip",
+              "ana_past_72hr_accum_precip_prvi (max)": "Accum Precip",
+              "ana_streamflow (max)": "AnA Streamflow",
+              "ana_streamflow_ak (max)": "Streamflow",
+              "ana_streamflow_hi (max)": "Streamflow",
+              "ana_streamflow_prvi (max)": "Streamflow",
+              "analysis_assim (last)": "AnA",
+              "analysis_assim (max)": "AnA",
+              "analysis_assim_alaska (last)": "AnA AK",
+              "analysis_assim_alaska (max)": "AnA AK",
+              "analysis_assim_coastal": "AnA Coastal",
+              "analysis_assim_coastal (last)": "C AnA",
+              "analysis_assim_coastal (max)": "C AnA",
+              "analysis_assim_coastal_hawaii (last)": "C AnA HI",
+              "analysis_assim_coastal_hawaii (max)": "C AnA HI",
+              "analysis_assim_coastal_puertorico (last)": "C AnA PRVI",
+              "analysis_assim_coastal_puertorico (max)": "C AnA PRVI",
+              "analysis_assim_hawaii (last)": "AnA HI",
+              "analysis_assim_hawaii (max)": "AnA HI",
+              "analysis_assim_puertorico (last)": "AnA PRVI",
+              "analysis_assim_puertorico (max)": "AnA PRVI",
+              "forcing_analysis_assim (last)": "F AnA",
+              "forcing_analysis_assim (max)": "F AnA",
+              "forcing_analysis_assim_alaska (last)": "F AnA AK",
+              "forcing_analysis_assim_alaska (max)": "F AnA AK",
+              "forcing_analysis_assim_hawaii (last)": "F AnA HI",
+              "forcing_analysis_assim_hawaii (max)": "F AnA HI",
+              "forcing_analysis_assim_puertorico (last)": "F AnA PRVI",
+              "forcing_analysis_assim_puertorico (max)": "F AnA PRVI",
+              "forcing_medium_range (last)": "F MRF GFS",
+              "forcing_medium_range (max)": "F MRF GFS",
+              "forcing_medium_range_alaska (last)": "F MRF GFS AK",
+              "forcing_medium_range_alaska (max)": "F MRF GFS AK",
+              "forcing_medium_range_blend (last)": "F MRF NBM",
+              "forcing_medium_range_blend (max)": "F MRF NBM",
+              "forcing_medium_range_blend_alaska (last)": "F MRF NBM AK",
+              "forcing_medium_range_blend_alaska (max)": "F MRF NBM AK",
+              "forcing_short_range (last)": "F SRF",
+              "forcing_short_range (max)": "F SRF",
+              "forcing_short_range_alaska (last)": "F SRF AK",
+              "forcing_short_range_alaska (max)": "F SRF AK",
+              "forcing_short_range_hawaii (last)": "F SRF HI",
+              "forcing_short_range_hawaii (max)": "F SRF HI",
+              "forcing_short_range_puertorico (last)": "F SRF PRVI",
+              "forcing_short_range_puertorico (max)": "F SRF PRVI",
+              "logging_status": "",
+              "medium_range_alaska_mem1 (last)": "MRF GFS AK",
+              "medium_range_alaska_mem1 (max)": "MRF GFS AK",
+              "medium_range_blend (last)": "MRF NBM",
+              "medium_range_blend (max)": "MRF NBM",
+              "medium_range_blend_alaska (last)": "MRF NBM AK",
+              "medium_range_blend_alaska (max)": "MRF NBM AK",
+              "medium_range_blend_coastal": "MRF NBM Coastal",
+              "medium_range_blend_coastal (last)": "C MRF NBM",
+              "medium_range_blend_coastal (max)": "C MRF NBM",
+              "medium_range_coastal_mem1 (last)": "C MRF GFS",
+              "medium_range_coastal_mem1 (max)": "C MRF GFS",
+              "medium_range_mem1 (last)": "MRF GFS",
+              "medium_range_mem1 (max)": "MRF GFS",
+              "mrf_gfs_10day_accum_precip_ak (max)": "Accum Precip",
+              "mrf_gfs_10day_peak_flow_arrival_time_ak (max)": "PFAT",
+              "reference_time": "Reference Time",
+              "replace_route": "RnR",
+              "replace_route (last)": "RnR",
+              "replace_route (max)": "RnR",
+              "rfc": "RFC",
+              "rfc (last)": "RFC",
+              "rfc (max)": "RFC",
+              "rfc_based_5day_max_streamflow (max)": "RFC Based 5 Day Max Streamflow",
+              "short_range (last)": "SRF",
+              "short_range (max)": "SRF",
+              "short_range_alaska (last)": "SRF AK",
+              "short_range_alaska (max)": "SRF AK",
+              "short_range_coastal (last)": "C SRF",
+              "short_range_coastal (max)": "C SRF",
+              "short_range_coastal_hawaii (last)": "C SRF HI",
+              "short_range_coastal_hawaii (max)": "C SRF HI",
+              "short_range_coastal_puertorico (last)": "C SRF PRVI",
+              "short_range_coastal_puertorico (max)": "C SRF PRVI",
+              "short_range_hawaii (last)": "SRF HI",
+              "short_range_hawaii (max)": "SRF HI",
+              "short_range_puertorico (last)": "SRF PRVI",
+              "short_range_puertorico (max)": "SRF PRVI",
+              "srf_15hr_accum_precip_ak (max)": "Accum Precip",
+              "srf_15hr_peak_flow_arrival_time_ak (max)": "PFAT",
+              "srf_18hr_high_water_arrival_time (max)": "SRF 18 HR High Water Arrival Time",
+              "srf_18hr_max_high_flow_magnitude (max)": "SRF 18 HR Max High Flow Magnitude",
+              "srf_18hr_peak_flow_arrival_time (max)": "SRF 18 HR Peak Flow Arrival Time",
+              "srf_18hr_rapid_onset_flooding (max)": "SRF 18 HR Rapid Onset Flooding",
+              "srf_18hr_rate_of_change (max)": "SRF 18 HR Rate of Change",
+              "step_finish": "Step Finish Time"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 76
+      },
+      "id": 44,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "<center style=\"color:black;background-color:white\"><h1>MRF NBM Product Processing Health</h1></center>",
+        "mode": "html"
+      },
+      "pluginVersion": "9.4.7",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "mode": "basic",
+              "type": "color-background"
+            },
+            "filterable": false,
+            "inspect": false,
+            "width": 75
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#dcdcdc",
+                "value": null
+              },
+              {
+                "color": "#d0e1f2",
+                "value": 1
+              },
+              {
+                "color": "#94c4df",
+                "value": 2
+              },
+              {
+                "color": "#4a98c9",
+                "value": 3
+              },
+              {
+                "color": "#1764ab",
+                "value": 4
+              },
+              {
+                "color": "dark-green",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Reference Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 165
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "transparent",
+                      "value": null
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Coastal FIM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 96
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Accum Precip"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 110
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Streamflow"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 93
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "FIM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 52
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "HFM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 51
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 78
+      },
+      "id": 56,
+      "options": {
+        "footer": {
+          "countRows": false,
+          "enablePagination": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Reference Time"
+          }
+        ]
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 39,
+          "refId": "A"
+        }
+      ],
+      "title": "MRF NBM CONUS Product Processing",
+      "transformations": [
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"mrf_nbm_*"
+                  }
+                },
+                "fieldName": "logging_status"
+              }
+            ],
+            "match": "any",
+            "type": "include"
+          }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"*_hi\\\"\"*"
+                  }
+                },
+                "fieldName": "logging_status"
+              },
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"*_prvi\\\"\"*"
+                  }
+                },
+                "fieldName": "logging_status"
+              },
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"*_ak\\\"\"*"
+                  }
+                },
+                "fieldName": "logging_status"
+              }
+            ],
+            "match": "any",
+            "type": "exclude"
+          }
+        },
+        {
+          "id": "extractFields",
+          "options": {
+            "format": "auto",
+            "jsonPaths": [
+              {
+                "path": ""
+              }
+            ],
+            "keepTime": false,
+            "replace": false,
+            "source": "logging_status"
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "reference_time"
+              },
+              {
+                "destinationType": "time",
+                "targetField": "step_finish"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "AnA Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "MRF NBM Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "RFC": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "Reference Time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "RnR": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_coastal_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_coastal_inundation_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_coastal_inundation_prvi": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "ana_for_rnr_ingest": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "ana_high_flow_magnitude": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_high_flow_magnitude_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_high_flow_magnitude_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_inundation_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_inundation_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_past_72hr_accum_precip": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_past_72hr_accum_precip_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_alaska_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_coastal_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_gfs_10day_accum_precip": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_gfs_10day_high_water_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_gfs_10day_max_high_flow_magnitude": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_gfs_10day_max_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_gfs_10day_peak_flow_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_gfs_10day_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_gfs_10day_rapid_onset_flooding": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_nbm_10day_accum_precip": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_nbm_10day_high_water_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_nbm_10day_max_high_flow_magnitude": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_nbm_10day_max_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_nbm_10day_peak_flow_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_nbm_10day_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_nbm_10day_rapid_onset_flooding": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "reference_time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "replace_route": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc_based_5day_max_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc_based_5day_max_streamflow": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_15hr_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_accum_precip": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_high_water_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_max_coastal_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_max_high_flow_magnitude": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_max_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_peak_flow_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_rapid_onset_flooding": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_rate_of_change": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              }
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "@timestamp": false,
+              "Time": true,
+              "ana_coastal_inundation_hi (max)": false,
+              "ana_coastal_inundation_prvi (max)": true,
+              "analysis_assim_coastal (last)": true,
+              "analysis_assim_coastal (max)": true,
+              "analysis_assim_coastal_hawaii (last)": true,
+              "analysis_assim_coastal_hawaii (max)": true,
+              "analysis_assim_coastal_puertorico (last)": true,
+              "analysis_assim_coastal_puertorico (max)": true,
+              "forcing_analysis_assim (last)": true,
+              "forcing_analysis_assim (max)": true,
+              "forcing_analysis_assim_alaska (last)": true,
+              "forcing_analysis_assim_alaska (max)": true,
+              "forcing_analysis_assim_hawaii (last)": true,
+              "forcing_analysis_assim_hawaii (max)": true,
+              "forcing_analysis_assim_puertorico (last)": true,
+              "forcing_analysis_assim_puertorico (max)": true,
+              "forcing_medium_range (last)": true,
+              "forcing_medium_range (max)": true,
+              "forcing_medium_range_alaska (last)": true,
+              "forcing_medium_range_alaska (max)": true,
+              "forcing_medium_range_blend (last)": true,
+              "forcing_medium_range_blend (max)": true,
+              "forcing_medium_range_blend_alaska (last)": true,
+              "forcing_medium_range_blend_alaska (max)": true,
+              "forcing_short_range (last)": true,
+              "forcing_short_range (max)": true,
+              "forcing_short_range_alaska (last)": true,
+              "forcing_short_range_alaska (max)": true,
+              "forcing_short_range_hawaii (last)": true,
+              "forcing_short_range_hawaii (max)": true,
+              "forcing_short_range_puertorico (last)": true,
+              "forcing_short_range_puertorico (max)": true,
+              "logging_status": true,
+              "medium_range_blend_coastal (last)": true,
+              "medium_range_blend_coastal (max)": true,
+              "medium_range_coastal_mem1 (last)": true,
+              "medium_range_coastal_mem1 (max)": true,
+              "message": true,
+              "pipeline_name": true,
+              "short_range_coastal (last)": true,
+              "short_range_coastal (max)": true,
+              "short_range_coastal_hawaii (last)": true,
+              "short_range_coastal_hawaii (max)": true,
+              "short_range_coastal_puertorico (last)": true,
+              "short_range_coastal_puertorico (max)": true,
+              "short_range_puertorico (max)": false
+            },
+            "indexByName": {
+              "mrf_nbm_10day_accum_precip (max)": 6,
+              "mrf_nbm_10day_high_water_arrival_time (max)": 5,
+              "mrf_nbm_10day_max_high_flow_magnitude (max)": 1,
+              "mrf_nbm_10day_max_inundation (max)": 4,
+              "mrf_nbm_10day_peak_flow_arrival_time (max)": 2,
+              "mrf_nbm_10day_rapid_onset_flooding (max)": 3,
+              "reference_time": 0
+            },
+            "renameByName": {
+              "@timestamp": "Log Time",
+              "ana_coastal_inundation (max)": "Coastal FIM",
+              "ana_coastal_inundation_hi (max)": "Coastal FIM",
+              "ana_coastal_inundation_prvi (max)": "AnA Coastal Inundation PRVI",
+              "ana_high_flow_magnitude (max)": "HFM",
+              "ana_high_flow_magnitude_hi (max)": "HFM",
+              "ana_inundation_hi (max)": "FIM",
+              "ana_past_72hr_accum_precip (max)": "Accum Precip",
+              "ana_past_72hr_accum_precip_hi (max)": "Accum Precip",
+              "ana_streamflow (max)": "Streamflow",
+              "ana_streamflow_hi (max)": "Streamflow",
+              "analysis_assim (last)": "AnA",
+              "analysis_assim (max)": "AnA",
+              "analysis_assim_alaska (last)": "AnA AK",
+              "analysis_assim_alaska (max)": "AnA AK",
+              "analysis_assim_coastal": "AnA Coastal",
+              "analysis_assim_coastal (last)": "C AnA",
+              "analysis_assim_coastal (max)": "C AnA",
+              "analysis_assim_coastal_hawaii (last)": "C AnA HI",
+              "analysis_assim_coastal_hawaii (max)": "C AnA HI",
+              "analysis_assim_coastal_puertorico (last)": "C AnA PRVI",
+              "analysis_assim_coastal_puertorico (max)": "C AnA PRVI",
+              "analysis_assim_hawaii (last)": "AnA HI",
+              "analysis_assim_hawaii (max)": "AnA HI",
+              "analysis_assim_puertorico (last)": "AnA PRVI",
+              "analysis_assim_puertorico (max)": "AnA PRVI",
+              "forcing_analysis_assim (last)": "F AnA",
+              "forcing_analysis_assim (max)": "F AnA",
+              "forcing_analysis_assim_alaska (last)": "F AnA AK",
+              "forcing_analysis_assim_alaska (max)": "F AnA AK",
+              "forcing_analysis_assim_hawaii (last)": "F AnA HI",
+              "forcing_analysis_assim_hawaii (max)": "F AnA HI",
+              "forcing_analysis_assim_puertorico (last)": "F AnA PRVI",
+              "forcing_analysis_assim_puertorico (max)": "F AnA PRVI",
+              "forcing_medium_range (last)": "F MRF GFS",
+              "forcing_medium_range (max)": "F MRF GFS",
+              "forcing_medium_range_alaska (last)": "F MRF GFS AK",
+              "forcing_medium_range_alaska (max)": "F MRF GFS AK",
+              "forcing_medium_range_blend (last)": "F MRF NBM",
+              "forcing_medium_range_blend (max)": "F MRF NBM",
+              "forcing_medium_range_blend_alaska (last)": "F MRF NBM AK",
+              "forcing_medium_range_blend_alaska (max)": "F MRF NBM AK",
+              "forcing_short_range (last)": "F SRF",
+              "forcing_short_range (max)": "F SRF",
+              "forcing_short_range_alaska (last)": "F SRF AK",
+              "forcing_short_range_alaska (max)": "F SRF AK",
+              "forcing_short_range_hawaii (last)": "F SRF HI",
+              "forcing_short_range_hawaii (max)": "F SRF HI",
+              "forcing_short_range_puertorico (last)": "F SRF PRVI",
+              "forcing_short_range_puertorico (max)": "F SRF PRVI",
+              "logging_status": "",
+              "medium_range_alaska_mem1 (last)": "MRF GFS AK",
+              "medium_range_alaska_mem1 (max)": "MRF GFS AK",
+              "medium_range_blend (last)": "MRF NBM",
+              "medium_range_blend (max)": "MRF NBM",
+              "medium_range_blend_alaska (last)": "MRF NBM AK",
+              "medium_range_blend_alaska (max)": "MRF NBM AK",
+              "medium_range_blend_coastal": "MRF NBM Coastal",
+              "medium_range_blend_coastal (last)": "C MRF NBM",
+              "medium_range_blend_coastal (max)": "C MRF NBM",
+              "medium_range_coastal_mem1 (last)": "C MRF GFS",
+              "medium_range_coastal_mem1 (max)": "C MRF GFS",
+              "medium_range_mem1 (last)": "MRF GFS",
+              "medium_range_mem1 (max)": "MRF GFS",
+              "mrf_gfs_10day_accum_precip (max)": "Accum Precip",
+              "mrf_gfs_10day_high_water_arrival_time (max)": "HWAT",
+              "mrf_gfs_10day_max_high_flow_magnitude (max)": "HFM",
+              "mrf_gfs_10day_max_inundation (max)": "FIM",
+              "mrf_gfs_10day_peak_flow_arrival_time (max)": "PFAT",
+              "mrf_gfs_10day_rapid_onset_flooding (max)": "ROF",
+              "mrf_nbm_10day_accum_precip (max)": "Accum Precip",
+              "mrf_nbm_10day_high_water_arrival_time (max)": "HWAT",
+              "mrf_nbm_10day_max_high_flow_magnitude (max)": "HFM",
+              "mrf_nbm_10day_max_inundation (max)": "FIM",
+              "mrf_nbm_10day_peak_flow_arrival_time (max)": "PFAT",
+              "mrf_nbm_10day_rapid_onset_flooding (max)": "ROF",
+              "reference_time": "Reference Time",
+              "replace_route": "RnR",
+              "replace_route (last)": "RnR",
+              "replace_route (max)": "RnR",
+              "rfc": "RFC",
+              "rfc (last)": "RFC",
+              "rfc (max)": "RFC",
+              "rfc_based_5day_max_streamflow (max)": "RFC Based 5 Day Max Streamflow",
+              "short_range (last)": "SRF",
+              "short_range (max)": "SRF",
+              "short_range_alaska (last)": "SRF AK",
+              "short_range_alaska (max)": "SRF AK",
+              "short_range_coastal (last)": "C SRF",
+              "short_range_coastal (max)": "C SRF",
+              "short_range_coastal_hawaii (last)": "C SRF HI",
+              "short_range_coastal_hawaii (max)": "C SRF HI",
+              "short_range_coastal_puertorico (last)": "C SRF PRVI",
+              "short_range_coastal_puertorico (max)": "C SRF PRVI",
+              "short_range_hawaii (last)": "SRF HI",
+              "short_range_hawaii (max)": "SRF HI",
+              "short_range_puertorico (last)": "SRF PRVI",
+              "short_range_puertorico (max)": "SRF PRVI",
+              "srf_15hr_peak_flow_arrival_time_ak (max)": "SRF 15 HR Peak Flow Arrival Time AK",
+              "srf_18hr_accum_precip (max)": "Accum Precip",
+              "srf_18hr_high_water_arrival_time (max)": "HWAT",
+              "srf_18hr_max_coastal_inundation (max)": "Coastal FIM",
+              "srf_18hr_max_high_flow_magnitude (max)": "HFM",
+              "srf_18hr_max_inundation (max)": "FIM",
+              "srf_18hr_peak_flow_arrival_time (max)": "PFAT",
+              "srf_18hr_rapid_onset_flooding (max)": "ROF",
+              "srf_18hr_rate_of_change (max)": "ROC",
+              "step_finish": "Step Finish Time"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "-- Dashboard --"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "center",
+            "cellOptions": {
+              "mode": "basic",
+              "type": "color-background"
+            },
+            "filterable": false,
+            "inspect": false,
+            "width": 75
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#dcdcdc",
+                "value": null
+              },
+              {
+                "color": "#d0e1f2",
+                "value": 1
+              },
+              {
+                "color": "#94c4df",
+                "value": 2
+              },
+              {
+                "color": "#4a98c9",
+                "value": 3
+              },
+              {
+                "color": "#1764ab",
+                "value": 4
+              },
+              {
+                "color": "dark-green",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Reference Time"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 165
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "transparent",
+                      "value": null
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Coastal FIM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 99
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Accum Precip"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 115
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Streamflow"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 99
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "FIM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 49
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "HFM"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 48
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 83
+      },
+      "id": 57,
+      "options": {
+        "footer": {
+          "countRows": false,
+          "enablePagination": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Reference Time"
+          }
+        ]
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "datasource": {
+            "type": "datasource",
+            "uid": "-- Dashboard --"
+          },
+          "panelId": 39,
+          "refId": "A"
+        }
+      ],
+      "title": "MRF NBM Alaska Product Processing",
+      "transformations": [
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"mrf_nbm_*"
+                  }
+                },
+                "fieldName": "logging_status"
+              }
+            ],
+            "match": "any",
+            "type": "include"
+          }
+        },
+        {
+          "id": "filterByValue",
+          "options": {
+            "filters": [
+              {
+                "config": {
+                  "id": "regex",
+                  "options": {
+                    "value": "\"*_ak\\\"\"*"
+                  }
+                },
+                "fieldName": "logging_status"
+              }
+            ],
+            "match": "any",
+            "type": "include"
+          }
+        },
+        {
+          "id": "extractFields",
+          "options": {
+            "format": "auto",
+            "jsonPaths": [
+              {
+                "path": ""
+              }
+            ],
+            "keepTime": false,
+            "replace": false,
+            "source": "logging_status"
+          }
+        },
+        {
+          "id": "convertFieldType",
+          "options": {
+            "conversions": [
+              {
+                "destinationType": "time",
+                "targetField": "reference_time"
+              },
+              {
+                "destinationType": "time",
+                "targetField": "step_finish"
+              }
+            ],
+            "fields": {}
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "AnA Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "MRF NBM Coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "RFC": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "Reference Time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "RnR": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_coastal_inundation_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_coastal_inundation_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_for_rnr_ingest": {
+                "aggregations": [
+                  "max"
+                ]
+              },
+              "ana_high_flow_magnitude": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_high_flow_magnitude_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_high_flow_magnitude_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_inundation_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_inundation_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_past_72hr_accum_precip_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_past_72hr_accum_precip_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_past_72hr_accum_precip_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_hi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "ana_streamflow_prvi": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_analysis_assim_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "forcing_short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_alaska_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_blend_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_coastal_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "medium_range_mem1": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_gfs_10day_accum_precip_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_gfs_10day_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_nbm_10day_accum_precip_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "mrf_nbm_10day_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "reference_time": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "replace_route": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc_based_5day_max_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "rfc_based_5day_max_streamflow": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_alaska": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_coastal_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_hawaii": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "short_range_puertorico": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_15hr_accum_precip_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_15hr_peak_flow_arrival_time_ak": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_high_water_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_max_high_flow_magnitude": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_max_inundation": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_peak_flow_arrival_time": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_rapid_onset_flooding": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              },
+              "srf_18hr_rate_of_change": {
+                "aggregations": [
+                  "max"
+                ],
+                "operation": "aggregate"
+              }
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "@timestamp": false,
+              "Time": true,
+              "ana_coastal_inundation_hi (max)": false,
+              "ana_coastal_inundation_prvi (max)": false,
+              "analysis_assim_coastal (last)": true,
+              "analysis_assim_coastal (max)": true,
+              "analysis_assim_coastal_hawaii (last)": true,
+              "analysis_assim_coastal_hawaii (max)": true,
+              "analysis_assim_coastal_puertorico (last)": true,
+              "analysis_assim_coastal_puertorico (max)": true,
+              "forcing_analysis_assim (last)": true,
+              "forcing_analysis_assim (max)": true,
+              "forcing_analysis_assim_alaska (last)": true,
+              "forcing_analysis_assim_alaska (max)": true,
+              "forcing_analysis_assim_hawaii (last)": true,
+              "forcing_analysis_assim_hawaii (max)": true,
+              "forcing_analysis_assim_puertorico (last)": true,
+              "forcing_analysis_assim_puertorico (max)": true,
+              "forcing_medium_range (last)": true,
+              "forcing_medium_range (max)": true,
+              "forcing_medium_range_alaska (last)": true,
+              "forcing_medium_range_alaska (max)": true,
+              "forcing_medium_range_blend (last)": true,
+              "forcing_medium_range_blend (max)": true,
+              "forcing_medium_range_blend_alaska (last)": true,
+              "forcing_medium_range_blend_alaska (max)": true,
+              "forcing_short_range (last)": true,
+              "forcing_short_range (max)": true,
+              "forcing_short_range_alaska (last)": true,
+              "forcing_short_range_alaska (max)": true,
+              "forcing_short_range_hawaii (last)": true,
+              "forcing_short_range_hawaii (max)": true,
+              "forcing_short_range_puertorico (last)": true,
+              "forcing_short_range_puertorico (max)": true,
+              "logging_status": true,
+              "medium_range_blend_coastal (last)": true,
+              "medium_range_blend_coastal (max)": true,
+              "medium_range_coastal_mem1 (last)": true,
+              "medium_range_coastal_mem1 (max)": true,
+              "message": true,
+              "pipeline_name": true,
+              "short_range_coastal (last)": true,
+              "short_range_coastal (max)": true,
+              "short_range_coastal_hawaii (last)": true,
+              "short_range_coastal_hawaii (max)": true,
+              "short_range_coastal_puertorico (last)": true,
+              "short_range_coastal_puertorico (max)": true,
+              "short_range_puertorico (max)": false
+            },
+            "indexByName": {
+              "mrf_nbm_10day_accum_precip_ak (max)": 2,
+              "mrf_nbm_10day_peak_flow_arrival_time_ak (max)": 1,
+              "reference_time": 0
+            },
+            "renameByName": {
+              "@timestamp": "Log Time",
+              "ana_coastal_inundation_hi (max)": "Coastal FIM",
+              "ana_coastal_inundation_prvi (max)": "Coastal FIM",
+              "ana_high_flow_magnitude (max)": "AnA High Flow Magnitude",
+              "ana_high_flow_magnitude_hi (max)": "HFM",
+              "ana_high_flow_magnitude_prvi (max)": "HFM",
+              "ana_inundation_hi (max)": "FIM",
+              "ana_inundation_prvi (max)": "FIM",
+              "ana_past_72hr_accum_precip_ak (max)": "Accum Precip",
+              "ana_past_72hr_accum_precip_hi (max)": "Accum Precip",
+              "ana_past_72hr_accum_precip_prvi (max)": "Accum Precip",
+              "ana_streamflow (max)": "AnA Streamflow",
+              "ana_streamflow_ak (max)": "Streamflow",
+              "ana_streamflow_hi (max)": "Streamflow",
+              "ana_streamflow_prvi (max)": "Streamflow",
+              "analysis_assim (last)": "AnA",
+              "analysis_assim (max)": "AnA",
+              "analysis_assim_alaska (last)": "AnA AK",
+              "analysis_assim_alaska (max)": "AnA AK",
+              "analysis_assim_coastal": "AnA Coastal",
+              "analysis_assim_coastal (last)": "C AnA",
+              "analysis_assim_coastal (max)": "C AnA",
+              "analysis_assim_coastal_hawaii (last)": "C AnA HI",
+              "analysis_assim_coastal_hawaii (max)": "C AnA HI",
+              "analysis_assim_coastal_puertorico (last)": "C AnA PRVI",
+              "analysis_assim_coastal_puertorico (max)": "C AnA PRVI",
+              "analysis_assim_hawaii (last)": "AnA HI",
+              "analysis_assim_hawaii (max)": "AnA HI",
+              "analysis_assim_puertorico (last)": "AnA PRVI",
+              "analysis_assim_puertorico (max)": "AnA PRVI",
+              "forcing_analysis_assim (last)": "F AnA",
+              "forcing_analysis_assim (max)": "F AnA",
+              "forcing_analysis_assim_alaska (last)": "F AnA AK",
+              "forcing_analysis_assim_alaska (max)": "F AnA AK",
+              "forcing_analysis_assim_hawaii (last)": "F AnA HI",
+              "forcing_analysis_assim_hawaii (max)": "F AnA HI",
+              "forcing_analysis_assim_puertorico (last)": "F AnA PRVI",
+              "forcing_analysis_assim_puertorico (max)": "F AnA PRVI",
+              "forcing_medium_range (last)": "F MRF GFS",
+              "forcing_medium_range (max)": "F MRF GFS",
+              "forcing_medium_range_alaska (last)": "F MRF GFS AK",
+              "forcing_medium_range_alaska (max)": "F MRF GFS AK",
+              "forcing_medium_range_blend (last)": "F MRF NBM",
+              "forcing_medium_range_blend (max)": "F MRF NBM",
+              "forcing_medium_range_blend_alaska (last)": "F MRF NBM AK",
+              "forcing_medium_range_blend_alaska (max)": "F MRF NBM AK",
+              "forcing_short_range (last)": "F SRF",
+              "forcing_short_range (max)": "F SRF",
+              "forcing_short_range_alaska (last)": "F SRF AK",
+              "forcing_short_range_alaska (max)": "F SRF AK",
+              "forcing_short_range_hawaii (last)": "F SRF HI",
+              "forcing_short_range_hawaii (max)": "F SRF HI",
+              "forcing_short_range_puertorico (last)": "F SRF PRVI",
+              "forcing_short_range_puertorico (max)": "F SRF PRVI",
+              "logging_status": "",
+              "medium_range_alaska_mem1 (last)": "MRF GFS AK",
+              "medium_range_alaska_mem1 (max)": "MRF GFS AK",
+              "medium_range_blend (last)": "MRF NBM",
+              "medium_range_blend (max)": "MRF NBM",
+              "medium_range_blend_alaska (last)": "MRF NBM AK",
+              "medium_range_blend_alaska (max)": "MRF NBM AK",
+              "medium_range_blend_coastal": "MRF NBM Coastal",
+              "medium_range_blend_coastal (last)": "C MRF NBM",
+              "medium_range_blend_coastal (max)": "C MRF NBM",
+              "medium_range_coastal_mem1 (last)": "C MRF GFS",
+              "medium_range_coastal_mem1 (max)": "C MRF GFS",
+              "medium_range_mem1 (last)": "MRF GFS",
+              "medium_range_mem1 (max)": "MRF GFS",
+              "mrf_gfs_10day_accum_precip_ak (max)": "Accum Precip",
+              "mrf_gfs_10day_peak_flow_arrival_time_ak (max)": "PFAT",
+              "mrf_nbm_10day_accum_precip_ak (max)": "Accum Precip",
+              "mrf_nbm_10day_peak_flow_arrival_time_ak (max)": "PFAT",
+              "reference_time": "Reference Time",
+              "replace_route": "RnR",
+              "replace_route (last)": "RnR",
+              "replace_route (max)": "RnR",
+              "rfc": "RFC",
+              "rfc (last)": "RFC",
+              "rfc (max)": "RFC",
+              "rfc_based_5day_max_streamflow (max)": "RFC Based 5 Day Max Streamflow",
+              "short_range (last)": "SRF",
+              "short_range (max)": "SRF",
+              "short_range_alaska (last)": "SRF AK",
+              "short_range_alaska (max)": "SRF AK",
+              "short_range_coastal (last)": "C SRF",
+              "short_range_coastal (max)": "C SRF",
+              "short_range_coastal_hawaii (last)": "C SRF HI",
+              "short_range_coastal_hawaii (max)": "C SRF HI",
+              "short_range_coastal_puertorico (last)": "C SRF PRVI",
+              "short_range_coastal_puertorico (max)": "C SRF PRVI",
+              "short_range_hawaii (last)": "SRF HI",
+              "short_range_hawaii (max)": "SRF HI",
+              "short_range_puertorico (last)": "SRF PRVI",
+              "short_range_puertorico (max)": "SRF PRVI",
+              "srf_15hr_accum_precip_ak (max)": "Accum Precip",
+              "srf_15hr_peak_flow_arrival_time_ak (max)": "PFAT",
+              "srf_18hr_high_water_arrival_time (max)": "SRF 18 HR High Water Arrival Time",
+              "srf_18hr_max_high_flow_magnitude (max)": "SRF 18 HR Max High Flow Magnitude",
+              "srf_18hr_peak_flow_arrival_time (max)": "SRF 18 HR Peak Flow Arrival Time",
+              "srf_18hr_rapid_onset_flooding (max)": "SRF 18 HR Rapid Onset Flooding",
+              "srf_18hr_rate_of_change (max)": "SRF 18 HR Rate of Change",
+              "step_finish": "Step Finish Time"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 88
+      },
+      "id": 35,
+      "panels": [
+        {
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "bars",
+                "fillOpacity": 100,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "decimals": 0,
+              "links": [],
+              "mappings": [],
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "ExecutionsFailed Sum"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "ExecutionsSucceeded Sum"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 63
+          },
+          "id": 10,
+          "links": [],
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull",
+                "max",
+                "min",
+                "sum"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.4.7",
+          "targets": [
+            {
+              "alias": "{{metric}} {{stat}}",
+              "application": {
+                "filter": ""
+              },
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "dimensions": {
+                "StateMachineArn": "$stateMachineArn"
+              },
+              "expression": "",
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "highResolution": false,
+              "host": {
+                "filter": ""
+              },
+              "id": "",
+              "item": {
+                "filter": ""
+              },
+              "label": "${PROP('MetricName')} ${PROP('Stat')}",
+              "metricEditorMode": 0,
+              "metricName": "ExecutionsSucceeded",
+              "metricQueryType": 0,
+              "mode": 0,
+              "namespace": "AWS/States",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "$agg",
+              "refId": "Succeeded",
+              "region": "$region",
+              "returnData": false,
+              "statistic": "Sum"
+            },
+            {
+              "alias": "{{metric}} {{stat}}",
+              "application": {
+                "filter": ""
+              },
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "dimensions": {
+                "StateMachineArn": "$stateMachineArn"
+              },
+              "expression": "",
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "hide": false,
+              "highResolution": false,
+              "host": {
+                "filter": ""
+              },
+              "id": "",
+              "item": {
+                "filter": ""
+              },
+              "label": "${PROP('MetricName')} ${PROP('Stat')}",
+              "metricEditorMode": 0,
+              "metricName": "ExecutionsFailed",
+              "metricQueryType": 0,
+              "mode": 0,
+              "namespace": "AWS/States",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "$agg",
+              "refId": "Failed",
+              "region": "$region",
+              "returnData": false,
+              "statistic": "Sum"
+            }
+          ],
+          "title": "Executions Succeeded/Failed",
+          "type": "timeseries"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "cloudwatch",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 0,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 63
+          },
+          "hiddenSeries": false,
+          "id": 12,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sort": "max",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "9.4.7",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "",
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "dimensions": {
+                "FunctionName": "$LambdaName"
+              },
+              "expression": "REMOVE_EMPTY(SEARCH('{AWS/Lambda,FunctionName} MetricName=\"Errors\"', 'Sum', $period))/$period",
+              "id": "",
+              "label": "",
+              "matchExact": true,
+              "metricEditorMode": 0,
+              "metricName": "Errors",
+              "metricQueryType": 0,
+              "namespace": "AWS/Lambda",
+              "period": "$agg",
+              "refId": "A",
+              "region": "$region",
+              "statistic": "Sum"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Errors per function [count/sec]",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "logBase": 1,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {
+            "ExecutionTime Average": "orange",
+            "Maximum": "#e24d42"
+          },
+          "bars": true,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "decimals": 3,
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "grid": {},
+          "gridPos": {
+            "h": 7,
+            "w": 24,
+            "x": 0,
+            "y": 70
+          },
+          "hiddenSeries": false,
+          "id": 1,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": true,
+            "show": true,
+            "sort": "current",
+            "sortDesc": true,
+            "total": true,
+            "values": true
+          },
+          "lines": false,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "9.4.7",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "ExecutionTime Maximum",
+              "bars": false,
+              "fill": 0,
+              "lines": true,
+              "yaxis": 2
+            }
+          ],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "alias": "{{metric}} {{stat}}",
+              "application": {
+                "filter": ""
+              },
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "dimensions": {
+                "StateMachineArn": "$stateMachineArn"
+              },
+              "expression": "",
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "highResolution": false,
+              "host": {
+                "filter": ""
+              },
+              "id": "",
+              "item": {
+                "filter": ""
+              },
+              "metricEditorMode": 0,
+              "metricName": "ExecutionTime",
+              "metricQueryType": 0,
+              "mode": 0,
+              "namespace": "AWS/States",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "$agg",
+              "refId": "A",
+              "region": "$region",
+              "returnData": false,
+              "statistic": "Average"
+            },
+            {
+              "alias": "{{metric}} {{stat}}",
+              "application": {
+                "filter": ""
+              },
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "dimensions": {
+                "StateMachineArn": "$stateMachineArn"
+              },
+              "expression": "",
+              "functions": [],
+              "group": {
+                "filter": ""
+              },
+              "hide": false,
+              "highResolution": false,
+              "host": {
+                "filter": ""
+              },
+              "id": "",
+              "item": {
+                "filter": ""
+              },
+              "metricEditorMode": 0,
+              "metricName": "ExecutionTime",
+              "metricQueryType": 0,
+              "mode": 0,
+              "namespace": "AWS/States",
+              "options": {
+                "showDisabledItems": false
+              },
+              "period": "$agg",
+              "refId": "B",
+              "region": "$region",
+              "returnData": false,
+              "statistic": "Maximum"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Execution Time",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "ms",
+              "logBase": 1,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "ms",
+              "logBase": 1,
+              "min": "0",
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        }
+      ],
+      "title": "Lambdas",
+      "type": "row"
+    }
+  ],
+  "refresh": "",
+  "revision": 1,
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "cloudwatch",
+    "homepage"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "CloudWatch",
+          "value": "CloudWatch"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "cloudwatch",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "auto": true,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "current": {
+          "selected": false,
+          "text": "15m",
+          "value": "15m"
+        },
+        "hide": 0,
+        "label": "Aggregation",
+        "name": "agg",
+        "options": [
+          {
+            "selected": false,
+            "text": "auto",
+            "value": "$__auto_interval_agg"
+          },
+          {
+            "selected": false,
+            "text": "1s",
+            "value": "1s"
+          },
+          {
+            "selected": false,
+            "text": "5s",
+            "value": "5s"
+          },
+          {
+            "selected": false,
+            "text": "10s",
+            "value": "10s"
+          },
+          {
+            "selected": false,
+            "text": "30s",
+            "value": "30s"
+          },
+          {
+            "selected": false,
+            "text": "1m",
+            "value": "1m"
+          },
+          {
+            "selected": false,
+            "text": "5m",
+            "value": "5m"
+          },
+          {
+            "selected": true,
+            "text": "15m",
+            "value": "15m"
+          },
+          {
+            "selected": false,
+            "text": "1h",
+            "value": "1h"
+          },
+          {
+            "selected": false,
+            "text": "6h",
+            "value": "6h"
+          },
+          {
+            "selected": false,
+            "text": "1d",
+            "value": "1d"
+          },
+          {
+            "selected": false,
+            "text": "7d",
+            "value": "7d"
+          },
+          {
+            "selected": false,
+            "text": "30d",
+            "value": "30d"
+          }
+        ],
+        "query": "1s,5s,10s,30s,1m,5m,15m,1h,6h,1d,7d,30d",
+        "queryValue": "",
+        "refresh": 2,
+        "skipUrlSync": false,
+        "type": "interval"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "us-east-2",
+          "value": "us-east-2"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Region",
+        "multi": false,
+        "name": "region",
+        "options": [
+          {
+            "selected": false,
+            "text": "us-east-1",
+            "value": "us-east-1"
+          },
+          {
+            "selected": true,
+            "text": "us-east-2",
+            "value": "us-east-2"
+          }
+        ],
+        "query": "us-east-1, us-east-2",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "arn:aws:states:us-east-2:799732994462:stateMachine:hv-vpp-uat-execute-replace-route",
+          "value": "arn:aws:states:us-east-2:799732994462:stateMachine:hv-vpp-uat-execute-replace-route"
+        },
+        "datasource": {
+          "uid": "$datasource"
+        },
+        "definition": "dimension_values($region,AWS/States,ExecutionsFailed,StateMachineArn)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "StateMachineArn",
+        "multi": false,
+        "name": "stateMachineArn",
+        "options": [],
+        "query": "dimension_values($region,AWS/States,ExecutionsFailed,StateMachineArn)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "HydroVIS Pipeline Health",
+  "uid": "AWSStepFn",
+  "version": 64,
+  "weekStart": ""
+}


### PR DESCRIPTION
This PR adds logging capabilities to the processing pipeline step function, creating a custom logstream for each run and capturing successful and failed runs. The new step function diagram can be found below. Although it definitely does not look as clean as before, the changes include the following:

- After each successful main map/process within the step function, the state machine will send a custom log to cloudwatch with the reference time, status code, and configuration/product name.
- After each failed main map/process within the step function, the state machine will catch the error and send a custom log to cloudwatch with the reference time, status code, configuration/product name, and error message.
- Because we are now catching errors within the product processing section of the workflow, a failed product will have now be caught and not cause other products running in parallel to fail (#530) but the step function will still result in a failure status after everything is processed

![stepfunctions_graph](https://github.com/NOAA-OWP/hydrovis/assets/69687817/9cf45dd9-d0ab-4856-96ec-ac9367e72473)

In addition to logging changes within the step function, I have also added JSON for a grafana dashboard to monitor the pipelines based on configuration and product, with the ability to also summarize and group error logs based on reference time.

![data_prep_monitor](https://github.com/NOAA-OWP/hydrovis/assets/69687817/e7188ca1-4d32-4d58-874c-ec2187f1a3c4)

![product_processing_monitor](https://github.com/NOAA-OWP/hydrovis/assets/69687817/35417682-f4b4-40c5-99f5-0c7018aa2c47)

