### PR TITLE
Final 2.1.3 Fixes

### DIFF
--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/reference/static_nwm_coastal_domain_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/reference/static_nwm_coastal_domain_noaa.yml
@@ -6,4 +6,4 @@ credits: National Water Model, NOAA/NWS National Water Center
 egis_server: server
 egis_folder: reference
 feature_service: false
-public_service: false
+public_service: true

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/reference/static_public_fim_domain.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/reference/static_public_fim_domain.yml
@@ -6,4 +6,4 @@ credits: National Water Model, NOAA/NWS National Water Center
 egis_server: server
 egis_folder: reference
 feature_service: false
-public_service: false
+public_service: true

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/replace_route/rfc_based_5day_max_streamflow.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/replace_route/rfc_based_5day_max_streamflow.yml
@@ -9,4 +9,4 @@ credits: National Water Model, NOAA/NWS National Water Center
 egis_server: server
 egis_folder: rfc
 feature_service: true
-public_service: false
+public_service: true

--- a/Core/StepFunctions/viz_processing_pipeline.json.tftpl
+++ b/Core/StepFunctions/viz_processing_pipeline.json.tftpl
@@ -376,7 +376,7 @@
       "Parameters": {
         "LogEvents": [
           {
-            "Message.$": "States.Format('\\{\"{}\": -9999, \"reference_time\": {}, \"step_finish\": {}, \"pipeline_step\": \"data_prep\", \"error\": {}\\}', $.product.product, $.reference_time, $$.State.EnteredTime, $.error.Cause)",
+            "Message.$": "States.Format('\\{\"{}\": -9999, \"reference_time\": {}, \"step_finish\": {}, \"pipeline_step\": \"data_prep\", \"error\": {}\\}', $.configuration, $.reference_time, $$.State.EnteredTime, $.error.Cause)",
             "Timestamp.$": "$.logging_info.Timestamp"
           }
         ],


### PR DESCRIPTION
This PR fixes 3 small issues

1. The failure log in the data prep was looking at $.product.product instead of $.configuration
2. Updated public status of rfc streamflow
3. Updated public status of coastal domain
4. Updated public status of public fim domain