### PR TITLE
Cached FIM - Part 0 - Terraform and RDS Bastion Setup

### DIFF
--- a/Core/EC2/RDSBastion/scripts/utils/setup_db_link_fdw_to_redshift.tftpl
+++ b/Core/EC2/RDSBastion/scripts/utils/setup_db_link_fdw_to_redshift.tftpl
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+echo ""
+echo "---- SETTING UP FOREIGN DATA WRAPPER TO REDSHIFT ----"
+
+# Setup foreign data server for db_link to Redshift - The syntax is a little diferent for this one, so I'm not abstracting it like the other foreign data wrapper connections at this time.
+echo "Adding foreing data_server for db_link to Redshift..."
+psql -h "${db_host}" -U "${db_username}" -p ${db_port} -d "${db_name}" \
+    -tAc "CREATE SERVER external_vpp_redshift
+                FOREIGN DATA WRAPPER postgres_fdw
+                OPTIONS (host '${viz_redshift_host}', port '${viz_redshift_port}', dbname '${viz_redshift_name}', sslmode 'require');
+          CREATE USER MAPPING FOR postgres
+                SERVER external_vpp_redshift
+                OPTIONS (user '${viz_redshift_user_username}', password '${viz_redshift_user_password}');
+          CREATE USER MAPPING FOR ${db_user_mapping}
+                SERVER external_vpp_redshift
+                OPTIONS (user '${viz_redshift_user_username}', password '${viz_redshift_user_password}');"

--- a/Core/EC2/RDSBastion/scripts/viz/postgresql_setup.sh.tftpl
+++ b/Core/EC2/RDSBastion/scripts/viz/postgresql_setup.sh.tftpl
@@ -18,10 +18,15 @@ aws s3 cp "s3://${deployment_bucket}/${postgis_setup_s3_key}" "$${postgres_data_
 psql -h "${viz_db_host}" -U "${viz_db_username}" -p ${viz_db_port} -d "${viz_db_name}" -qtAf "$${postgres_data_folder}/postgis_setup.sql"
 rm "$${postgres_data_folder}/postgis_setup.sql"
 
-
 echo "Setting up aws_s3..."
 psql -h "${viz_db_host}" -U "${viz_db_username}" -p ${viz_db_port} -d "${viz_db_name}" -qtAc "CREATE EXTENSION IF NOT EXISTS aws_s3 CASCADE;"
 
+echo "Setting up db_link..."
+psql -h "${viz_db_host}" -U "${viz_db_username}" -p ${viz_db_port} -d "${viz_db_name}" -qtAc "CREATE EXTENSION IF NOT EXISTS dblink CASCADE;"
+
+# Set password encryption to md5 - we need this to play nice with Redshift foreign data connections
+echo "Setting password encyption to md5"
+psql -h "${viz_db_host}" -U "${viz_db_username}" -p ${viz_db_port} -d "${viz_db_name}" -qtAc "SET password_encryption = 'md5';"
 
 # Adding users to Viz DB
 echo "Adding viz proc user..."
@@ -31,7 +36,6 @@ psql -h "${viz_db_host}" -U "${viz_db_username}" -p ${viz_db_port} -d "${viz_db_
 echo "Adding viz dev user..."
 psql -h "${viz_db_host}" -U "${viz_db_username}" -p ${viz_db_port} -d "${viz_db_name}" -qtAc "CREATE ROLE ${viz_proc_dev_rw_username};"
 psql -h "${viz_db_host}" -U "${viz_db_username}" -p ${viz_db_port} -d "${viz_db_name}" -qtAc "ALTER ROLE ${viz_proc_dev_rw_username} WITH INHERIT NOCREATEROLE NOCREATEDB LOGIN NOBYPASSRLS CONNECTION LIMIT 25 ENCRYPTED PASSWORD '${viz_proc_dev_rw_password}';"
-
 
 # Add permissions for aws_s3 extension to viz user.
 echo "Adding permissions to aws_s3 extension for viz user..."

