### PR TITLE
OCONUS Feature Removal for CONUS Products

### DIFF
--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/admin/ingest_finish.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/admin/ingest_finish.sql
@@ -2,3 +2,8 @@ CREATE INDEX {index_name} ON {target_table} {index_columns};
 
 ALTER TABLE {target_table}
 ADD COLUMN reference_time TEXT DEFAULT '1900-01-01 00:00:00 UTC';
+
+-- Checks to see if feature_id is a column in the target table
+SELECT EXISTS (SELECT 1 
+FROM information_schema.columns
+WHERE table_schema = '{target_schema}' AND table_name = '{target_table_only}' AND column_name='feature_id');

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/admin/remove_oconus_features.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/admin/remove_oconus_features.sql
@@ -1,0 +1,2 @@
+DELETE FROM {target_table} t1
+WHERE EXISTS(SELECT 1 FROM derived.oconus_features t2 Where t1.feature_id = t2.feature_id)

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/lambda_function.py
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/lambda_function.py
@@ -81,7 +81,6 @@ def run_admin_tasks(event, folder, step, sql_replace, reference_time):
         sql_replace.update({"{rows_imported}": 'NULL'}) #TODO Figure out how to get this from the last map of the state machine to here
         
         feature_id_column_exists = run_sql('admin/ingest_finish.sql', sql_replace)
-        print(feature_id_column_exists[0])
         if feature_id_column_exists[0]:
             run_sql('admin/remove_oconus_features.sql', sql_replace)
         

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/ana_inundation/public_subset.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/ana_inundation/public_subset.sql
@@ -2,7 +2,7 @@ DROP TABLE IF EXISTS publish.ana_inundation_public;
 
 SELECT
     inun.feature_id_str,
-    inun.geom,
+    ST_Intersection(inun.geom, fim_domain.geom) as geom,
     inun.streamflow_cfs,
     inun.reference_time,
 	to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS update_time

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/ana_inundation/public_subset.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/ana_inundation/public_subset.sql
@@ -9,5 +9,3 @@ SELECT
 INTO publish.ana_inundation_public
 FROM publish.ana_inundation as inun
 JOIN derived.public_fim_domain as fim_domain ON ST_Intersects(inun.geom, fim_domain.geom)
-JOIN derived.channels_conus cc ON cc.feature_id = inun.feature_id
-WHERE public_fim = true

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/mrf_gfs_10day_max_inundation/5day_public_subset.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/mrf_gfs_10day_max_inundation/5day_public_subset.sql
@@ -2,7 +2,7 @@ DROP TABLE IF EXISTS publish.mrf_gfs_max_inundation_5day_public;
 
 SELECT
     inun.feature_id_str,
-    inun.geom,
+    ST_Intersection(inun.geom, fim_domain.geom) as geom,
     inun.streamflow_cfs,
     inun.reference_time,
 	to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS update_time

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/mrf_gfs_10day_max_inundation/5day_public_subset.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/mrf_gfs_10day_max_inundation/5day_public_subset.sql
@@ -9,5 +9,3 @@ SELECT
 INTO publish.mrf_gfs_max_inundation_5day_public
 FROM publish.mrf_gfs_max_inundation_5day as inun
 JOIN derived.public_fim_domain as fim_domain ON ST_Intersects(inun.geom, fim_domain.geom)
-JOIN derived.channels_conus cc ON cc.feature_id = inun.feature_id
-WHERE public_fim = true

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/rfc_based_5day_max_inundation/public_subset.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/rfc_based_5day_max_inundation/public_subset.sql
@@ -9,5 +9,3 @@ SELECT
 INTO publish.rfc_based_5day_max_inundation_public
 FROM publish.rfc_based_5day_max_inundation as inun
 JOIN derived.public_fim_domain as fim_domain ON ST_Intersects(inun.geom, fim_domain.geom)
-JOIN derived.channels_conus cc ON cc.feature_id = inun.feature_id
-WHERE public_fim = true

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/rfc_based_5day_max_inundation/public_subset.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/rfc_based_5day_max_inundation/public_subset.sql
@@ -2,7 +2,7 @@ DROP TABLE IF EXISTS publish.rfc_based_5day_max_inundation_public;
 
 SELECT
     inun.feature_id_str,
-    inun.geom,
+    ST_Intersection(inun.geom, fim_domain.geom) as geom,
     inun.streamflow_cfs,
     inun.reference_time,
 	to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS update_time


### PR DESCRIPTION
This PR removes features found in Mexico and Canada. This is done by using a new derived.oconus_features table to remove features after model data is ingested.

Additionally, I added a "ST_Intersection(inun.geom, fim_domain.geom) as geom" line to the public subset sql. This will make it so that all features within the fim domain are clipped to the boundary and don't extend beyond the public fim domain

This PR requires the vizDB_derived_v2_1_4.dump