### PR TITLE
Rio Grande FIM Removal

### DIFF
--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/ana_inundation/public_subset.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/ana_inundation/public_subset.sql
@@ -8,6 +8,6 @@ SELECT
 	to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS update_time
 INTO publish.ana_inundation_public
 FROM publish.ana_inundation as inun
-JOIN derived.fim_domain as fim_domain ON ST_Intersects(inun.geom, fim_domain.geom)
+JOIN derived.public_fim_domain as fim_domain ON ST_Intersects(inun.geom, fim_domain.geom)
 JOIN derived.channels_conus cc ON cc.feature_id = inun.feature_id
 WHERE public_fim = true

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/ana_inundation/public_subset.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/ana_inundation/public_subset.sql
@@ -7,5 +7,7 @@ SELECT
     inun.reference_time,
 	to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS update_time
 INTO publish.ana_inundation_public
-FROM publish.ana_inundation as inun, derived.fim_domain as fim_domain
-WHERE ST_Intersects(inun.geom, fim_domain.geom)
+FROM publish.ana_inundation as inun
+JOIN derived.fim_domain as fim_domain ON ST_Intersects(inun.geom, fim_domain.geom)
+JOIN derived.channels_conus cc ON cc.feature_id = inun.feature_id
+WHERE public_fim = true

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/mrf_gfs_10day_max_inundation/5day_public_subset.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/mrf_gfs_10day_max_inundation/5day_public_subset.sql
@@ -8,6 +8,6 @@ SELECT
 	to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS update_time
 INTO publish.mrf_gfs_max_inundation_5day_public
 FROM publish.mrf_gfs_max_inundation_5day as inun
-JOIN derived.fim_domain as fim_domain ON ST_Intersects(inun.geom, fim_domain.geom)
+JOIN derived.public_fim_domain as fim_domain ON ST_Intersects(inun.geom, fim_domain.geom)
 JOIN derived.channels_conus cc ON cc.feature_id = inun.feature_id
 WHERE public_fim = true

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/mrf_gfs_10day_max_inundation/5day_public_subset.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/mrf_gfs_10day_max_inundation/5day_public_subset.sql
@@ -7,5 +7,7 @@ SELECT
     inun.reference_time,
 	to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS update_time
 INTO publish.mrf_gfs_max_inundation_5day_public
-FROM publish.mrf_gfs_max_inundation_5day as inun, derived.fim_domain as fim_domain
-WHERE ST_Intersects(inun.geom, fim_domain.geom)
+FROM publish.mrf_gfs_max_inundation_5day as inun
+JOIN derived.fim_domain as fim_domain ON ST_Intersects(inun.geom, fim_domain.geom)
+JOIN derived.channels_conus cc ON cc.feature_id = inun.feature_id
+WHERE public_fim = true

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/rfc_based_5day_max_inundation/public_subset.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/rfc_based_5day_max_inundation/public_subset.sql
@@ -8,6 +8,6 @@ SELECT
 	to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS update_time
 INTO publish.rfc_based_5day_max_inundation_public
 FROM publish.rfc_based_5day_max_inundation as inun
-JOIN derived.fim_domain as fim_domain ON ST_Intersects(inun.geom, fim_domain.geom)
+JOIN derived.public_fim_domain as fim_domain ON ST_Intersects(inun.geom, fim_domain.geom)
 JOIN derived.channels_conus cc ON cc.feature_id = inun.feature_id
 WHERE public_fim = true

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/rfc_based_5day_max_inundation/public_subset.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/rfc_based_5day_max_inundation/public_subset.sql
@@ -7,5 +7,7 @@ SELECT
     inun.reference_time,
 	to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS update_time
 INTO publish.rfc_based_5day_max_inundation_public
-FROM publish.rfc_based_5day_max_inundation as inun, derived.fim_domain as fim_domain
-WHERE ST_Intersects(inun.geom, fim_domain.geom)
+FROM publish.rfc_based_5day_max_inundation as inun
+JOIN derived.fim_domain as fim_domain ON ST_Intersects(inun.geom, fim_domain.geom)
+JOIN derived.channels_conus cc ON cc.feature_id = inun.feature_id
+WHERE public_fim = true


### PR DESCRIPTION
This PR removes the Rio Grande FIM from public services. Eventually we will want to remove all non-CONUS reaches out of all services but this is immediate action needed.

In addition to these code changes, I also updated the derived.channels_conus table with a new "public_fim" column. This is a boolean column which indicates if certain reached can be public or not.