--- a/Core/EC2/RDSBastion/scripts/viz/redshift_setup.sh.tftpl
+++ b/Core/EC2/RDSBastion/scripts/viz/redshift_setup.sh.tftpl
@@ -23,5 +23,5 @@ psql -h "${viz_redshift_host}" -U "${viz_redshift_username}" -p ${viz_redshift_p
           FROM POSTGRES
           DATABASE '${viz_db_name}' SCHEMA 'ingest'
           URI '${viz_db_host}' PORT ${viz_db_port}
-          IAM_ROLE ${viz_redshift_iam_role_arn}
+          IAM_ROLE '${viz_redshift_iam_role_arn}'
           SECRET_ARN '${viz_proc_admin_rw_secret_arn}';"

--- a/Core/EC2/RDSBastion/scripts/viz/redshift_setup.sh.tftpl
+++ b/Core/EC2/RDSBastion/scripts/viz/redshift_setup.sh.tftpl
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+export PGOPTIONS='-c client_min_messages=warning'
+
+postgres_data_folder="/home/ec2-user/postgres_data"
+
+echo ""
+echo "---- SETTING UP VIZ REDSHIFT DB ----"
+
+
+# Setting up Viz Redshift DB
+export PGPASSWORD=${viz_db_password}
+
+# Adding users to Viz Redshift DB
+echo "Adding viz redshift user..."
+psql -h "${viz_redshift_host}" -U "${viz_redshift_username}" -p ${viz_redshift_port} -d "${viz_redshift_name}" -qtAc "CREATE USER ${viz_redshift_user_username} WITH PASSWORD '${viz_redshift_user_password}';"
+
+# Setup external schemas - linked to viz processing rds datbase - this could be abstracted as done with the viz processing foreign schemas, but I'm not doing that now since it is only one schema we need.
+echo "Adding external schema link to viz ingest ..."
+psql -h "${viz_redshift_host}" -U "${viz_redshift_username}" -p ${viz_redshift_port} -d "${viz_redshift_name}" \
+    -tAc "DROP SCHEMA IF EXISTS external_viz_ingest;
+          CREATE EXTERNAL SCHEMA external_viz_ingest
+          FROM POSTGRES
+          DATABASE '${viz_db_name}' SCHEMA 'ingest'
+          URI '${viz_db_host}' PORT ${viz_db_port}
+          IAM_ROLE ${viz_redshift_iam_role_arn}
+          SECRET_ARN '${viz_proc_admin_rw_secret_arn}';"

--- a/Core/IAM/Roles/main.tf
+++ b/Core/IAM/Roles/main.tf
@@ -26,6 +26,10 @@ variable "nws_shared_account_s3_bucket" {
   type = string
 }
 
+variable "viz_proc_admin_rw_secret_arn" {
+  type = string
+}
+
 # Autoscaling Role
 resource "aws_iam_service_linked_role" "autoscaling" {
   aws_service_name = "autoscaling.amazonaws.com"
@@ -199,6 +203,35 @@ resource "aws_iam_role_policy" "rds_s3_export" {
   })
 }
 
+# Redshift Role
+resource "aws_iam_role" "redshift" {
+  name = "hv-vpp-${var.environment}-${var.region}-redshift"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "redshift.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "redshift" {
+  name   = "hv-vpp-${var.environment}-${var.region}-redshift"
+  role   = aws_iam_role.redshift.id
+  policy = templatefile("${path.module}/redshift.json.tftpl", {
+    environment                  = var.environment
+    account_id                   = var.account_id
+    region                       = var.region
+    viz_proc_admin_rw_secret_arn = var.viz_proc_admin_rw_secret_arn
+  })
+}
 
 # data-services Role
 resource "aws_iam_role" "data_services" {
@@ -414,6 +447,10 @@ output "role_viz_pipeline" {
 
 output "role_rds_s3_export" {
   value = aws_iam_role.rds_s3_export
+}
+
+output "role_redshift" {
+  value = aws_iam_role.redshift
 }
 
 output "profile_data_services" {

--- a/Core/IAM/Roles/redshift.json.tftpl
+++ b/Core/IAM/Roles/redshift.json.tftpl
@@ -1,0 +1,28 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "s3_access",
+            "Action": [
+                "s3:PutObject",
+                "s3:Get*",
+                "s3:List*"
+            ],
+            "Effect": "Allow",
+            "Resource": [
+                "arn:aws:s3:::hydrovis-${environment}-fim-${region}/*"
+            ] 
+        },
+        {
+            "Sid": "secret_for_external_data_schema",
+            "Action": [
+                "secretsmanager:DescribeSecret",
+                "secretsmanager:GetSecretValue"
+            ],
+            "Effect": "Allow",
+            "Resource": [
+                "${viz_proc_admin_rw_secret_arn}"
+            ] 
+        }
+    ] 
+}

