### PR TITLE
Viz EC2 Services to Lambda - Part 1b - High Water Probability Fixes

### DIFF
--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_mem1/mrf_gfs_5day_max_high_water_probability.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_mem1/mrf_gfs_5day_max_high_water_probability.mapx
@@ -461,7 +461,7 @@
             },
             {
               "name" : "hours_3_to_24",
-              "type" : "esriFieldTypeInteger",
+              "type" : "esriFieldTypeDouble",
               "alias" : "hours_3_to_24"
             },
             {
@@ -1222,7 +1222,7 @@
             },
             {
               "name" : "hours_27_to_48",
-              "type" : "esriFieldTypeInteger",
+              "type" : "esriFieldTypeDouble",
               "alias" : "hours_27_to_48"
             },
             {
@@ -1983,7 +1983,7 @@
             },
             {
               "name" : "hours_51_to_72",
-              "type" : "esriFieldTypeInteger",
+              "type" : "esriFieldTypeDouble",
               "alias" : "hours_51_to_72"
             },
             {
@@ -2744,7 +2744,7 @@
             },
             {
               "name" : "hours_75_to_120",
-              "type" : "esriFieldTypeInteger",
+              "type" : "esriFieldTypeDouble",
               "alias" : "hours_75_to_120"
             },
             {
@@ -3495,7 +3495,7 @@
             },
             {
               "name" : "hours_3_to_120",
-              "type" : "esriFieldTypeInteger",
+              "type" : "esriFieldTypeDouble",
               "alias" : "hours_3_to_120"
             },
             {

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_mem1/mrf_gfs_5day_max_high_water_probability.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_mem1/mrf_gfs_5day_max_high_water_probability.mapx
@@ -413,7 +413,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.services.%Day 1 Bankfull Probability (%)_6",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select strm_order,name,huc6,nwm_vers,geom,hours_3_to_24,high_water_threshold,reference_time,feature_id_str AS feature_id,update_time,oid from hydrovis.services.mrf_gfs_5day_high_water_probability",
+          "sqlQuery" : "select strm_order,name,huc6,nwm_vers,geom,hours_3_to_24,high_water_threshold,reference_time,feature_id_str AS feature_id,update_time,oid from hydrovis.services.mrf_gfs_5day_max_high_water_probability",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -1174,7 +1174,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.services.%Day 1 Bankfull Probability (%)_1_5",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select strm_order,name,huc6,nwm_vers,geom,hours_27_to_48,high_water_threshold,reference_time,feature_id_str AS feature_id,update_time,oid from hydrovis.services.mrf_gfs_5day_high_water_probability",
+          "sqlQuery" : "select strm_order,name,huc6,nwm_vers,geom,hours_27_to_48,high_water_threshold,reference_time,feature_id_str AS feature_id,update_time,oid from hydrovis.services.mrf_gfs_5day_max_high_water_probability",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -1935,7 +1935,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.services.%Day 1 Bankfull Probability (%)_1_2_4",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select strm_order,name,huc6,nwm_vers,geom,hours_51_to_72,high_water_threshold,reference_time,feature_id_str AS feature_id,update_time,oid from hydrovis.services.mrf_gfs_5day_high_water_probability",
+          "sqlQuery" : "select strm_order,name,huc6,nwm_vers,geom,hours_51_to_72,high_water_threshold,reference_time,feature_id_str AS feature_id,update_time,oid from hydrovis.services.mrf_gfs_5day_max_high_water_probability",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -2696,7 +2696,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.services.%Day 1 Bankfull Probability (%)_1_2_3_3",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select strm_order,name,huc6,nwm_vers,geom,hours_75_to_120, high_water_threshold,reference_time,feature_id_str AS feature_id,update_time,oid from hydrovis.services.mrf_gfs_5day_high_water_probability",
+          "sqlQuery" : "select strm_order,name,huc6,nwm_vers,geom,hours_75_to_120, high_water_threshold,reference_time,feature_id_str AS feature_id,update_time,oid from hydrovis.services.mrf_gfs_5day_max_high_water_probability",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -3447,7 +3447,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.services.%Day 1 Bankfull Probability (%)_1_2_3_1_1_2",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select strm_order,name,huc6,nwm_vers,geom,hours_3_to_120,high_water_threshold,reference_time,feature_id_str AS feature_id,update_time,oid from hydrovis.services.mrf_gfs_5day_high_water_probability",
+          "sqlQuery" : "select strm_order,name,huc6,nwm_vers,geom,hours_3_to_120,high_water_threshold,reference_time,feature_id_str AS feature_id,update_time,oid from hydrovis.services.mrf_gfs_5day_max_high_water_probability",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -4182,7 +4182,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.hydrovis.%hucs",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select huc8_str, total_nwm_features, nwm_features_flooded_percent, avg_prob, reference_time, update_time, geom, oid from hydrovis.services.mrf_gfs_5day_high_water_probability_hucs",
+          "sqlQuery" : "select huc8_str, total_nwm_features, nwm_features_flooded_percent, avg_prob, reference_time, update_time, geom, oid from hydrovis.services.mrf_gfs_5day_max_high_water_probability_hucs",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range/srf_12hr_max_high_water_probability.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range/srf_12hr_max_high_water_probability.mapx
@@ -473,7 +473,7 @@
             },
             {
               "name" : "srf_prob",
-              "type" : "esriFieldTypeInteger",
+              "type" : "esriFieldTypeDouble",
               "alias" : "srf_prob"
             },
             {


### PR DESCRIPTION
This PR contains a couple of minor fixes to the MRF and SRF High Water Probability mapx files.

This is to address issues I found while testing in UAT, so this should be good to greenlight through to UAT as soon as possible. We'll need to re-deploy the Viz EC2 in order for these changes to take effect.