### PR TITLE
Implements coastal fim processing by tile, not huc

### DIFF
--- a/Core/LAMBDA/viz_functions/image_based/viz_optimize_rasters/lambda_function.py
+++ b/Core/LAMBDA/viz_functions/image_based/viz_optimize_rasters/lambda_function.py
@@ -114,7 +114,6 @@ def run_create_vrt(event):
     # publish folder it has to also exist in the tif folder since the tif folder
     # is used as the basis for what gets copied over in the viz_update_egis_data lambda
     create_vrt(output_bucket, f'{output_workspace}/tif/', '.tif')
-    create_vrt(output_bucket, f'{output_workspace}/mrf/', '.mrf')
 
 def create_vrt(output_bucket, output_workspace, extension):
     s3_client = boto3.client('s3')

--- a/Core/LAMBDA/viz_functions/image_based/viz_schism_fim_processing/lambda_function.py
+++ b/Core/LAMBDA/viz_functions/image_based/viz_schism_fim_processing/lambda_function.py
@@ -3,7 +3,7 @@
 # SCHISM FIM Workflow
 # 
 # This script takes a SCHISM netCDF file and generates
-# a FIM tif for the specified HUC8s along the coast.
+# a FIM tif for the provided raster tile along the coast.
 #
 # Author: Laura Keys, laura.keys@noaa.gov
 #
@@ -28,8 +28,11 @@ from rasterio import features
 from rasterio.session import AWSSession
 from shapely.geometry import box
 from time import sleep
+from rasterio.io import MemoryFile
 
+# DO NOT LEAVE THIS COMMENTED!!!!!!!
 from viz_classes import database
+# database = {}
 
 DEM_RESOLUTION = 30
 GRID_SIZE = DEM_RESOLUTION / 111000 # calc degrees, assume 111km/degree
@@ -43,8 +46,21 @@ METERS_TO_FT = 3.281
 
 
 def lambda_handler(event, context):
+    print("Executing lambda handler...")
     step = event['step']
-    huc = event['huc']
+    fim_config = event['args']['fim_config']['name']
+
+    if step == 'get_domain_tile_basenames':
+        domain = [d for d in DOMAINS if d in fim_config][0]
+        domain_tile_basenames = get_domain_tile_basenames(domain)
+        return {
+            "domain_tile_basenames": domain_tile_basenames
+        }
+
+    if step != 'iteration': 
+        raise Exception(f'Step "{step}" is invalid.')
+
+    tile_basename = event['tile_basename']
     reference_time = event['args']['reference_time']
     sql_rename_dict = event['args']['sql_rename_dict']
     fim_config = event['args']['fim_config']['name']
@@ -66,79 +82,88 @@ def lambda_handler(event, context):
     
     print(f"Processing the {fim_config} fim config")
 
-    depth_key = create_fim_by_huc(huc, schism_fim_s3_uri, product, fim_config, reference_date, target_table, output_bucket, output_workspace)
+    depth_key = create_fim_by_tile(tile_basename, schism_fim_s3_uri, product, fim_config, reference_date, target_table, output_bucket, output_workspace)
     
     return {
         "output_raster": depth_key,
         "output_bucket": output_bucket
     }
 
-def create_fim_by_huc(huc, schism_fim_s3_uri, product, fim_config, reference_date, target_table, output_bucket, output_workspace):
+def get_domain_tile_basenames(domain):
+    prefix = f'{INPUTS_PREFIX}/dems/{domain}/tiles/'
+    paginator = S3.get_paginator('list_objects')
+    operation_parameters = {'Bucket': INPUTS_BUCKET,
+                            'Prefix': prefix}
+    page_iterator = paginator.paginate(**operation_parameters)
+    valid_ids = []
+    for page in page_iterator:
+        objects = page['Contents']
+        for obj in objects:
+            key = obj['Key']
+            if key.endswith('.tif'):
+                valid_ids.append(key.split('/')[-1])
+
+    return valid_ids
+
+def create_fim_by_tile(tile_basename, schism_fim_s3_uri, product, fim_config, reference_date, target_table, output_bucket, output_workspace):
     domain = [d for d in DOMAINS if d in schism_fim_s3_uri][0]
     full_ref_time = reference_date.strftime("%Y-%m-%d %H:%M:%S UTC")
 
     target_table_schema = target_table.split(".")[0]
     target_table = target_table.split(".")[1]
 
-    depth_key = f'{output_workspace}/tif/{huc}.tif'
-    dem_filename = f's3://{INPUTS_BUCKET}/{INPUTS_PREFIX}/dems/{domain}/{huc}.tif'
-    coastal_hucs = f'zip+s3://{INPUTS_BUCKET}/{INPUTS_PREFIX}/hucs/coastal_{domain}_huc8s.zip'
-    temp_folder = tempfile.mkdtemp()
-    huc_feature = None
+    depth_key = f'{output_workspace}/tif/{tile_basename}'
+    dem_filename = f's3://{INPUTS_BUCKET}/{INPUTS_PREFIX}/dems/{domain}/tiles/{tile_basename}'
 
-    print("Executing lambda handler...")
-    print(f"Writing tempfiles to {temp_folder}")
-
-    with fiona.Env(session=AWS_SESSION):
-        with fiona.open(coastal_hucs, "r") as shapefile:
-            for feature in shapefile:
-                if feature['properties']['huc8_str'] == huc:
-                    huc_feature = feature
-                    break
-
-    if not huc_feature:
-        raise Exception(f'HUC {huc} not found in file {coastal_hucs}')
+    print(f'Processing Schism FIM for {tile_basename}...')
     
-    print(f'Processing Schism FIM for HUC {huc}...')
-    # limit the schism data to only the relevant HUC8
+    dem_obj = None
+    with rasterio.Env(AWS_SESSION):
+        dem_obj = rasterio.open(dem_filename)
+
     try:
-        clipped_npds = clip_to_extent(schism_fim_s3_uri, huc_feature)
+        # limit the schism data to the tile bounds
+        clipped_npds = clip_to_bounds(schism_fim_s3_uri, dem_obj.bounds)
         
         if len(clipped_npds.x) == 0:
-            print(f"!! No forecast points in netCDF in HUC {huc}")
+            print(f"!! No forecast points in netCDF in tile {tile_basename}")
             raise Exception
 
-        print(f".. {len(clipped_npds.x)} forecast points in HUC {huc}")
+        print(f".. {len(clipped_npds.x)} forecast points in tile {tile_basename}")
         # interpolate the schism data
-        interp_grid_file = interpolate(clipped_npds, GRID_SIZE, temp_folder)
+        interp_grid_memfile = interpolate(clipped_npds, GRID_SIZE)
 
         # subtract dem from schism data 
         # (includes code to match extent/resolution)
-        wse_grid = wse_to_depth(interp_grid_file, dem_filename, temp_folder)
-        if wse_grid == "":
+        wse_grid = wse_to_depth(interp_grid_memfile, dem_obj)
+        if wse_grid is None:
             print("!! No overlap between raster and DEM")
-            return
+            raise Exception
 
         # apply masks
-        final_grid = mask_fim(wse_grid, domain, temp_folder)
+        final_grid_memfile = mask_fim(wse_grid, domain)
     except Exception as e:
-        final_grid = create_empty_grid_for_feature(huc_feature, temp_folder)
-    
-    print(f"Uploading depth grid to AWS at s3://{output_bucket}/{depth_key}")
-    S3.upload_file(final_grid, output_bucket, depth_key)
+        print(e)
+        print("Issue encountered (see above). Creating empty tile...")
+        final_grid_memfile = create_empty_tile(dem_obj)
 
+    print("Converting depth to binary fim...")
     # translate all > 0 depth values to 1 for wet (everything else [dry] already 0)
-    binary_fim = fim_to_binary(final_grid, temp_folder)
-    
-    # We shouldn't need to clip since the raster is already at the HUC level
-    # clipped_result = clip_to_shape(binary_fim, bounds)
+    binary_fim_memfile = fim_to_binary(final_grid_memfile)
+
+    print(f"Uploading depth grid to AWS at s3://{output_bucket}/{depth_key}")
+    S3.upload_fileobj(
+        final_grid_memfile,
+        output_bucket,
+        depth_key
+    )
 
     attributes = {
-        'huc8': huc,
+        'huc8': tile_basename,
         'reference_time': full_ref_time
     }
 
-    polygon_df = raster_to_polygon_dataframe(binary_fim, attributes)
+    polygon_df = raster_to_polygon_dataframe(binary_fim_memfile, attributes)
 
     if polygon_df.empty:
         print("Raster to polygon yielded no features.")