--- a/Core/LAMBDA/viz_functions/main.tf
+++ b/Core/LAMBDA/viz_functions/main.tf
@@ -114,6 +114,16 @@ variable "egis_db_name" {
   type = string
 }
 
+variable "viz_redshift_host" {
+  description = "Hostname of the viz data warehouse redshift cluster."
+  type        = string
+}
+
+variable "viz_redshift_db_name" {
+  description = "DB Name of the viz data warehouse redshift cluster."
+  type        = string
+}
+
 variable "viz_db_user_secret_string" {
   description = "The secret string of the viz_processing data base user to write/read data as."
   type        = string
@@ -121,6 +131,11 @@ variable "viz_db_user_secret_string" {
 
 variable "egis_db_user_secret_string" {
   description = "The secret string for the egis rds database."
+  type        = string
+}
+
+variable "viz_redshift_user_secret_string" {
+  description = "The secret string of the viz_processing data base user to write/read data as."
   type        = string
 }
 
@@ -622,10 +637,14 @@ resource "aws_lambda_function" "viz_db_postprocess_sql" {
   }
   environment {
     variables = {
-      VIZ_DB_DATABASE = var.viz_db_name
-      VIZ_DB_HOST     = var.viz_db_host
-      VIZ_DB_USERNAME = jsondecode(var.viz_db_user_secret_string)["username"]
-      VIZ_DB_PASSWORD = jsondecode(var.viz_db_user_secret_string)["password"]
+      VIZ_DB_DATABASE       = var.viz_db_name
+      VIZ_DB_HOST           = var.viz_db_host
+      VIZ_DB_USERNAME       = jsondecode(var.viz_db_user_secret_string)["username"]
+      VIZ_DB_PASSWORD       = jsondecode(var.viz_db_user_secret_string)["password"]
+      REDSHIFT_DB_DATABASE  = var.viz_redshift_db_name
+      REDSHIFT_DB_HOST      = var.viz_redshift_host
+      REDSHIFT_DB_USERNAME  = jsondecode(var.viz_redshift_user_secret_string)["username"]
+      REDSHIFT_DB_PASSWORD  = jsondecode(var.viz_redshift_user_secret_string)["password"]
     }
   }
   s3_bucket        = aws_s3_object.db_postprocess_sql_zip_upload.bucket

--- a/Core/Redshift/viz/main.tf
+++ b/Core/Redshift/viz/main.tf
@@ -1,0 +1,70 @@
+variable "environment" {
+  type = string
+}
+
+variable "db_viz_redshift_security_groups" {
+  type = list(any)
+}
+
+variable "subnet-a" {
+  type = string
+}
+
+variable "subnet-b" {
+  type = string
+}
+
+variable "db_viz_redshift_master_secret_string" {
+  type = string
+}
+
+variable "db_viz_redshift_user_secret_string" {
+  type = string
+}
+
+variable "viz_redshift_db_name" {
+  type = string
+}
+
+variable "role_viz_redshift_arn" {
+  type = string
+}
+
+variable "private_route_53_zone" {
+  type = object({
+    name     = string
+    zone_id  = string
+  })
+}
+
+resource "aws_redshift_subnet_group" "viz_redshift_subnet_group" {
+  name       = "hv-vpp-${var.environment}-viz-data-warehouse-subnets"
+  subnet_ids = [var.subnet-a, var.subnet-b]
+  tags = {
+    Name = "Viz Redshift Data Warehouse Subnet Group"
+  }
+}
+
+resource "aws_redshift_cluster" "viz_redshift_data_warehouse" {
+  cluster_identifier        = "hv-vpp-${var.environment}-viz-data-warehouse"
+  database_name             = var.viz_redshift_db_name
+  master_username           = jsondecode(var.db_viz_redshift_master_secret_string)["username"]
+  master_password           = jsondecode(var.db_viz_redshift_master_secret_string)["password"]
+  node_type                 = "dc2.large"
+  cluster_type              = "single-node"
+  iam_roles                 = [var.role_viz_redshift_arn]
+  vpc_security_group_ids    = var.db_viz_redshift_security_groups
+  cluster_subnet_group_name = aws_redshift_subnet_group.viz_redshift_subnet_group.name
+}
+
+resource "aws_route53_record" "viz_redshift_data_warehouse" {
+  zone_id = var.private_route_53_zone.zone_id
+  name    = "redshift-viz.${var.private_route_53_zone.name}"
+  type    = "CNAME"
+  ttl     = 300
+  records = [aws_redshift_cluster.viz_redshift_data_warehouse.address]
+}
+
+output "dns_name" {
+  value = aws_route53_record.viz_redshift_data_warehouse.name
+}

--- a/Core/SecretsManager/main.tf
+++ b/Core/SecretsManager/main.tf
@@ -18,3 +18,7 @@ module "secret" {
 output "secret_strings" {
   value = { for name in keys(var.names_and_users) : name => module.secret[name].secret_string }
 }
+
+output "arns" {
+  value = { for name in keys(var.names_and_users) : name => module.secret[name].secret_arn }
+}

--- a/Core/SecretsManager/secret/main.tf
+++ b/Core/SecretsManager/secret/main.tf
@@ -36,3 +36,7 @@ resource "aws_secretsmanager_secret_version" "hydrovis" {
 output "secret_string" {
   value = aws_secretsmanager_secret_version.hydrovis.secret_string
 }
+
+output "secret_arn" {
+  value = aws_secretsmanager_secret.hydrovis.arn
+}

--- a/Core/SecurityGroups/main.tf
+++ b/Core/SecurityGroups/main.tf
@@ -125,6 +125,48 @@ resource "aws_security_group" "rds" {
   }
 }
 
+resource "aws_security_group" "redshift" {
+  name = "hv-vpp-${var.environment}-redshift"
+  description = "Redshift access"
+  vpc_id = var.vpc_main_id
+
+  egress = [
+    {
+      cidr_blocks = [
+        "0.0.0.0/0",
+      ]
+      description      = ""
+      from_port        = 0
+      ipv6_cidr_blocks = []
+      prefix_list_ids  = []
+      protocol         = "-1"
+      security_groups  = []
+      self             = false
+      to_port          = 0
+    },
+  ]
+
+  ingress = [
+    {
+      cidr_blocks = [
+        var.vpc_main_cidr_block,
+      ]
+      description      = ""
+      from_port        = 5439
+      ipv6_cidr_blocks = []
+      prefix_list_ids  = []
+      protocol         = "tcp"
+      security_groups  = []
+      self             = false
+      to_port          = 22
+    }
+  ]
+  
+  tags = {
+    "Name" = "hv-vpp-${var.environment}-redshift"
+  }
+}
+
 resource "aws_security_group" "vpc_access" {
   name = "ssm-session-manager-sg"
   description = "allow access to VPC endpoints"
@@ -333,6 +375,10 @@ output "rabbitmq" {
 
 output "rds" {
   value = aws_security_group.rds
+}
+
+output "redshift" {
+  value = aws_security_group.redshift
 }
 
 output "vpc_access" {


### PR DESCRIPTION
This PR is the first step to implementing the new Cached FIM Workflow I've been developing (I'll have 1-3 follow-up PRs - I'm trying to split this all up into appropriately sized chunks).

**This PR:**
- Adds a new IAM role for the Redshift cluster (which notably has permission to read the viz RDS user secret for external schema setup).
- Adds a new security group for the Redshift cluster
- Adds a Redshift cluster (including a cluster subnet group)
- Adds two steps to the RDS Bastion:
  - Redshift cluster setup: Adds a user for use in the pipelines & sets up a external schema pointed to the ingest schema on viz RDS database (I didn't abstract this yet, like what was done for the foreign data wrapper connections on RDS, since it's only one schema, but we could do that in the future)
  - DB_Link Foreign Data Wrapper From RDS to Redshift: I went ahead and put this in a separate util script, as the syntax is a little different than the other foreign data wrapper connections between RDS instances (it's possible that the same syntax could work for all, but I'm not prioritizing figuring that our right now).
  
**Testing / Deployment Considerations:**
I've tested the IAM Role and Redshift setup in terraform, and the RDS Bastion steps manually on both Redshift and RDS... but I haven't tested it all together through the central terraform module yet - I'm hoping this should be pretty smooth, and I can help troubleshoot any deployment issues in real-time, Nick. I've also included a couple comments in the code below for your consideration.