### PR TITLE
Viz EC2 Fixes

### DIFF
--- a/Core/EC2/viz/scripts/viz_ec2_setup.ps1
+++ b/Core/EC2/viz/scripts/viz_ec2_setup.ps1
@@ -273,7 +273,7 @@ $ACL | Set-Acl -Path "D:\"
 
 LogWrite "ADDING $PUBLISHED_ROOT TO $EGIS_HOST"
 $python_file = "$AWS_SERVICE_REPO\aws_loosa\deploy\update_data_stores_and_sd_files.py"
-Invoke-CommandAs -ScriptBlock {"C:\Program Files\ArcGIS\Pro\bin\Python\envs\viz\python.exe" $python_file $LATEST_DEPLOYED_GITHUB_REPO_COMMIT} -AsUser $cred
+Invoke-CommandAs -ScriptBlock {& "C:\Program Files\ArcGIS\Pro\bin\Python\envs\viz\python.exe" $python_file $LATEST_DEPLOYED_GITHUB_REPO_COMMIT} -AsUser $cred
 
 Set-Location HKCU:\Software\ESRI\ArcGISPro
 Remove-Item -Recurse -Force -Confirm:$false Licensing

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_hawaii/ana_streamflow_hi_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_hawaii/ana_streamflow_hi_noaa.yml
@@ -1,7 +1,7 @@
 service: ana_streamflow_hi_noaa
 summary: Streamflow Analysis for Hawaii
 description: Depicts the streamflow output from the operational National Water Model (NWM) analysis and assimilation for the state of Hawaii. Updated hourly.
-tags: streamflow, national water model, nwm, ana, hawaii, hi
+tags: streamflow, national water model, nwm, ana, hawaii,hi
 credits: National Water Model, NOAA/NWS National Water Center
 egis_server: server
 egis_folder: nwm

--- a/Source/Visualizations/aws_loosa/deploy/pipelines_config.yml
+++ b/Source/Visualizations/aws_loosa/deploy/pipelines_config.yml
@@ -1,6 +1,4 @@
 ADDED:
   - ana_anomaly
-  - srf_12hr_max_high_water_probability
-  - mrf_gfs_5day_high_water_probability
   - mrf_gfs_5day_rapid_onset_flooding_probability
   - srf_12hr_rapid_onset_flooding_probability

--- a/Source/Visualizations/aws_loosa/deploy/update_data_stores_and_sd_files.py
+++ b/Source/Visualizations/aws_loosa/deploy/update_data_stores_and_sd_files.py
@@ -117,7 +117,7 @@ def update_db_sd_files(latest_deployed_github_repo_commit):
     diffs = repo.head.commit.diff(latest_deployed_github_repo_commit)
     for d in diffs:
         changed_file = Path(d.a_path)
-        if ".mapx" in changed_file.name:
+        if (".mapx" in changed_file.name or ".yml" in changed_file.name) and "viz_publish_service" in str(changed_file):
             changed_services.append(changed_file.name.replace(".mapx", ""))
         
     for service_name in changed_services:

--- a/Source/Visualizations/requirements.txt
+++ b/Source/Visualizations/requirements.txt
@@ -20,3 +20,4 @@ xarray==0.14.1
 natsort==7.0.1
 elasticsearch==7.5.1
 XlsxWriter==1.3.3
+GitPython==3.1.37


### PR DESCRIPTION
This PR fixes a few things in the viz EC2 from the last PR, namely

- SD files are recreated if the service yml files also
- Added missing git python package
- Added missing & for powershell user data script
- Removed high water probabilites from EC2 setup so that windows services are not created for them