@@ -155,26 +180,22 @@ def create_fim_by_huc(huc, schism_fim_s3_uri, product, fim_config, reference_dat
                 break
             except Exception as e:
                 if attempt == attempts - 1:
-                    raise Exception(f"Failed to add SCHISM FIM polygons to DB for HUC {huc}: ({e})")
+                    raise Exception(f"Failed to add SCHISM FIM polygons to DB for tile {tile_basename} of {fim_config} for {full_ref_time}: ({e})")
                 else:
                     sleep(1)
         process_db.engine.dispose()
-    
-    print("Removing temp files...")
-    rmtree(temp_folder)
 
-    print(f"Successfully processed SCHISM FIM for HUC {huc} of {fim_config} for {full_ref_time}")
+    print(f"Successfully processed SCHISM FIM for tile {tile_basename} of {fim_config} for {full_ref_time}")
     return depth_key
 
 #
 # Clips SCHISM forecast points to fit some shapefile bounds
 #
-def clip_to_extent(schism_fim_s3_uri, clip_feature):
-    print("++ Clipping SCHISM point domain to new domain ++")
+def clip_to_bounds(schism_fim_s3_uri, bounds):
+    print("Clipping SCHISM max_elevs domain to new tile domain...")
 
-    bounds = rasterio.features.bounds(clip_feature['geometry'])
     fs = s3fs.S3FileSystem()
-    print(f'Opening {schism_fim_s3_uri}...')
+    print(f'...Opening {schism_fim_s3_uri}...')
     with fs.open(schism_fim_s3_uri, 'rb') as f:
         with xr.open_dataset(f) as n:
             n_ = check_names(n)
@@ -183,7 +204,7 @@ def clip_to_extent(schism_fim_s3_uri, clip_feature):
                 (n_.x > bounds[0]) & #x_min
                 (n_.y < bounds[3]) & #y_max
                 (n_.y > bounds[1])), #y_min
-                    np.nan)
+                    NO_DATA)
 
     n_clip = n_clip.dropna('node', how="any")
     
@@ -194,18 +215,19 @@ def check_names(f):
         f = f.rename({'SCHISM_hgrid_node_x':'x',
             'SCHISM_hgrid_node_y':'y',
             'elevation':'elev'})
-        print("..Renamed variables in netcdf.")
+        print("...Renamed variables in netcdf.")
     except:
-        print("..No variables to rename in netcdf. Good!") 
+        print("...No variables to rename in netcdf. Good!") 
     try:
         f = f.rename_dims({'nSCHISM_hgrid_node':'node'})
-        print("..Renamed dim in netcdf.")
+        print("...Renamed dim in netcdf.")
     except:
-        print("..No dimension to rename in netcdf. Good!") 
+        print("...No dimension to rename in netcdf. Good!") 
 
     return f
 
-def interpolate(numpy_ds, grid_size, temp_folder):
+def interpolate(numpy_ds, grid_size):
+    print('Interpolating max_elevs grid...')
     # time series netcdf needs to have x, y, and elev variables
     # ... SCHISM files operationally might use "elevation",
     # "SCHISM_hgrid_node_x" and "SCHISM_hgrid_node_y", so
@@ -229,13 +251,14 @@ def interpolate(numpy_ds, grid_size, temp_folder):
     y_max = np.max(n.y)
 
     # create grid of evenly-spaced locations to interpolate over
+    print('...Creating grid...')
     xx, yy = np.meshgrid(np.arange(x_min, x_max, grid_size), \
         np.arange(y_min, y_max, grid_size)) 
 
-    print(f"** Number of SCHISM forecast points: {len(coords)}")
+    print(f"...Number of SCHISM forecast points: {len(coords)}")
 
     # interpolation
-    print("*** Interpolating ***")
+    print("...Interpolating...")
     # interpolate over forecast points' elevation data onto the new xx-yy grid
     # .. cubic is also an option for cubic spline, vs barycentric linear
     # .. or nearest, for nearest neighbor, but that's slower (better for depth?)
@@ -245,50 +268,52 @@ def interpolate(numpy_ds, grid_size, temp_folder):
     interp_grid = np.flip(interp_grid, 0)
 
     # write out interpolated raster to file or to a memory file for later use
-    interp_file = os.path.join(temp_folder, 'interp_temp.tif') # xxx
-    with rasterio.open(interp_file, 'w',
-            height=interp_grid.shape[0],
-            width=interp_grid.shape[1],
-            count=1,
-            compress='lzw',
-            dtype=interp_grid.dtype,
-            driver="GTiff",
-            crs="epsg:4326",
-            transform=rasterio.transform.from_origin(
-                x_min, y_max, grid_size, grid_size)) as src:
+    interp_memfile = MemoryFile()
+    with interp_memfile.open(
+        height=interp_grid.shape[0],
+        width=interp_grid.shape[1],
+        count=1,
+        compress='lzw',
+        dtype=interp_grid.dtype,
+        driver="GTiff",
+        crs="epsg:4326",
+        transform=rasterio.transform.from_origin(
+            x_min, y_max, grid_size, grid_size)
+    ) as src:
         # write single-band raster
         src.write(interp_grid, 1)
-    return interp_file
 
-def wse_to_depth(interp_grid, dem_filename, temp_folder):
+    return interp_memfile
+
+def wse_to_depth(interp_grid_memfile, dem):
     # clip the interpolated rst and dem to match bounding boxes
-    with rasterio.open(interp_grid) as rst:
+    dem_bounds = None
+    rst_bounds = None
+    with interp_grid_memfile.open() as rst:
         rst_bounds = rst.bounds
-        with rasterio.Env(AWS_SESSION):
-            with rasterio.open(dem_filename) as dem:
-                dem_bounds = dem.bounds
-                # get overlapping boundaries
-                x_min = max(rst_bounds[0], dem_bounds[0]) # max of left values
-                y_min = max(rst_bounds[1], dem_bounds[1]) # max of bottom values
-                x_max = min(rst_bounds[2], dem_bounds[2]) # min of right values
-                y_max = min(rst_bounds[3], dem_bounds[3]) # min of top values
+        dem_bounds = dem.bounds
+        # get overlapping boundaries
+        x_min = max(rst_bounds[0], dem_bounds[0]) # max of left values
+        y_min = max(rst_bounds[1], dem_bounds[1]) # max of bottom values
+        x_max = min(rst_bounds[2], dem_bounds[2]) # min of right values
+        y_max = min(rst_bounds[3], dem_bounds[3]) # min of top values
 
-                # create a clipping box of the overlapping boundaries
-                feature = box(x_min, y_min, x_max, y_max)
+        # create a clipping box of the overlapping boundaries
+        feature = box(x_min, y_min, x_max, y_max)
 
-                # clip the interp raster and topobathy dem to be same bounds
-                try:
-                    rst_masked, rst_trans = rasterio.mask.mask(rst, [feature],
-                        crop=True,
-                        #nodata=0)
-                        nodata=np.nan)
-                    dem_masked, dem_trans = rasterio.mask.mask(dem, [feature],
-                        crop=True,
-                        #nodata=0)
-                        nodata=np.nan)
-                except:
-                    # no overlapping area for the raster and dem
-                    return ""
+        # clip the interp raster and topobathy dem to be same bounds
+        try:
+            rst_masked, rst_trans = rasterio.mask.mask(rst, [feature],
+                crop=True,
+                #nodata=0)
+                nodata=NO_DATA)
+            dem_masked, dem_trans = rasterio.mask.mask(dem, [feature],
+                crop=True,
+                #nodata=0)
+                nodata=NO_DATA)
+        except:
+            # no overlapping area for the raster and dem
+            return None
 
     # write out rst_masked with updated metadata
     # (can write to memory file instead)
@@ -296,36 +321,40 @@ def wse_to_depth(interp_grid, dem_filename, temp_folder):
     # ... writing these to a file or memfile lets us use them as rasterio
     # DatasetReader later, which makes it easier to match their extents and
     # resolution perfectly to allow us to subtract correctly
-    with rasterio.open(os.path.join(temp_folder, 'temprst.tif'), 'w', # xxx
-            height=rst_masked.shape[1],
-            width=rst_masked.shape[2],
-            count=1,
-            compress='lzw',
-            dtype=rst_masked.dtype,
-            driver="GTiff",
-            crs="epsg:4326",
-            transform=rst_trans) as src:
+    temp_rst_memfile = MemoryFile()
+    with temp_rst_memfile.open(
+        height=rst_masked.shape[1],
+        width=rst_masked.shape[2],
+        count=1,
+        compress='lzw',
+        dtype=rst_masked.dtype,
+        driver="GTiff",
+        crs="epsg:4326",
+        transform=rst_trans
+    ) as rst_src:
         # write single-band raster
-        src.write(rst_masked[0], 1)
+        rst_src.write(rst_masked[0], 1)
 
     # write out dem with updated metadata
-    with rasterio.open(os.path.join(temp_folder, 'tempdem.tif'), 'w', #xxx
-            height=dem_masked.shape[1],
-            width=dem_masked.shape[2],
-            count=1,
-            compress='lzw',
-            dtype=dem_masked.dtype,
-            driver="GTiff",
-            crs="epsg:4326",
-            transform=dem_trans) as src:
+    temp_dem_memfile = MemoryFile()
+    with temp_dem_memfile.open(
+        height=dem_masked.shape[1],
+        width=dem_masked.shape[2],
+        count=1,
+        compress='lzw',
+        dtype=dem_masked.dtype,
+        driver="GTiff",
+        crs="epsg:4326",
+        transform=dem_trans
+    ) as dem_src:
         # write single-band raster
-        src.write(dem_masked[0], 1)
+        dem_src.write(dem_masked[0], 1)
 
     # match resolution and coordinates of dem to the interpolation
     # .. even if the extent and resolution are the same, it's good to do
     # this to be absolutely certain before trying to do raster math
-    with rxr.open_rasterio(os.path.join(temp_folder, 'temprst.tif')) as rst_masked:
-        with rxr.open_rasterio(os.path.join(temp_folder, 'tempdem.tif')) as dem_masked:
+    with rxr.open_rasterio(temp_rst_memfile) as rst_masked:
+        with rxr.open_rasterio(temp_dem_memfile) as dem_masked:
             # create dem with projection and resolution that matches interp rst
             matching_dem = dem_masked.rio.reproject_match(rst_masked)
             # make sure coordinates of dem match rst
