### PR TITLE
V2.1.4 Fixes #1

### DIFF
--- a/Core/LAMBDA/viz_functions/viz_db_ingest/lambda_function.py
+++ b/Core/LAMBDA/viz_functions/viz_db_ingest/lambda_function.py
@@ -69,7 +69,10 @@ def lambda_handler(event, context):
                     target_cols = ds_vars
 
                 try:
-                    ds['forecast_hour'] = int(re.findall("(\d{8})/[a-z0-9_]*/.*t(\d{2})z.*[ftm](\d*)\.", file)[0][-1])
+                    if "hawaii" in file:
+                        ds['forecast_hour'] = int(int(re.findall("(\d{8})/[a-z0-9_]*/.*t(\d{2})z.*[ftm](\d*)\.", file)[0][-1])/100)
+                    else:
+                        ds['forecast_hour'] = int(re.findall("(\d{8})/[a-z0-9_]*/.*t(\d{2})z.*[ftm](\d*)\.", file)[0][-1])
                     if 'forecast_hour' not in target_cols:
                         target_cols.append('forecast_hour')
                 except:

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range/srf_18hr_peak_flow_arrival_time.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range/srf_18hr_peak_flow_arrival_time.sql
@@ -12,7 +12,7 @@ SELECT
     CASE WHEN rf.high_water_threshold = -9999 THEN NULL ELSE min(forecast_hour) END AS peak_flow_arrival_hour,
     CASE WHEN rf.high_water_threshold = -9999 THEN NULL ELSE to_char(forecasts.reference_time::timestamp without time zone + INTERVAL '1 hour' * min(forecast_hour), 'YYYY-MM-DD HH24:MI:SS UTC') END AS peak_flow_arrival_time,
     CASE WHEN rf.high_water_threshold = -9999 THEN NULL ELSE arrival_time.below_bank_return_hour END AS below_bank_return_hour,
-    CASE WHEN rf.high_water_threshold = -9999 THEN NULL ELSE arrival_time.below_bank_return_time,
+    CASE WHEN rf.high_water_threshold = -9999 THEN NULL ELSE arrival_time.below_bank_return_time END AS below_bank_return_time,
     round((max_flows.maxflow_18hour_cms*35.315)::numeric, 2) AS max_flow_cfs,
     rf.high_water_threshold,
     to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS update_time,

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_hawaii/srf_48hr_peak_flow_arrival_time_hi.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_hawaii/srf_48hr_peak_flow_arrival_time_hi.sql
@@ -12,7 +12,7 @@ SELECT
     CASE WHEN rf.high_water_threshold = -9999 THEN NULL ELSE min(forecast_hour) END AS peak_flow_arrival_hour,
     CASE WHEN rf.high_water_threshold = -9999 THEN NULL ELSE to_char(forecasts.reference_time::timestamp without time zone + INTERVAL '1 hour' * min(forecast_hour), 'YYYY-MM-DD HH24:MI:SS UTC') END AS peak_flow_arrival_time,
     CASE WHEN rf.high_water_threshold = -9999 THEN NULL ELSE arrival_time.below_bank_return_hour END AS below_bank_return_hour,
-    CASE WHEN rf.high_water_threshold = -9999 THEN NULL ELSE to_char(forecasts.reference_time::timestamp without time zone + INTERVAL '1 hour' * arrival_time.below_bank_return_hour, 'YYYY-MM-DD HH24:MI:SS UTC') END AS below_bank_return_time,
+    CASE WHEN rf.high_water_threshold = -9999 THEN NULL ELSE arrival_time.below_bank_return_time END AS below_bank_return_time,
     round((max_flows.maxflow_48hour_cms*35.315)::numeric, 2) AS max_flow_cfs,
     rf.high_water_threshold,
     to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS update_time, 
