### PR TITLE
File Forecast Regex Bug

### DIFF
--- a/Core/LAMBDA/layers/viz_lambda_shared_funcs/python/viz_lambda_shared_funcs.py
+++ b/Core/LAMBDA/layers/viz_lambda_shared_funcs/python/viz_lambda_shared_funcs.py
@@ -565,7 +565,7 @@ def check_if_file_exists(bucket, file, download=False):
         else:
             if "/prod" in file:
 
-                date_metadata = re.findall("(\d{8})/[a-z0-9_]*/nwm.t(\d{2})z.*[ftm](\d*)\.", file)
+                date_metadata = re.findall(r"(\d{8})/[a-z0-9_]*/nwm.t(\d{2})z.*[ftm](\d{1,9})\.", file)
                 date = date_metadata[0][0]
                 initialize_hour = date_metadata[0][1]
                 delta_hour = date_metadata[0][2]


### PR DESCRIPTION
This PR fixes a regex issue when trying to grab the forecast timestep from the file name. For some reason the wildcard with a digit (\d*) was not grabbing the number correctly. I updated the regex (\d{1,9}) to look for a certain amount of digits. The numbers used were a bit arbitrary. I just wanted it to be small enough and big enough to work and then added some buffer just in case future files would need it.