@@ -337,51 +366,49 @@ def wse_to_depth(interp_grid, dem_filename, temp_folder):
     # calculate WSE depth
     wse_depth = rst_masked - matching_dem
     wse_depth = wse_depth * METERS_TO_FT
-    wse_file = os.path.join(temp_folder, 'wse_temp.tif') #xxx
-    wse_depth.rio.to_raster(wse_file)
-    return wse_file
+    wse_depth = wse_depth.round()
 
-def fim_to_binary(wse_file, temp_folder):
-    wse_rst = rasterio.open(wse_file)
-    interp_grid = wse_rst.read(1)
+    wse_memfile = MemoryFile()
+    with wse_memfile.open( 
+        height=wse_depth.shape[1],
+        width=wse_depth.shape[2],
+        count=1,
+        dtype=wse_depth.dtype,
+        compress='lzw',
+        driver="GTiff",
+        crs="epsg:4326",
+        transform=rasterio.transform.from_origin(rst_bounds[0], rst_bounds[3], GRID_SIZE, GRID_SIZE)
+    ) as wse_src:
+        # write single-band raster
+        wse_src.write(wse_depth[0], 1)
+
+    return wse_memfile
+
+def fim_to_binary(wse_memfile):
+    with wse_memfile.open() as wse_rst:
+        interp_grid = wse_rst.read(1)
 
     print("+++ Translating to binary fim")
     interp_grid[interp_grid > 0] = 1
 
-    '''
-    # example of memory file writing
-    # write to memfile
-    memfile = MemoryFile()
-    with memfile.open(
+    # need interpolation in rasterio DatasetReader format for easy masking
+    # steps, so need to save as file or memory file because it's a
+    # numpy array right here
+    fim_memfile = MemoryFile()
+    with fim_memfile.open( 
         height=interp_grid.shape[0],
         width=interp_grid.shape[1],
         count=1,
         dtype=interp_grid.dtype,
+        compress='lzw',
         driver="GTiff",
         crs="epsg:4326",
-        transform=rasterio.transform.from_origin(x_min, y_max, grid_size, grid_size)) as src:
-        # write single-band raster
-        src.write(interp_grid, 1)
-    '''
-
-
-    fim_file = os.path.join(temp_folder, 'fim_temp.tif') #xxx
-    # need interpolation in rasterio DatasetReader format for easy masking
-    # steps, so need to save as file or memory file because it's a
-    # numpy array right here
-    with rasterio.open(fim_file, 'w', 
-            height=interp_grid.shape[0],
-            width=interp_grid.shape[1],
-            count=1,
-            dtype=interp_grid.dtype,
-            compress='lzw',
-            driver="GTiff",
-            crs="epsg:4326",
-            transform=wse_rst.transform) as src:
+        transform=wse_rst.transform
+    ) as src:
         # write single-band raster
         src.write(interp_grid, 1)
     
-    return fim_file 
+    return fim_memfile 
 
 # Mask class that correctly handles masking inside or outside a specified layer
 class Mask:
@@ -398,7 +425,6 @@ class Mask:
         if m == "interior":
             self.invert = True
             self.crop = False
-        return
 
     def mask(self, rst):
         # get all the masking shapefile coordinates
@@ -408,9 +434,10 @@ class Mask:
 
         out_image, out_transform = rasterio.mask.mask(
             rst, geoms, crop=self.crop, invert=self.invert, nodata=NO_DATA)
+        
         return out_image, out_transform
 
-def mask_fim(input_fim, domain, temp_folder):
+def mask_fim(input_fim, domain):
     out_meta = {}
     masks_prefix = f'{INPUTS_PREFIX}/masks/{domain}'
 
@@ -421,120 +448,77 @@ def mask_fim(input_fim, domain, temp_folder):
     # list of mask locations and "interior" or "exterior" (see Mask Class)
     mask_list = [Mask(uri, re.search('[inex]{2}terior', uri)[0]) for uri in mask_uris]
 
-    current_raster = input_fim
     for mask_number, mask in enumerate(mask_list, 1):
-        print(f'** Applying mask: {mask.fpath} **')
+        print(f'...Applying mask: {mask.fpath}...')
         
         # open the latest intermediate file and mask out the next mask
         # ... need rst in rasterio DatasetReader format, so need to save
         # as file or memory file, because the rasterio mask function does not
         # return out_image in a format we can directly reuse!
-        with rasterio.open(current_raster) as rst:
+        with input_fim.open() as rst:
             out_image, out_transform = mask.mask(rst)
 
         # update raster metadata in case it was cropped
         # (or not filled in yet)
-        out_meta.update({"driver": "GTiff",
+        out_meta.update({
+            "driver": "GTiff",
             "height":out_image.shape[1],
             "width":out_image.shape[2],
             "compress": 'lzw',
             "crs":"epsg:4326",
             "count":1,
             "dtype":out_image.dtype,
-            "transform":out_transform})
+            "transform":out_transform
+        })
         
-        current_raster = f'{temp_folder}/temp{mask_number}.tif'
+        input_fim = MemoryFile()
         # write out latest intermediate mask
         # .. needs to be written as file or memory file so we can use it as a
         # rasterio DatasetReader for next mask
         # xxx specify location
-        with rasterio.open(current_raster, 'w', **out_meta) as src:
+
+        with input_fim.open(**out_meta) as src:
             src.write(out_image[0], 1)
 
-    # write over mosaiced raster with masked version
-    final_filename = input_fim
-    print(f"** Writing out final raster to {final_filename} **")
-    with rasterio.open(final_filename, "w", **out_meta) as dest:
+    final_memfile = MemoryFile()
+    print(f"** Writing out final raster to MemoryFile **")
+    with final_memfile.open(**out_meta) as dest:
         # Set every cell less than 0 to NO_DATA value
         out_image[out_image < 0] = NO_DATA
         dest.write(out_image[0], 1)
 
-    return final_filename
+    return final_memfile
 
-def clip_to_shape(current_raster, final_clip_bounds):
-    # after all masks are applied, clip to HUC8 shape and save
-    with rasterio.open(current_raster) as rst:
-        try:
-            out_image, out_transform = rasterio.mask.mask(
-                #rst, [final_clip_bounds], crop=True, nodata=0)
-                rst, [final_clip_bounds], crop=True, nodata=np.nan)
-            out_meta = {"driver": "GTiff",
-                "height":out_image.shape[1],
-                "width":out_image.shape[2],
-                "compress": 'lzw',
-                "crs":"epsg:4326",
-                "count":1,
-                "dtype":out_image.dtype,
-                "transform":out_transform}
-        except:
-            print(".. No overlap in clipping bounds and interpolation.")
-
-    # overwrite input file
-    final_filename = current_raster
-    with rasterio.open(final_filename, "w", **out_meta) as dest:
-        dest.write(out_image[0], 1)
-
-    return final_filename
-
-def raster_to_polygon_dataframe(input_raster, attributes):
+def raster_to_polygon_dataframe(input_raster_memfile, attributes):
     gpd_polygonized_raster = gpd.GeoDataFrame()
-    with rasterio.Env(AWS_SESSION):
-        with rasterio.open(input_raster) as src:
-            image = src.read(1).astype('float32')
-            results = (
-                {'properties': attributes, 'geometry': s} for i, (s, v) 
-                in enumerate(rasterio.features.shapes(image, mask=image > 0, transform=src.transform))
-            )
-            geoms = list(results)
-            if geoms:
-                gpd_polygonized_raster  = gpd.GeoDataFrame.from_features(geoms, crs='4326')
-    
+    with input_raster_memfile.open() as src:
+        image = src.read(1).astype('float32')
+        results = (
+            {'properties': attributes, 'geometry': s} for i, (s, v) 
+            in enumerate(rasterio.features.shapes(image, mask=image > 0, transform=src.transform))
+        )
+        geoms = list(results)
+        if geoms:
+            gpd_polygonized_raster  = gpd.GeoDataFrame.from_features(geoms, crs='4326')
+
     return gpd_polygonized_raster
 
-def create_empty_grid_for_feature(feature, output_dpath):
-    output_fpath = os.path.join(output_dpath, 'empty.tif')
-    ds = gpd.GeoDataFrame.from_features([feature])
-    geom = [shapes for shapes in ds.geometry]
-    x_min = ds.bounds.minx[0]
-    x_max = ds.bounds.maxx[0]
-    y_min = ds.bounds.miny[0]
-    y_max = ds.bounds.maxy[0]
+def create_empty_tile(dem_memfile):
+    dem = dem_memfile.read(1)
+    dem[dem != 0] = 0
 
-    # Get number of grid cells in x and y directions
-    x_size = np.arange(x_min, x_max, GRID_SIZE).size
-    y_size = np.arange(y_min, y_max, GRID_SIZE).size
-
-    transform = rasterio.transform.from_origin(x_min, y_max, GRID_SIZE, GRID_SIZE)
-
-    empty_grid = features.rasterize(geom,
-                                out_shape=(x_size, y_size),
-                                fill=0,
-                                out=None,
-                                transform=transform,
-                                all_touched=False,
-                                default_value=0,
-                                dtype=None)
-    
-    with rasterio.open(output_fpath, 'w',
-            height=empty_grid.shape[0],
-            width=empty_grid.shape[1],
-            count=1,
-            compress='lzw',
-            dtype=empty_grid.dtype,
-            driver="GTiff",
-            crs="epsg:4326",
-            transform=transform) as src:
+    memfile = MemoryFile()
+    with memfile.open(
+        height=dem_memfile.shape[0],
+        width=dem_memfile.shape[1],
+        count=1,
+        compress='lzw',
+        dtype=dem.dtype,
+        driver="GTiff",
+        crs="epsg:4326",
+        transform=dem_memfile.transform
+    ) as src:
         # write single-band raster