@@ -35,7 +35,7 @@ JOIN derived.recurrence_flows_hi as rf ON forecasts.feature_id = rf.feature_id
 JOIN publish.srf_48hr_high_water_arrival_time_hi as arrival_time ON forecasts.feature_id = arrival_time.feature_id and forecasts.reference_time = arrival_time.reference_time
 
 WHERE (rf.high_water_threshold > 0 OR rf.high_water_threshold = '-9999') AND forecasts.streamflow * 35.315::double precision >= rf.high_water_threshold
-GROUP BY forecasts.feature_id, forecasts.reference_time, forecasts.nwm_vers, channels.name, channels.strm_order, channels.huc6, rf.high_water_threshold, arrival_time.below_bank_return_hour, max_flows.maxflow_48hour_cms, channels.geom;
+GROUP BY forecasts.feature_id, forecasts.reference_time, forecasts.nwm_vers, channels.name, channels.strm_order, channels.huc6, rf.high_water_threshold, arrival_time.below_bank_return_hour, arrival_time.below_bank_return_time, max_flows.maxflow_48hour_cms, channels.geom;
 
 --Add an empty row so that service monitor will pick up a reference and update time in the event of no fim features
 INSERT INTO publish.srf_48hr_peak_flow_arrival_time_hi(

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_hawaii/srf_48hr_rapid_onset_flooding_hi.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_hawaii/srf_48hr_rapid_onset_flooding_hi.sql
@@ -73,4 +73,9 @@ SELECT channels.feature_id,
 INTO publish.srf_48hr_rapid_onset_flooding_hi
 FROM derived.channels_hi channels
 JOIN rapid_onset ON channels.feature_id = rapid_onset.feature_id
-where channels.strm_order <= 4;
+WHERE channels.strm_order <= 4;
+
+--Add an empty row so that service monitor will pick up a reference and update time in the event of no fim features
+INSERT INTO publish.srf_48hr_rapid_onset_flooding_hi(
+            state, reference_time, update_time)
+            VALUES('HI', to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'));

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_puertorico/srf_48hr_peak_flow_arrival_time_prvi.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_puertorico/srf_48hr_peak_flow_arrival_time_prvi.sql
@@ -12,7 +12,7 @@ SELECT
     CASE WHEN rf.high_water_threshold = -9999 THEN NULL ELSE min(forecast_hour) END AS peak_flow_arrival_hour,
     CASE WHEN rf.high_water_threshold = -9999 THEN NULL ELSE to_char(forecasts.reference_time::timestamp without time zone + INTERVAL '1 hour' * min(forecast_hour), 'YYYY-MM-DD HH24:MI:SS UTC') END AS peak_flow_arrival_time,
     CASE WHEN rf.high_water_threshold = -9999 THEN NULL ELSE arrival_time.below_bank_return_hour END AS below_bank_return_hour,
-    CASE WHEN rf.high_water_threshold = -9999 THEN NULL ELSE to_char(forecasts.reference_time::timestamp without time zone + INTERVAL '1 hour' * arrival_time.below_bank_return_hour, 'YYYY-MM-DD HH24:MI:SS UTC') END AS below_bank_return_time,
+    CASE WHEN rf.high_water_threshold = -9999 THEN NULL ELSE arrival_time.below_bank_return_time END AS below_bank_return_time,
     round((max_flows.maxflow_48hour_cms*35.315)::numeric, 2) AS max_flow_cfs,
     rf.high_water_threshold,
     to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS update_time, 
@@ -35,7 +35,7 @@ JOIN derived.recurrence_flows_prvi as rf ON forecasts.feature_id = rf.feature_id
 JOIN publish.srf_48hr_high_water_arrival_time_prvi as arrival_time ON forecasts.feature_id = arrival_time.feature_id and forecasts.reference_time = arrival_time.reference_time
 
 WHERE round((forecasts.streamflow*35.315)::numeric, 2) >= rf.high_water_threshold
-GROUP BY forecasts.feature_id, forecasts.reference_time, forecasts.nwm_vers, channels.name, channels.strm_order, channels.huc6, rf.high_water_threshold, arrival_time.below_bank_return_hour, max_flows.maxflow_48hour_cms, channels.geom;
+GROUP BY forecasts.feature_id, forecasts.reference_time, forecasts.nwm_vers, channels.name, channels.strm_order, channels.huc6, rf.high_water_threshold, arrival_time.below_bank_return_hour, arrival_time.below_bank_return_time, max_flows.maxflow_48hour_cms, channels.geom;
 
 --Add an empty row so that service monitor will pick up a reference and update time in the event of no fim features
 INSERT INTO publish.srf_48hr_peak_flow_arrival_time_prvi(

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_puertorico/srf_48hr_rapid_onset_flooding_prvi.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_puertorico/srf_48hr_rapid_onset_flooding_prvi.sql
@@ -74,3 +74,8 @@ INTO publish.srf_48hr_rapid_onset_flooding_prvi
 FROM derived.channels_prvi channels
 JOIN rapid_onset ON channels.feature_id = rapid_onset.feature_id
 where channels.strm_order <= 4;
+
+--Add an empty row so that service monitor will pick up a reference and update time in the event of no fim features
+INSERT INTO publish.srf_48hr_rapid_onset_flooding_prvi(
+            state, reference_time, update_time)
+            VALUES('HI', to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'));

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_blend/mrf_nbm_10day_peak_flow_arrival_time_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_blend/mrf_nbm_10day_peak_flow_arrival_time_noaa.mapx
@@ -405,7 +405,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "vizprocessing.services.%Bankfull Arrival Time_1_1_1_2_1",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select oid,feature_id_str AS feature_id,name,strm_order,peak_flow_arrival_hour,peak_flow_arrival_time,huc6,state,nwm_vers,reference_time,max_flow_cfs,high_water_threshold,below_bank_return_hour,below_bank_return_time,update_time,geom from vizprocessing.dev.mrf_nbm_10day_peak_flow_arrival_time",
+          "sqlQuery" : "select oid,feature_id_str AS feature_id,name,strm_order,peak_flow_arrival_hour,peak_flow_arrival_time,huc6,state,nwm_vers,reference_time,max_flow_cfs,high_water_threshold,below_bank_return_hour,below_bank_return_time,update_time,geom from services.mrf_nbm_10day_peak_flow_arrival_time",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -442,7 +442,7 @@
               "alias" : "peak_flow_arrival_hour"
             },
             {
-              "name" : peak_flow_arrival_time",
+              "name" : "peak_flow_arrival_time",
               "type" : "esriFieldTypeString",
               "alias" : "peak_flow_arrival_time",
               "length" : 25
@@ -486,7 +486,7 @@
               "alias" : "below_bank_return_hour"
             },
             {
-              "name" : below_bank_return_time",
+              "name" : "below_bank_return_time",
               "type" : "esriFieldTypeString",
               "alias" : "below_bank_return_time",
               "length" : 25
@@ -1313,7 +1313,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "vizprocessing.services.%Bankfull Arrival Time_1_1_1_2_1",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select oid,feature_id_str AS feature_id,name,strm_order,peak_flow_arrival_hour,peak_flow_arrival_time,huc6,state,nwm_vers,reference_time,max_flow_cfs,high_water_threshold,below_bank_return_hour,below_bank_return_time,update_time,geom from vizprocessing.dev.mrf_nbm_10day_peak_flow_arrival_time",
+          "sqlQuery" : "select oid,feature_id_str AS feature_id,name,strm_order,peak_flow_arrival_hour,peak_flow_arrival_time,huc6,state,nwm_vers,reference_time,max_flow_cfs,high_water_threshold,below_bank_return_hour,below_bank_return_time,update_time,geom from services.mrf_nbm_10day_peak_flow_arrival_time",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,


### PR DESCRIPTION
Few more fixes for V2.1.4, notably:

-  HI NWM Ingest fix - Looks like we've been reading the forecast hour incorrectly on HI configuration NWM ingest for a while.
-  Couple more QA/QC fixes to your new timestamp columns and ROF configurations, @shawncrawley (as well as fixes to my previous fixes)