### PR TITLE
RDS Bastion - pg_restore tweaks

### DIFF
--- a/Core/EC2/RDSBastion/scripts/utils/restore_db_dumps_from_s3.sh.tftpl
+++ b/Core/EC2/RDSBastion/scripts/utils/restore_db_dumps_from_s3.sh.tftpl
@@ -20,9 +20,8 @@ RE='^(.+)\/(([a-z].+)DB_(.+)_v[0-9]+_.+\.dump)$'
 
 # Drop old schema and restore from S3 object
 echo "Setting up $${BASH_REMATCH[4]} schema in the $${BASH_REMATCH[3]} DB..."
-psql -h "${db_host}" -U "${db_username}" -p ${db_port} -d "${db_name}" -qtAc "DROP SCHEMA IF EXISTS $${BASH_REMATCH[4]} CASCADE;"
 aws s3 cp "s3://${s3_bucket}/${s3_key}" "$${postgres_data_folder}/db.dump" --only-show-errors
-pg_restore -h "${db_host}" -p ${db_port} -d "${db_name}" -U ${db_username} -j 4 "$${postgres_data_folder}/db.dump"
+pg_restore -h "${db_host}" -p ${db_port} -d "${db_name}" -U ${db_username} --clean --if-exists -j 4 "$${postgres_data_folder}/db.dump"
 
 # Remove temp file
 rm "$${postgres_data_folder}/db.dump"


### PR DESCRIPTION
This PR changes the Core\EC2\RDSBastion\scripts\utils\restore_db_dumps_from_s3.sh.tftpl script in two ways:

- Removes the DROP SCHEMA command prior to running pg_restore and instead:
- Adds the --clean --if-exists argument to pg_restore.

This should accomplish the same thing, and hopefully will prevent the commands from running independent of each other for any reason (which I believe to be the most likely cause a bunch of duplicate record we round in the derived schema tables the week of 9/11/2023).