-        src.write(empty_grid, 1)
+        src.write(dem, 1)
     
-    return output_fpath
+    return memfile

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/analysis_assim_coastal/ana_coastal_inundation_depth.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/analysis_assim_coastal/ana_coastal_inundation_depth.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS publish.ana_coastal_inundation_depth;
+CREATE TABLE publish.ana_coastal_inundation_depth (
+    reference_time TEXT,
+    valid_time TEXT,
+    update_time TEXT
+);
+INSERT INTO publish.ana_coastal_inundation_depth
+VALUES (
+    to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), 
+    to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), 
+    to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC')
+);

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/analysis_assim_coastal_hawaii/ana_coastal_inundation_depth_hi.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/analysis_assim_coastal_hawaii/ana_coastal_inundation_depth_hi.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS publish.ana_coastal_inundation_depth_hi;
+CREATE TABLE publish.ana_coastal_inundation_depth_hi (
+    reference_time TEXT,
+    valid_time TEXT,
+    update_time TEXT
+);
+INSERT INTO publish.ana_coastal_inundation_depth_hi
+VALUES (
+    to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), 
+    to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), 
+    to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC')
+);

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/analysis_assim_coastal_puertorico/ana_coastal_inundation_depth_prvi.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/analysis_assim_coastal_puertorico/ana_coastal_inundation_depth_prvi.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS publish.ana_coastal_inundation_depth_prvi;
+CREATE TABLE publish.ana_coastal_inundation_depth_prvi (
+    reference_time TEXT,
+    valid_time TEXT,
+    update_time TEXT
+);
+INSERT INTO publish.ana_coastal_inundation_depth_prvi
+VALUES (
+    to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), 
+    to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), 
+    to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC')
+);

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/medium_range_blend_coastal/mrf_nbm_10day_max_coastal_inundation_depth.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/medium_range_blend_coastal/mrf_nbm_10day_max_coastal_inundation_depth.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS publish.mrf_nbm_10day_max_coastal_inundation_depth;
+CREATE TABLE publish.mrf_nbm_10day_max_coastal_inundation_depth (
+    reference_time TEXT,
+    valid_time TEXT,
+    update_time TEXT
+);
+INSERT INTO publish.mrf_nbm_10day_max_coastal_inundation_depth
+VALUES (
+    to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), 
+    to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), 
+    to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC')
+);

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/medium_range_coastal_mem1/mrf_gfs_10day_max_coastal_inundation_depth.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/medium_range_coastal_mem1/mrf_gfs_10day_max_coastal_inundation_depth.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS publish.mrf_gfs_10day_max_coastal_inundation_depth;
+CREATE TABLE publish.mrf_gfs_10day_max_coastal_inundation_depth (
+    reference_time TEXT,
+    valid_time TEXT,
+    update_time TEXT
+);
+INSERT INTO publish.mrf_gfs_10day_max_coastal_inundation_depth
+VALUES (
+    to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), 
+    to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), 
+    to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC')
+);

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_coastal/srf_18hr_max_coastal_inundation_depth.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_coastal/srf_18hr_max_coastal_inundation_depth.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS publish.srf_18hr_max_coastal_inundation_depth;
+CREATE TABLE publish.srf_18hr_max_coastal_inundation_depth (
+    reference_time TEXT,
+    valid_time TEXT,
+    update_time TEXT
+);
+INSERT INTO publish.srf_18hr_max_coastal_inundation_depth
+VALUES (
+    to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), 
+    to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), 
+    to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC')
+);

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_coastal_hawaii/srf_18hr_max_coastal_inundation_depth_hi.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_coastal_hawaii/srf_18hr_max_coastal_inundation_depth_hi.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS publish.srf_18hr_max_coastal_inundation_depth_hi;
+CREATE TABLE publish.srf_18hr_max_coastal_inundation_depth_hi (
+    reference_time TEXT,
+    valid_time TEXT,
+    update_time TEXT
+);
+INSERT INTO publish.srf_18hr_max_coastal_inundation_depth_hi
+VALUES (
+    to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), 
+    to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), 
+    to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC')
+);

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_coastal_puertorico/srf_18hr_max_coastal_inundation_depth_prvi.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_coastal_puertorico/srf_18hr_max_coastal_inundation_depth_prvi.sql
@@ -1,0 +1,12 @@
+DROP TABLE IF EXISTS publish.srf_18hr_max_coastal_inundation_depth_prvi;
+CREATE TABLE publish.srf_18hr_max_coastal_inundation_depth_prvi (
+    reference_time TEXT,
+    valid_time TEXT,
+    update_time TEXT
+);
+INSERT INTO publish.srf_18hr_max_coastal_inundation_depth_prvi
+VALUES (
+    to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), 
+    to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), 
+    to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC')
+);

--- a/Core/LAMBDA/viz_functions/viz_fim_data_prep/data_sql/coastal_atlgulf.sql
+++ b/Core/LAMBDA/viz_functions/viz_fim_data_prep/data_sql/coastal_atlgulf.sql
@@ -1,5 +1,0 @@
-SELECT 
-    DISTINCT LPAD(huc8::text, 8, '0') as huc
-FROM derived.featureid_huc_crosswalk
-WHERE 
-    coastal = 'atlgulf'

--- a/Core/LAMBDA/viz_functions/viz_fim_data_prep/data_sql/coastal_hi.sql
+++ b/Core/LAMBDA/viz_functions/viz_fim_data_prep/data_sql/coastal_hi.sql
@@ -1,5 +1,0 @@
-SELECT 
-    DISTINCT LPAD(huc8::text, 8, '0') as huc
-FROM derived.featureid_huc_crosswalk
-WHERE 
-    coastal = 'hi'

--- a/Core/LAMBDA/viz_functions/viz_fim_data_prep/data_sql/coastal_pacific.sql
+++ b/Core/LAMBDA/viz_functions/viz_fim_data_prep/data_sql/coastal_pacific.sql
@@ -1,5 +1,0 @@
-SELECT 
-    DISTINCT LPAD(huc8::text, 8, '0') as huc
-FROM derived.featureid_huc_crosswalk
-WHERE 
-    coastal = 'pacific'

--- a/Core/LAMBDA/viz_functions/viz_fim_data_prep/data_sql/coastal_prvi.sql
+++ b/Core/LAMBDA/viz_functions/viz_fim_data_prep/data_sql/coastal_prvi.sql
@@ -1,5 +1,0 @@
-SELECT 
-    DISTINCT LPAD(huc8::text, 8, '0') as huc
-FROM derived.featureid_huc_crosswalk
-WHERE 
-    coastal = 'pr'

--- a/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/analysis_assim_coastal/ana_coastal_inundation.yml
+++ b/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/analysis_assim_coastal/ana_coastal_inundation.yml
@@ -1,6 +1,7 @@
 product: ana_coastal_inundation
 configuration: analysis_assim_coastal
 product_type: "fim"
+published_format: "tif"
 run: true
 
 fim_configs:
@@ -26,6 +27,8 @@ fim_configs:
 postprocess_sql:
   - sql_file: ana_coastal_inundation
     target_table: publish.ana_coastal_inundation
+  - sql_file: ana_coastal_inundation_depth
+    target_table: publish.ana_coastal_inundation_depth
 
 services:
   - ana_coastal_inundation_extent_noaa

--- a/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/analysis_assim_coastal_hawaii/ana_coastal_inundation_hi.yml
+++ b/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/analysis_assim_coastal_hawaii/ana_coastal_inundation_hi.yml
@@ -1,6 +1,7 @@
 product: ana_coastal_inundation_hi
 configuration: analysis_assim_coastal_hawaii
 product_type: "fim"
+published_format: "tif"
 run: true
 
 fim_configs:
@@ -16,6 +17,10 @@ fim_configs:
     postprocess:
       sql_file: ana_coastal_inundation_hi
       target_table: publish.ana_coastal_inundation_hi
+
+postprocess_sql:
+  - sql_file: ana_coastal_inundation_depth_hi
+    target_table: publish.ana_coastal_inundation_depth_hi
 
 services:
   - ana_coastal_inundation_extent_hi_noaa

--- a/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/analysis_assim_coastal_puertorico/ana_coastal_inundation_prvi.yml
+++ b/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/analysis_assim_coastal_puertorico/ana_coastal_inundation_prvi.yml
@@ -1,6 +1,7 @@
 product: ana_coastal_inundation_prvi
 configuration: analysis_assim_coastal_puertorico
 product_type: "fim"
+published_format: "tif"
 run: true
 
 fim_configs:
@@ -16,6 +17,10 @@ fim_configs:
     postprocess:
       sql_file: ana_coastal_inundation_prvi
       target_table: publish.ana_coastal_inundation_prvi
+
+postprocess_sql:
+  - sql_file: ana_coastal_inundation_depth_prvi
+    target_table: publish.ana_coastal_inundation_depth_prvi
 
 services:
   - ana_coastal_inundation_extent_prvi_noaa

--- a/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/medium_range_blend_coastal/mrf_nbm_10day_max_coastal_inundation.yml
+++ b/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/medium_range_blend_coastal/mrf_nbm_10day_max_coastal_inundation.yml
@@ -1,6 +1,7 @@
 product: mrf_nbm_10day_max_coastal_inundation
 configuration: medium_range_blend_coastal
 product_type: "fim"
+published_format: "tif"
 run: true
 
 fim_configs:
@@ -113,6 +114,8 @@ postprocess_sql:
     target_table: publish.mrf_nbm_5day_max_coastal_inundation
   - sql_file: mrf_nbm_10day_max_coastal_inundation
     target_table: publish.mrf_nbm_10day_max_coastal_inundation
+  - sql_file: mrf_nbm_10day_max_coastal_inundation_depth
+    target_table: publish.mrf_nbm_10day_max_coastal_inundation_depth
 
 services:
   - mrf_nbm_10day_max_coastal_inundation_extent_noaa

--- a/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/medium_range_coastal_mem1/mrf_gfs_10day_max_coastal_inundation.yml
+++ b/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/medium_range_coastal_mem1/mrf_gfs_10day_max_coastal_inundation.yml
@@ -1,6 +1,7 @@
 product: mrf_gfs_10day_max_coastal_inundation
 configuration: medium_range_coastal_mem1
 product_type: "fim"
+published_format: "tif"
 run: true
 
 fim_configs:
@@ -113,6 +114,8 @@ postprocess_sql:
     target_table: publish.mrf_gfs_5day_max_coastal_inundation
   - sql_file: mrf_gfs_10day_max_coastal_inundation
     target_table: publish.mrf_gfs_10day_max_coastal_inundation
+  - sql_file: mrf_gfs_10day_max_coastal_inundation_depth
+    target_table: publish.mrf_gfs_10day_max_coastal_inundation_depth
 
 services:
   - mrf_gfs_10day_max_coastal_inundation_extent_noaa

--- a/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/short_range_coastal/srf_18hr_max_coastal_inundation.yml
+++ b/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/short_range_coastal/srf_18hr_max_coastal_inundation.yml
@@ -1,6 +1,7 @@
 product: srf_18hr_max_coastal_inundation
 configuration: short_range_coastal
 product_type: "fim"
+published_format: "tif"
 run: true
 
 fim_configs:
@@ -39,6 +40,8 @@ fim_configs:
 postprocess_sql:
   - sql_file: srf_18hr_max_coastal_inundation
     target_table: publish.srf_18hr_max_coastal_inundation
+  - sql_file: srf_18hr_max_coastal_inundation_depth
+    target_table: publish.srf_18hr_max_coastal_inundation_depth
 
 services:
   - srf_18hr_max_coastal_inundation_extent_noaa

--- a/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/short_range_coastal_hawaii/srf_48hr_max_coastal_inundation_hi.yml
+++ b/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/short_range_coastal_hawaii/srf_48hr_max_coastal_inundation_hi.yml
@@ -1,6 +1,7 @@
 product: srf_48hr_max_coastal_inundation_hi
 configuration: short_range_coastal_hawaii
 product_type: "fim"
+published_format: "tif"
 run: true
 
 fim_configs:
@@ -16,6 +17,10 @@ fim_configs:
     postprocess:
       sql_file: srf_48hr_max_coastal_inundation_hi
       target_table: publish.srf_48hr_max_coastal_inundation_hi
+
+postprocess_sql:
+  - sql_file: srf_18hr_max_coastal_inundation_depth_hi
+    target_table: publish.srf_18hr_max_coastal_inundation_depth_hi
 
 services:
   - srf_48hr_max_coastal_inundation_extent_hi_noaa

--- a/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/short_range_coastal_puertorico/srf_48hr_max_coastal_inundation_prvi.yml
+++ b/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/short_range_coastal_puertorico/srf_48hr_max_coastal_inundation_prvi.yml
@@ -1,6 +1,7 @@
 product: srf_48hr_max_coastal_inundation_prvi
 configuration: short_range_coastal_puertorico
 product_type: "fim"
+published_format: "tif"
 run: true
 
 fim_configs:
@@ -16,6 +17,10 @@ fim_configs:
     postprocess:
       sql_file: srf_48hr_max_coastal_inundation_prvi
       target_table: publish.srf_48hr_max_coastal_inundation_prvi
+
+postprocess_sql:
+  - sql_file: srf_18hr_max_coastal_inundation_depth_prvi
+    target_table: publish.srf_18hr_max_coastal_inundation_depth_prvi
 
 services:
   - srf_48hr_max_coastal_inundation_extent_prvi_noaa

--- a/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/template.yml
+++ b/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/template.yml
@@ -1,6 +1,7 @@
 product: product_name  # (REQUIRED) The name of the product that will be processed
 configuration: configuration_name  # (REQUIRED) The configuration of the product (analysis_assim, short_range, etc)
 product_type: "vector"  # (REQUIRED) Type of product being created. Values can be "fim", "vector", or "raster"
+published_format: "tif"  # (OPTIONAL) Format of underlying services data. Values can be "mrf" or "tif". Defaults to "mrf".
 run: true  # (REQUIRED) Determines if this product is enabled or disabled
 run_times:  # (OPTIONAL) List of reference time hours that this product will run
   - 00:00  # (REQUIRED) reference hour:minute to run the service

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal/ana_coastal_inundation_depth_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal/ana_coastal_inundation_depth_noaa.mapx
@@ -449,5 +449,94 @@
       "uRI" : "CIMPATH=Metadata/d37718d89ece7ecbefff4476d478739a.xml",
       "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>20055700</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri></metadata>\r\n"
     }
+  ],
+  "tableDefinitions" : [
+    {
+      "type" : "CIMStandaloneTable",
+      "name" : "Service Metadata",
+      "uRI" : "CIMPATH=ana_coastal_inundation_depth/vizprocessing_publish_ana_coastal_inundation_depth.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant"
+      },
+      "useSourceMetadata" : true,
+      "displayField" : "reference_time",
+      "editable" : true,
+      "fieldDescriptions" : [
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "oid",
+          "fieldName" : "oid",
+          "numberFormat" : {
+            "type" : "CIMNumericFormat",
+            "alignmentOption" : "esriAlignRight",
+            "alignmentWidth" : 0,
+            "roundingOption" : "esriRoundNumberOfDecimals",
+            "roundingValue" : 0
+          },
+          "readOnly" : true,
+          "visible" : false,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Reference Time",
+          "fieldName" : "reference_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Valid Time",
+          "fieldName" : "valid_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Update Time",
+          "fieldName" : "update_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        }
+      ],
+      "dataConnection" : {
+        "type" : "CIMSqlQueryDataConnection",
+        "workspaceConnectionString" : "SERVER=rds-egis.hydrovis.internal;INSTANCE=sde:postgresql:rds-egis.hydrovis.internal;DBCLIENT=postgresql;DB_CONNECTION_PROPERTIES=rds-egis.hydrovis.internal;DATABASE=hydrovis;USER=hydrovis;AUTHENTICATION_MODE=DBMS",
+        "workspaceFactory" : "SDE",
+        "dataset" : "vizprocessing.publish.%ana_coastal_inundation_depth",
+        "datasetType" : "esriDTTable",
+        "sqlQuery" : "select oid,reference_time,valid_time,update_time from vizprocessing.publish.ana_coastal_inundation_depth",
+        "oIDFields" : "oid",
+        "geometryType" : "esriGeometryNull",
+        "queryFields" : [
+          {
+            "name" : "oid",
+            "type" : "esriFieldTypeInteger",
+            "alias" : "oid"
+          },
+          {
+            "name" : "reference_time",
+            "type" : "esriFieldTypeString",
+            "alias" : "reference_time",
+            "length" : 25
+          },
+          {
+            "name" : "valid_time",
+            "type" : "esriFieldTypeString",
+            "alias" : "valid_time",
+            "length" : 25
+          },
+          {
+            "name" : "update_time",
+            "type" : "esriFieldTypeString",
+            "alias" : "update_time",
+            "length" : 25
+          }
+        ]
+      },
+      "autoGenerateRowTemplates" : true,
+      "serviceTableID" : -1,
+      "showPopups" : true
+    }
   ]
 }

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal_hawaii/ana_coastal_inundation_depth_hi_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal_hawaii/ana_coastal_inundation_depth_hi_noaa.mapx
@@ -291,5 +291,94 @@
       "uRI" : "CIMPATH=Metadata/d37718d89ece7ecbefff4476d478739a.xml",
       "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>20055700</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri></metadata>\r\n"
     }
+  ],
+  "tableDefinitions" : [
+    {
+      "type" : "CIMStandaloneTable",
+      "name" : "Service Metadata",
+      "uRI" : "CIMPATH=ana_coastal_inundation_depth_hi/vizprocessing_publish_ana_coastal_inundation_depth_hi.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant"
+      },
+      "useSourceMetadata" : true,
+      "displayField" : "reference_time",
+      "editable" : true,
+      "fieldDescriptions" : [
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "oid",
+          "fieldName" : "oid",
+          "numberFormat" : {
+            "type" : "CIMNumericFormat",
+            "alignmentOption" : "esriAlignRight",
+            "alignmentWidth" : 0,
+            "roundingOption" : "esriRoundNumberOfDecimals",
+            "roundingValue" : 0
+          },
+          "readOnly" : true,
+          "visible" : false,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Reference Time",
+          "fieldName" : "reference_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Valid Time",
+          "fieldName" : "valid_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Update Time",
+          "fieldName" : "update_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        }
+      ],
+      "dataConnection" : {
+        "type" : "CIMSqlQueryDataConnection",
+        "workspaceConnectionString" : "SERVER=rds-egis.hydrovis.internal;INSTANCE=sde:postgresql:rds-egis.hydrovis.internal;DBCLIENT=postgresql;DB_CONNECTION_PROPERTIES=rds-egis.hydrovis.internal;DATABASE=hydrovis;USER=hydrovis;AUTHENTICATION_MODE=DBMS",
+        "workspaceFactory" : "SDE",
+        "dataset" : "vizprocessing.publish.%ana_coastal_inundation_depth_hi",
+        "datasetType" : "esriDTTable",
+        "sqlQuery" : "select oid,reference_time,valid_time,update_time from vizprocessing.publish.ana_coastal_inundation_depth_hi",
+        "oIDFields" : "oid",
+        "geometryType" : "esriGeometryNull",
+        "queryFields" : [
+          {
+            "name" : "oid",
+            "type" : "esriFieldTypeInteger",
+            "alias" : "oid"
+          },
+          {
+            "name" : "reference_time",
+            "type" : "esriFieldTypeString",
+            "alias" : "reference_time",
+            "length" : 25
+          },
+          {
+            "name" : "valid_time",
+            "type" : "esriFieldTypeString",
+            "alias" : "valid_time",
+            "length" : 25
+          },
+          {
+            "name" : "update_time",
+            "type" : "esriFieldTypeString",
+            "alias" : "update_time",
+            "length" : 25
+          }
+        ]
+      },
+      "autoGenerateRowTemplates" : true,
+      "serviceTableID" : -1,
+      "showPopups" : true
+    }
   ]
 }

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal_puertorico/ana_coastal_inundation_depth_prvi_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal_puertorico/ana_coastal_inundation_depth_prvi_noaa.mapx
@@ -291,5 +291,94 @@
       "uRI" : "CIMPATH=Metadata/d37718d89ece7ecbefff4476d478739a.xml",
       "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>20055700</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri></metadata>\r\n"
     }
+  ],
+  "tableDefinitions" : [
+    {
+      "type" : "CIMStandaloneTable",
+      "name" : "Service Metadata",
+      "uRI" : "CIMPATH=ana_coastal_inundation_depth_prvi/vizprocessing_publish_ana_coastal_inundation_depth_prvi.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant"
+      },
+      "useSourceMetadata" : true,
+      "displayField" : "reference_time",
+      "editable" : true,
+      "fieldDescriptions" : [
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "oid",
+          "fieldName" : "oid",
+          "numberFormat" : {
+            "type" : "CIMNumericFormat",
+            "alignmentOption" : "esriAlignRight",
+            "alignmentWidth" : 0,
+            "roundingOption" : "esriRoundNumberOfDecimals",
+            "roundingValue" : 0
+          },
+          "readOnly" : true,
+          "visible" : false,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Reference Time",
+          "fieldName" : "reference_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Valid Time",
+          "fieldName" : "valid_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Update Time",
+          "fieldName" : "update_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        }
+      ],
+      "dataConnection" : {
+        "type" : "CIMSqlQueryDataConnection",
+        "workspaceConnectionString" : "SERVER=rds-egis.hydrovis.internal;INSTANCE=sde:postgresql:rds-egis.hydrovis.internal;DBCLIENT=postgresql;DB_CONNECTION_PROPERTIES=rds-egis.hydrovis.internal;DATABASE=hydrovis;USER=hydrovis;AUTHENTICATION_MODE=DBMS",
+        "workspaceFactory" : "SDE",
+        "dataset" : "vizprocessing.publish.%ana_coastal_inundation_depth_prvi",
+        "datasetType" : "esriDTTable",
+        "sqlQuery" : "select oid,reference_time,valid_time,update_time from vizprocessing.publish.ana_coastal_inundation_depth_prvi",
+        "oIDFields" : "oid",
+        "geometryType" : "esriGeometryNull",
+        "queryFields" : [
+          {
+            "name" : "oid",
+            "type" : "esriFieldTypeInteger",
+            "alias" : "oid"
+          },
+          {
+            "name" : "reference_time",
+            "type" : "esriFieldTypeString",
+            "alias" : "reference_time",
+            "length" : 25
+          },
+          {
+            "name" : "valid_time",
+            "type" : "esriFieldTypeString",
+            "alias" : "valid_time",
+            "length" : 25
+          },
+          {
+            "name" : "update_time",
+            "type" : "esriFieldTypeString",
+            "alias" : "update_time",
+            "length" : 25
+          }
+        ]
+      },
+      "autoGenerateRowTemplates" : true,
+      "serviceTableID" : -1,
+      "showPopups" : true
+    }
   ]
 }

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_blend_coastal/mrf_nbm_10day_max_coastal_inundation_depth_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_blend_coastal/mrf_nbm_10day_max_coastal_inundation_depth_noaa.mapx
@@ -1657,5 +1657,94 @@
       "uRI" : "CIMPATH=Metadata/d37718d89ece7ecbefff4476d478739a.xml",
       "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>20055700</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri></metadata>\r\n"
     }
+  ],
+  "tableDefinitions" : [
+    {
+      "type" : "CIMStandaloneTable",
+      "name" : "Service Metadata",
+      "uRI" : "CIMPATH=mrf_nbm_10day_max_coastal_inundation_depth/vizprocessing_publish_mrf_nbm_10day_max_coastal_inundation_depth.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant"
+      },
+      "useSourceMetadata" : true,
+      "displayField" : "reference_time",
+      "editable" : true,
+      "fieldDescriptions" : [
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "oid",
+          "fieldName" : "oid",
+          "numberFormat" : {
+            "type" : "CIMNumericFormat",
+            "alignmentOption" : "esriAlignRight",
+            "alignmentWidth" : 0,
+            "roundingOption" : "esriRoundNumberOfDecimals",
+            "roundingValue" : 0
+          },
+          "readOnly" : true,
+          "visible" : false,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Reference Time",
+          "fieldName" : "reference_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Valid Time",
+          "fieldName" : "valid_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Update Time",
+          "fieldName" : "update_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        }
+      ],
+      "dataConnection" : {
+        "type" : "CIMSqlQueryDataConnection",
+        "workspaceConnectionString" : "SERVER=rds-egis.hydrovis.internal;INSTANCE=sde:postgresql:rds-egis.hydrovis.internal;DBCLIENT=postgresql;DB_CONNECTION_PROPERTIES=rds-egis.hydrovis.internal;DATABASE=hydrovis;USER=hydrovis;AUTHENTICATION_MODE=DBMS",
+        "workspaceFactory" : "SDE",
+        "dataset" : "vizprocessing.publish.%mrf_nbm_10day_max_coastal_inundation_depth",
+        "datasetType" : "esriDTTable",
+        "sqlQuery" : "select oid,reference_time,valid_time,update_time from vizprocessing.publish.mrf_nbm_10day_max_coastal_inundation_depth",
+        "oIDFields" : "oid",
+        "geometryType" : "esriGeometryNull",
+        "queryFields" : [
+          {
+            "name" : "oid",
+            "type" : "esriFieldTypeInteger",
+            "alias" : "oid"
+          },
+          {
+            "name" : "reference_time",
+            "type" : "esriFieldTypeString",
+            "alias" : "reference_time",
+            "length" : 25
+          },
+          {
+            "name" : "valid_time",
+            "type" : "esriFieldTypeString",
+            "alias" : "valid_time",
+            "length" : 25
+          },
+          {
+            "name" : "update_time",
+            "type" : "esriFieldTypeString",
+            "alias" : "update_time",
+            "length" : 25
+          }
+        ]
+      },
+      "autoGenerateRowTemplates" : true,
+      "serviceTableID" : -1,
+      "showPopups" : true
+    }
   ]
 }

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_coastal_mem1/mrf_gfs_10day_max_coastal_inundation_depth_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_coastal_mem1/mrf_gfs_10day_max_coastal_inundation_depth_noaa.mapx
@@ -1657,5 +1657,94 @@
       "uRI" : "CIMPATH=Metadata/d37718d89ece7ecbefff4476d478739a.xml",
       "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>20055700</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri></metadata>\r\n"
     }
+  ],
+  "tableDefinitions" : [
+    {
+      "type" : "CIMStandaloneTable",
+      "name" : "Service Metadata",
+      "uRI" : "CIMPATH=mrf_gfs_10day_max_coastal_inundation_depth/vizprocessing_publish_mrf_gfs_10day_max_coastal_inundation_depth.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant"
+      },
+      "useSourceMetadata" : true,
+      "displayField" : "reference_time",
+      "editable" : true,
+      "fieldDescriptions" : [
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "oid",
+          "fieldName" : "oid",
+          "numberFormat" : {
+            "type" : "CIMNumericFormat",
+            "alignmentOption" : "esriAlignRight",
+            "alignmentWidth" : 0,
+            "roundingOption" : "esriRoundNumberOfDecimals",
+            "roundingValue" : 0
+          },
+          "readOnly" : true,
+          "visible" : false,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Reference Time",
+          "fieldName" : "reference_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Valid Time",
+          "fieldName" : "valid_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Update Time",
+          "fieldName" : "update_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        }
+      ],
+      "dataConnection" : {
+        "type" : "CIMSqlQueryDataConnection",
+        "workspaceConnectionString" : "SERVER=rds-egis.hydrovis.internal;INSTANCE=sde:postgresql:rds-egis.hydrovis.internal;DBCLIENT=postgresql;DB_CONNECTION_PROPERTIES=rds-egis.hydrovis.internal;DATABASE=hydrovis;USER=hydrovis;AUTHENTICATION_MODE=DBMS",
+        "workspaceFactory" : "SDE",
+        "dataset" : "vizprocessing.publish.%mrf_gfs_10day_max_coastal_inundation_depth",
+        "datasetType" : "esriDTTable",
+        "sqlQuery" : "select oid,reference_time,valid_time,update_time from vizprocessing.publish.mrf_gfs_10day_max_coastal_inundation_depth",
+        "oIDFields" : "oid",
+        "geometryType" : "esriGeometryNull",
+        "queryFields" : [
+          {
+            "name" : "oid",
+            "type" : "esriFieldTypeInteger",
+            "alias" : "oid"
+          },
+          {
+            "name" : "reference_time",
+            "type" : "esriFieldTypeString",
+            "alias" : "reference_time",
+            "length" : 25
+          },
+          {
+            "name" : "valid_time",
+            "type" : "esriFieldTypeString",
+            "alias" : "valid_time",
+            "length" : 25
+          },
+          {
+            "name" : "update_time",
+            "type" : "esriFieldTypeString",
+            "alias" : "update_time",
+            "length" : 25
+          }
+        ]
+      },
+      "autoGenerateRowTemplates" : true,
+      "serviceTableID" : -1,
+      "showPopups" : true
+    }
   ]
 }

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal/srf_18hr_max_coastal_inundation_depth_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal/srf_18hr_max_coastal_inundation_depth_noaa.mapx
@@ -607,5 +607,94 @@
       "uRI" : "CIMPATH=Metadata/d37718d89ece7ecbefff4476d478739a.xml",
       "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>20055700</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri></metadata>\r\n"
     }
+  ],
+  "tableDefinitions" : [
+    {
+      "type" : "CIMStandaloneTable",
+      "name" : "Service Metadata",
+      "uRI" : "CIMPATH=srf_18hr_max_coastal_inundation_depth/vizprocessing_publish_srf_18hr_max_coastal_inundation_depth.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant"
+      },
+      "useSourceMetadata" : true,
+      "displayField" : "reference_time",
+      "editable" : true,
+      "fieldDescriptions" : [
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "oid",
+          "fieldName" : "oid",
+          "numberFormat" : {
+            "type" : "CIMNumericFormat",
+            "alignmentOption" : "esriAlignRight",
+            "alignmentWidth" : 0,
+            "roundingOption" : "esriRoundNumberOfDecimals",
+            "roundingValue" : 0
+          },
+          "readOnly" : true,
+          "visible" : false,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Reference Time",
+          "fieldName" : "reference_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Valid Time",
+          "fieldName" : "valid_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Update Time",
+          "fieldName" : "update_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        }
+      ],
+      "dataConnection" : {
+        "type" : "CIMSqlQueryDataConnection",
+        "workspaceConnectionString" : "SERVER=rds-egis.hydrovis.internal;INSTANCE=sde:postgresql:rds-egis.hydrovis.internal;DBCLIENT=postgresql;DB_CONNECTION_PROPERTIES=rds-egis.hydrovis.internal;DATABASE=hydrovis;USER=hydrovis;AUTHENTICATION_MODE=DBMS",
+        "workspaceFactory" : "SDE",
+        "dataset" : "vizprocessing.publish.%srf_18hr_max_coastal_inundation_depth",
+        "datasetType" : "esriDTTable",
+        "sqlQuery" : "select oid,reference_time,valid_time,update_time from vizprocessing.publish.srf_18hr_max_coastal_inundation_depth",
+        "oIDFields" : "oid",
+        "geometryType" : "esriGeometryNull",
+        "queryFields" : [
+          {
+            "name" : "oid",
+            "type" : "esriFieldTypeInteger",
+            "alias" : "oid"
+          },
+          {
+            "name" : "reference_time",
+            "type" : "esriFieldTypeString",
+            "alias" : "reference_time",
+            "length" : 25
+          },
+          {
+            "name" : "valid_time",
+            "type" : "esriFieldTypeString",
+            "alias" : "valid_time",
+            "length" : 25
+          },
+          {
+            "name" : "update_time",
+            "type" : "esriFieldTypeString",
+            "alias" : "update_time",
+            "length" : 25
+          }
+        ]
+      },
+      "autoGenerateRowTemplates" : true,
+      "serviceTableID" : -1,
+      "showPopups" : true
+    }
   ]
 }

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal_hawaii/srf_48hr_max_coastal_inundation_depth_hi_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal_hawaii/srf_48hr_max_coastal_inundation_depth_hi_noaa.mapx
@@ -291,5 +291,94 @@
       "uRI" : "CIMPATH=Metadata/d37718d89ece7ecbefff4476d478739a.xml",
       "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>20055700</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri></metadata>\r\n"
     }
+  ],
+  "tableDefinitions" : [
+    {
+      "type" : "CIMStandaloneTable",
+      "name" : "Service Metadata",
+      "uRI" : "CIMPATH=srf_18hr_max_coastal_inundation_depth_hi/vizprocessing_publish_srf_18hr_max_coastal_inundation_depth_hi.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant"
+      },
+      "useSourceMetadata" : true,
+      "displayField" : "reference_time",
+      "editable" : true,
+      "fieldDescriptions" : [
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "oid",
+          "fieldName" : "oid",
+          "numberFormat" : {
+            "type" : "CIMNumericFormat",
+            "alignmentOption" : "esriAlignRight",
+            "alignmentWidth" : 0,
+            "roundingOption" : "esriRoundNumberOfDecimals",
+            "roundingValue" : 0
+          },
+          "readOnly" : true,
+          "visible" : false,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Reference Time",
+          "fieldName" : "reference_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Valid Time",
+          "fieldName" : "valid_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Update Time",
+          "fieldName" : "update_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        }
+      ],
+      "dataConnection" : {
+        "type" : "CIMSqlQueryDataConnection",
+        "workspaceConnectionString" : "SERVER=rds-egis.hydrovis.internal;INSTANCE=sde:postgresql:rds-egis.hydrovis.internal;DBCLIENT=postgresql;DB_CONNECTION_PROPERTIES=rds-egis.hydrovis.internal;DATABASE=hydrovis;USER=hydrovis;AUTHENTICATION_MODE=DBMS",
+        "workspaceFactory" : "SDE",
+        "dataset" : "vizprocessing.publish.%srf_18hr_max_coastal_inundation_depth_hi",
+        "datasetType" : "esriDTTable",
+        "sqlQuery" : "select oid,reference_time,valid_time,update_time from vizprocessing.publish.srf_18hr_max_coastal_inundation_depth_hi",
+        "oIDFields" : "oid",
+        "geometryType" : "esriGeometryNull",
+        "queryFields" : [
+          {
+            "name" : "oid",
+            "type" : "esriFieldTypeInteger",
+            "alias" : "oid"
+          },
+          {
+            "name" : "reference_time",
+            "type" : "esriFieldTypeString",
+            "alias" : "reference_time",
+            "length" : 25
+          },
+          {
+            "name" : "valid_time",
+            "type" : "esriFieldTypeString",
+            "alias" : "valid_time",
+            "length" : 25
+          },
+          {
+            "name" : "update_time",
+            "type" : "esriFieldTypeString",
+            "alias" : "update_time",
+            "length" : 25
+          }
+        ]
+      },
+      "autoGenerateRowTemplates" : true,
+      "serviceTableID" : -1,
+      "showPopups" : true
+    }
   ]
 }

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal_puertorico/srf_48hr_max_coastal_inundation_depth_prvi_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal_puertorico/srf_48hr_max_coastal_inundation_depth_prvi_noaa.mapx
@@ -291,5 +291,94 @@
       "uRI" : "CIMPATH=Metadata/d37718d89ece7ecbefff4476d478739a.xml",
       "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230628</CreaDate><CreaTime>20055700</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri></metadata>\r\n"
     }
+  ],
+  "tableDefinitions" : [
+    {
+      "type" : "CIMStandaloneTable",
+      "name" : "Service Metadata",
+      "uRI" : "CIMPATH=srf_18hr_max_coastal_inundation_depth_prvi/vizprocessing_publish_srf_18hr_max_coastal_inundation_depth_prvi.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant"
+      },
+      "useSourceMetadata" : true,
+      "displayField" : "reference_time",
+      "editable" : true,
+      "fieldDescriptions" : [
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "oid",
+          "fieldName" : "oid",
+          "numberFormat" : {
+            "type" : "CIMNumericFormat",
+            "alignmentOption" : "esriAlignRight",
+            "alignmentWidth" : 0,
+            "roundingOption" : "esriRoundNumberOfDecimals",
+            "roundingValue" : 0
+          },
+          "readOnly" : true,
+          "visible" : false,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Reference Time",
+          "fieldName" : "reference_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Valid Time",
+          "fieldName" : "valid_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        },
+        {
+          "type" : "CIMFieldDescription",
+          "alias" : "Update Time",
+          "fieldName" : "update_time",
+          "visible" : true,
+          "searchMode" : "Exact"
+        }
+      ],
+      "dataConnection" : {
+        "type" : "CIMSqlQueryDataConnection",
+        "workspaceConnectionString" : "SERVER=rds-egis.hydrovis.internal;INSTANCE=sde:postgresql:rds-egis.hydrovis.internal;DBCLIENT=postgresql;DB_CONNECTION_PROPERTIES=rds-egis.hydrovis.internal;DATABASE=hydrovis;USER=hydrovis;AUTHENTICATION_MODE=DBMS",
+        "workspaceFactory" : "SDE",
+        "dataset" : "vizprocessing.publish.%srf_18hr_max_coastal_inundation_depth_prvi",
+        "datasetType" : "esriDTTable",
+        "sqlQuery" : "select oid,reference_time,valid_time,update_time from vizprocessing.publish.srf_18hr_max_coastal_inundation_depth_prvi",
+        "oIDFields" : "oid",
+        "geometryType" : "esriGeometryNull",
+        "queryFields" : [
+          {
+            "name" : "oid",
+            "type" : "esriFieldTypeInteger",
+            "alias" : "oid"
+          },
+          {
+            "name" : "reference_time",
+            "type" : "esriFieldTypeString",
+            "alias" : "reference_time",
+            "length" : 25
+          },
+          {
+            "name" : "valid_time",
+            "type" : "esriFieldTypeString",
+            "alias" : "valid_time",
+            "length" : 25
+          },
+          {
+            "name" : "update_time",
+            "type" : "esriFieldTypeString",
+            "alias" : "update_time",
+            "length" : 25
+          }
+        ]
+      },
+      "autoGenerateRowTemplates" : true,
+      "serviceTableID" : -1,
+      "showPopups" : true
+    }
   ]
 }

--- a/Core/StepFunctions/schism_fim_processing.json.tftpl
+++ b/Core/StepFunctions/schism_fim_processing.json.tftpl
@@ -1,16 +1,42 @@
 {
   "Comment": "Processes the outputs for all SCHISM FIM services.",
-  "StartAt": "Iterate over HUC8s",
+  "StartAt": "Get Domain Tile Basenames",
   "States": {
-    "Iterate over HUC8s": {
+    "Get Domain Tile Basenames": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "${schism_fim_processing_arn}",
+        "Payload": {
+          "original_input.$": "$",
+          "step": "get_domain_tile_basenames",
+          "args": {
+            "fim_config.$": "$.fim_config"
+          }
+        }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "IntervalSeconds": 1,
+          "MaxAttempts": 2,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "Iterate over Tiles",
+      "ResultPath": "$.result"
+    },
+    "Iterate over Tiles": {
       "Type": "Map",
       "ItemProcessor": {
         "ProcessorConfig": {
           "Mode": "INLINE"
         },
-        "StartAt": "Process FIM By HUC8",
+        "StartAt": "Process FIM By Tile",
         "States": {
-          "Process FIM By HUC8": {
+          "Process FIM By Tile": {
             "Type": "Task",
             "Resource": "arn:aws:states:::lambda:invoke",
             "Parameters": {
@@ -27,64 +53,18 @@
                 "BackoffRate": 2
               }
             ],
-            "Next": "Choice",
-            "ResultPath": "$.result",
             "ResultSelector": {
               "output_raster.$": "$.Payload.output_raster",
               "output_bucket.$": "$.Payload.output_bucket"
-            }
-          },
-          "Choice": {
-            "Type": "Choice",
-            "Choices": [
-              {
-                "Not": {
-                  "Variable": "$.result.output_raster",
-                  "IsNull": true
-                },
-                "Next": "Cloud Optimize Raster"
-              }
-            ],
-            "Default": "Pass"
-          },
-          "Cloud Optimize Raster": {
-            "Type": "Task",
-            "Resource": "arn:aws:states:::lambda:invoke",
-            "Parameters": {
-              "FunctionName": "${optimize_rasters_arn}",
-              "Payload": {
-                "output_raster.$": "$.result.output_raster",
-                "output_bucket.$": "$.output_bucket"
-              }
             },
-            "Retry": [
-              {
-                "ErrorEquals": [
-                  "Lambda.ServiceException",
-                  "Lambda.AWSLambdaException",
-                  "Lambda.SdkClientException",
-                  "Lambda.TooManyRequestsException"
-                ],
-                "IntervalSeconds": 2,
-                "MaxAttempts": 6,
-                "BackoffRate": 2
-              }
-            ],
-            "Next": "Pass",
-            "ResultPath": null
-          },
-          "Pass": {
-            "Type": "Pass",
             "End": true
           }
         }
       },
-      "ItemsPath": "$.hucs_to_process",
+      "ItemsPath": "$.result.Payload.domain_tile_basenames",
       "ItemSelector": {
         "step": "iteration",
-        "huc.$": "$$.Map.Item.Value",
-        "output_bucket.$": "$.data_bucket",
-        "output_prefix.$": "$.data_prefix",
+        "tile_basename.$": "$$.Map.Item.Value",
         "args": {
           "job_type.$": "$.job_type",
           "reference_time.$": "$.reference_time",
@@ -93,8 +73,8 @@
           "sql_rename_dict.$": "$.sql_rename_dict"
         }
       },
-      "ResultPath": null,
-      "Next": "Create VRT"
+      "Next": "Create VRT",
+      "ResultPath": null
     },
     "Create VRT": {
       "Type": "Task",
@@ -103,8 +83,6 @@
         "FunctionName": "${optimize_rasters_arn}",
         "Payload": {
           "step": "create_vrt",
-          "output_bucket.$": "$.data_bucket",
-          "output_prefix.$": "$.data_prefix",
           "args": {
             "fim_config.$": "$.fim_config",
             "product.$": "$.product"

--- a/Core/StepFunctions/viz_processing_pipeline.json.tftpl
+++ b/Core/StepFunctions/viz_processing_pipeline.json.tftpl
@@ -663,7 +663,7 @@
           },
           "FIM Config Processing": {
             "Type": "Map",
-            "Next": "Product Processing Finished Log",
+            "Next": "Product Postprocessing",
             "Iterator": {
               "StartAt": "Fim Config Preprocessing",
               "States": {
@@ -677,7 +677,7 @@
                       "Next": "FIM Config Max File"
                     }
                   ],
-                  "Default": "FIM Data Preparation"
+                  "Default": "Coastal vs Inland Inundation"
                 },
                 "FIM Config Max File": {
                   "Type": "Task",
@@ -711,7 +711,7 @@
                       "Comment": "Missing S3 File"
                     }
                   ],
-                  "Next": "FIM Data Preparation",
+                  "Next": "Coastal vs Inland Inundation",
                   "OutputPath": "$.Payload",
                   "Catch": [
                     {
@@ -738,7 +738,7 @@
                           "BooleanEquals": true
                         }
                       ],
-                      "Next": "FIM Data Preparation"
+                      "Next": "Coastal vs Inland Inundation"
                     }
                   ],
                   "Default": "Fail"
@@ -778,7 +778,7 @@
                       "Comment": "Lambda Service Errors"
                     }
                   ],
-                  "Next": "Coastal vs Inland Inundation",
+                  "Next": "HUC Processing Map",
                   "ResultPath": "$.huc_processing_payload",
                   "ResultSelector": {
                     "hucs_to_process.$": "$.Payload.hucs_to_process",
@@ -795,7 +795,7 @@
                       "Next": "Process Coastal (SCHISM) FIM"
                     }
                   ],
-                  "Default": "HUC Processing Map"
+                  "Default": "FIM Data Preparation"
                 },
                 "Process Coastal (SCHISM) FIM": {
                   "Type": "Task",
@@ -807,10 +807,7 @@
                       "reference_time.$": "$.reference_time",
                       "job_type.$": "$.job_type",
                       "product.$": "$.product",
-                      "sql_rename_dict.$": "$.sql_rename_dict",
-                      "data_bucket.$": "$.huc_processing_payload.data_bucket",
-                      "data_prefix.$": "$.huc_processing_payload.data_prefix",
-                      "hucs_to_process.$": "$.huc_processing_payload.hucs_to_process"
+                      "sql_rename_dict.$": "$.sql_rename_dict"
                     }
                   },
                   "Next": "Postprocess SQL - FIM Config",


### PR DESCRIPTION
This PR is being created to address the issue of certain HUCs not rendering in the coastal fim services (#538). The problem was that VRTs render in layered order, and the HUC dems were overlapping each other and thus covering up actual fim data. This is because the HUC-based dems are still rectangular (i.e. the bbox of the HUC) and not the shape of the HUCs themselves. It's true that all of the non-HUC grid cells are marked as no-data, but it's these no-data cells that are getting layer- ordering priority and masking the actual underlying HUC data cells. The solution was to subset the coastal DEMs to non-overlapping rectangular, tile-based DEMs for processing. These can then be rendered without any overlaps. It also results in many fewer rasters for both processing and rendering, thus speeding up the process. I also discovered while testing that the VRT pointing to the underlying MRF files was rendering much slower than if I pointed the VRT to the TIF files instead. So that change is also incorporated here. Lastly, I converted the viz_schism_fim_proceesing lambda processing code to operate completely on MemoryFile objects, rather than writing to disk. This also speeds up the processing a bit.