### PR TITLE
Fully implements db-centric rfc_max_forecast

### DIFF
--- a/Core/EC2/RDSBastion/scripts/viz/postgresql_setup.sh.tftpl
+++ b/Core/EC2/RDSBastion/scripts/viz/postgresql_setup.sh.tftpl
@@ -40,3 +40,7 @@ psql -h "${viz_db_host}" -U "${viz_db_username}" -p ${viz_db_port} -d "${viz_db_
 # Add permissions for aws_s3 extension to viz user.
 echo "Adding permissions to aws_s3 extension for viz user..."
 psql -h "${viz_db_host}" -U "${viz_db_username}" -p ${viz_db_port} -d "${viz_db_name}" -qtAc "GRANT USAGE ON schema aws_s3 TO ${viz_proc_admin_rw_username}; GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA aws_s3 TO ${viz_proc_admin_rw_username};"
+
+echo "Creating enum types for use in rfc-based services"
+psql -h "${viz_db_host}" -U "${viz_db_username}" -p ${viz_db_port} -d "${viz_db_name}" -qtAc "CREATE TYPE flood_status AS ENUM ('no_flooding', 'action', 'minor', 'moderate', 'major');"
+psql -h "${viz_db_host}" -U "${viz_db_username}" -p ${viz_db_port} -d "${viz_db_name}" -qtAc "CREATE TYPE forecast_ts AS ENUM ('FE', 'FF', 'FM', 'FN', 'FP', 'FQ', 'FU', 'FV', 'FW', 'FA', 'FB', 'FC', 'FD', 'FX', 'FG', 'FL', 'FZ');"

--- a/Core/LAMBDA/rnr_functions/rnr_domain_generator/sql/dba_stuff.sql
+++ b/Core/LAMBDA/rnr_functions/rnr_domain_generator/sql/dba_stuff.sql
@@ -44,3 +44,101 @@ ORDER BY
 	nws_station_id,
 	nws_usgs_crosswalk_dataset_id DESC NULLS LAST,
 	location_nwm_crosswalk_dataset_id DESC NULLS LAST;
+
+-- CREATE FLOW_THRESHOLDS VIEW
+DROP VIEW IF EXISTS rnr.flow_thresholds;
+CREATE VIEW rnr.flow_thresholds AS
+
+WITH
+
+main AS (
+	SELECT 
+		station.location_id as nws_station_id,
+		COALESCE(native.action_flow, usgs.action_flow_calc, nrldb.action_flow_calc) as action,
+			CASE 
+				WHEN native.action_flow IS NOT NULL
+				THEN 'Native'
+				WHEN usgs.action_flow_calc IS NOT NULL
+				THEN 'USGS'
+				WHEN nrldb.action_flow_calc IS NOT NULL
+				THEN 'NRLDB'
+			END as action_source,
+			COALESCE(native.minor_flow, usgs.minor_flow_calc, nrldb.minor_flow_calc) as minor,
+			CASE 
+				WHEN native.minor_flow IS NOT NULL
+				THEN 'Native'
+				WHEN usgs.minor_flow_calc IS NOT NULL
+				THEN 'USGS'
+				WHEN nrldb.minor_flow_calc IS NOT NULL
+				THEN 'NRLDB'
+			END as minor_source,
+			COALESCE(native.moderate_flow, usgs.moderate_flow_calc, nrldb.moderate_flow_calc) as moderate,
+			CASE 
+				WHEN native.moderate_flow IS NOT NULL
+				THEN 'Native'
+				WHEN usgs.moderate_flow_calc IS NOT NULL
+				THEN 'USGS'
+				WHEN nrldb.moderate_flow_calc IS NOT NULL
+				THEN 'NRLDB'
+			END as moderate_source,
+			COALESCE(native.major_flow, usgs.major_flow_calc, nrldb.major_flow_calc) as major,
+			CASE 
+				WHEN native.major_flow IS NOT NULL
+				THEN 'Native'
+				WHEN usgs.major_flow_calc IS NOT NULL
+				THEN 'USGS'
+				WHEN nrldb.major_flow_calc IS NOT NULL
+				THEN 'NRLDB'
+			END as major_source,
+			COALESCE(native.record_flow, usgs.record_flow_calc, nrldb.record_flow_calc) as record,
+			CASE 
+				WHEN native.record_flow IS NOT NULL
+				THEN 'Native'
+				WHEN usgs.record_flow_calc IS NOT NULL
+				THEN 'USGS'
+				WHEN nrldb.record_flow_calc IS NOT NULL
+				THEN 'NRLDB'
+			END as record_source
+	FROM (SELECT DISTINCT location_id FROM external.threshold) AS station
+	LEFT JOIN external.threshold native
+		ON native.location_id = station.location_id 
+		AND native.rating_source = 'NONE'
+	LEFT JOIN external.threshold usgs
+		ON usgs.location_id = station.location_id 
+		AND usgs.rating_source = 'USGS Rating Depot'
+	LEFT JOIN external.threshold nrldb
+		ON nrldb.location_id = station.location_id 
+		AND nrldb.rating_source = 'NRLDB'
+)
+
+SELECT * FROM main
+WHERE COALESCE(action, minor, moderate, major, record) IS NOT NULL;
+
+-- CREATE STAGE THRESHOLDS VIEW
+DROP VIEW IF EXISTS rnr.stage_thresholds;
+CREATE VIEW rnr.stage_thresholds AS
+
+WITH
+
+native_stage_thresholds AS (
+	SELECT 
+		location_id,
+		action_stage,
+		minor_stage,
+		moderate_stage,
+		major_stage,
+		record_stage
+	FROM external.threshold
+	WHERE rating_source = 'NONE'
+)
+
+SELECT 
+	location_id AS nws_station_id,
+	action_stage as action,
+	minor_stage as minor,
+	moderate_stage as moderate,
+	major_stage as major,
+	record_stage as record
+FROM external.threshold station
+WHERE rating_source = 'NONE' 
+	AND COALESCE(action_stage, minor_stage, moderate_stage, major_stage, record_stage) IS NOT NULL;

--- a/Core/LAMBDA/viz_functions/main.tf
+++ b/Core/LAMBDA/viz_functions/main.tf
@@ -278,8 +278,9 @@ resource "aws_lambda_function" "viz_wrds_api_handler" {
 
 resource "aws_cloudwatch_event_target" "check_lambda_every_five_minutes" {
   rule      = var.five_minute_trigger.name
-  target_id = aws_lambda_function.viz_wrds_api_handler.function_name
-  arn       = aws_lambda_function.viz_wrds_api_handler.arn
+  target_id = aws_lambda_function.viz_initialize_pipeline.function_name
+  arn       = aws_lambda_function.viz_initialize_pipeline.arn
+  input     = "{\"configuration\":\"rfc\"}"
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch_to_call_check_lambda" {

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/rfc/rfc_max_forecast.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/rfc/rfc_max_forecast.sql
@@ -1,123 +1,339 @@
 DROP TABLE IF EXISTS publish.rfc_max_forecast;
 
 WITH
-	-------- Max Stage Sub Query -------
-	max_stage AS
-		(SELECT 
-			af.nws_lid, 
-			af.stage, 
-			af.status,
-		 	MIN(af.time) AS timestep,
-		 	CASE			
-				WHEN af.status = 'action' THEN 1::integer
-				WHEN af.status = 'minor' THEN 2::integer
-				WHEN af.status = 'moderate' THEN 3::integer
-				WHEN af.status = 'major' THEN 4::integer
-				ELSE 0::integer
-			END AS status_value
-		FROM ingest.ahps_forecasts AS af
-		INNER JOIN (
-			SELECT
-				nws_lid,
-				MAX(stage) AS max_stage
-			FROM ingest.ahps_forecasts
-			GROUP BY nws_lid
-		) AS b ON af.nws_lid = b.nws_lid AND af.stage = b.max_stage
-		 LEFT OUTER JOIN ingest.ahps_metadata AS c on af.nws_lid = c.nws_lid
-		 GROUP BY af.nws_lid, af.stage, af.status, c.record_threshold),
-	-------- Min Stage Sub Query -------
-	min_stage AS
-		(SELECT 
-			af.nws_lid,  
-			af.stage, 
-			af.status,
-		 	MIN(af.time) AS timestep,
-		 	CASE			
-				WHEN af.status = 'action' THEN 1::integer
-				WHEN af.status = 'minor' THEN 2::integer
-				WHEN af.status = 'moderate' THEN 3::integer
-				WHEN af.status = 'major' THEN 4::integer
-				ELSE 0::integer
-			END AS status_value
-		FROM ingest.ahps_forecasts AS af
-		INNER JOIN (
-			SELECT
-				nws_lid,
-				MIN(stage) AS min_stage
-			FROM ingest.ahps_forecasts
-			GROUP BY nws_lid
-		) AS b ON af.nws_lid = b.nws_lid AND af.stage = b.min_stage
-		LEFT OUTER JOIN ingest.ahps_metadata AS c on af.nws_lid = c.nws_lid
-		GROUP BY af.nws_lid, af.stage, af.status, c.record_threshold),
-	-------- Initial Stage Sub Query -------
-	initial_stage AS
-		(SELECT 
-			af.nws_lid,
-			af.stage,
-			af.status,
-		 	af.time AS timestep,
-		 	CASE			
-				WHEN af.status = 'action' THEN 1::integer
-				WHEN af.status = 'minor' THEN 2::integer
-				WHEN af.status = 'moderate' THEN 3::integer
-				WHEN af.status = 'major' THEN 4::integer
-				ELSE 0::integer
-			END AS status_value
-		FROM ingest.ahps_forecasts AS af
-		INNER JOIN (
-			SELECT
-				nws_lid,
-				MIN(time) AS min_timestep
-			FROM ingest.ahps_forecasts
-			GROUP BY nws_lid
-		) AS b ON af.nws_lid = b.nws_lid AND af.time = b.min_timestep
-		LEFT OUTER JOIN ingest.ahps_metadata AS c on af.nws_lid = c.nws_lid)
 
--------- Main Query (Put it all together) -------
-SELECT 
-	max_stage.nws_lid,
-	initial_stage.stage AS initial_stage,
-	initial_stage.status AS initial_status,
-	to_char(initial_stage.timestep::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS initial_stage_timestep,
-	min_stage.stage AS min_stage,
-	min_stage.status AS min_status,
-	to_char(min_stage.timestep::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS min_stage_timestep,
-	max_stage.stage AS max_stage,
-	max_stage.status AS max_status,
-	to_char(max_stage.timestep::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS max_stage_timestep,
+latest_forecast AS (
+	SELECT DISTINCT ON (
+		lid, 
+		pe, 
+		d, 
+		ts, 
+		e, 
+		p, 
+		product_time, 
+		start_time, 
+		valid_time
+	)
+		lid,
+		distributor AS distributor_name,
+		producer_name,
+		generation_time,
+		product_time,
+		valid_time,
+		pe,
+		d,
+		ts,
+		e,
+		p,
+		pe_priority,
+		value,
+		units
+	FROM wrds_rfcfcst.last_forecast_view
+	ORDER BY 
+		last_forecast_view.lid, 
+		last_forecast_view.pe, 
+		last_forecast_view.d, 
+		last_forecast_view.ts, 
+		last_forecast_view.e, 
+		last_forecast_view.p, 
+		last_forecast_view.product_time DESC, 
+		last_forecast_view.start_time, 
+		last_forecast_view.valid_time, 
+		last_forecast_view.generation_time DESC
+),
+
+considerable_forecast_metadata AS (
+	SELECT DISTINCT ON (lid, units)
+		lid, pe, ts, product_time, units
+	FROM latest_forecast
+	WHERE (pe LIKE 'H%' OR pe LIKE 'Q%')
+		AND pe_priority = 1
+		AND product_time >= NOW() - INTERVAL '48 hours'
+		AND valid_time >= NOW()
+		AND value > -999
+	ORDER BY lid, units, ts::forecast_ts
+),
+
+relevant_forecasts AS (
+	SELECT 
+		main.lid, 
+		main.pe,
+		main.ts,
+		main.generation_time,
+		main.product_time,
+		main.valid_time,
+	CASE 
+		WHEN main.units = 'KCFS' 
+		THEN value * 1000
+		ELSE value
+	END as value,
 	CASE
-		WHEN initial_stage.stage = 0 THEN 'increasing'::text
-		WHEN ((max_stage.stage-initial_stage.stage)/initial_stage.stage) > .05 THEN 'increasing'::text									
-		WHEN ((min_stage.stage-initial_stage.stage)/initial_stage.stage) < -.05 THEN 'decreasing'::text									
-		WHEN max_stage.status_value > initial_stage.status_value THEN 'increasing'::text								
-		WHEN max_stage.status_value < initial_stage.status_value THEN 'decreasing'::text
-		ELSE 'constant'::text
-	END AS forecast_trend,
-	CASE
-		WHEN max_stage.stage >= metadata.record_threshold THEN true
-		ELSE false
-	END AS record_forecast,
-	metadata.producer, 
-	metadata.issuer,
-	to_char(metadata."issuedTime"::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS issued_time,
-	to_char(metadata."generationTime"::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS generation_time,
-	metadata.usgs_sitecode, 
-	metadata.feature_id, 
-	metadata.nws_name, 
-	metadata.usgs_name,
-	ST_TRANSFORM(ST_SetSRID(ST_MakePoint(metadata.longitude, metadata.latitude),4326),3857) as geom, 
-	metadata.action_threshold, 
-	metadata.minor_threshold, 
-	metadata.moderate_threshold, 
-	metadata.major_threshold, 
-	metadata.record_threshold, 
-	metadata.units,
-	CONCAT('https://water.weather.gov/resources/hydrographs/', LOWER(metadata.nws_lid), '_hg.png') AS hydrograph_link,
-	CONCAT('https://water.weather.gov/ahps2/rfc/', metadata.nws_lid, '.shortrange.hefs.png') AS hefs_link,
-	to_char(NOW()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS UPDATE_TIME
+		WHEN main.units = 'KCFS'
+		THEN 'CFS'
+		ELSE main.units
+	END AS units
+	FROM latest_forecast main
+	JOIN considerable_forecast_metadata meta
+		ON meta.lid = main.lid AND meta.pe = main.pe AND meta.ts = main.ts AND meta.product_time = main.product_time
+	WHERE valid_time >= NOW()
+	ORDER BY
+		lid, 
+		pe,
+		generation_time,
+		product_time,
+		valid_time
+),
+
+relevant_thresholds AS (
+	SELECT
+		lid,
+		CASE
+			WHEN units = 'KCFS'
+			THEN 'CFS'
+			ELSE units
+		END as units,
+		COALESCE(st.action, ft.action) AS action,
+		COALESCE(st.minor, ft.minor) AS minor,
+		COALESCE(st.moderate, ft.moderate) AS moderate,
+		COALESCE(st.major, ft.major) AS major,
+		COALESCE(st.record, ft.record) AS record
+	FROM considerable_forecast_metadata main
+	LEFT JOIN rnr.stage_thresholds st
+		ON units = 'FT' AND st.nws_station_id = main.lid
+	LEFT JOIN rnr.flow_thresholds ft
+		ON units LIKE '%CFS' AND ft.nws_station_id = main.lid
+),
+
+forecast_max_value AS (
+	SELECT DISTINCT ON (lid, pe, product_time)
+		lid,
+		pe,
+		ts,
+		product_time,
+		valid_time as max_timestep,
+		value as max_value,
+		units,
+		generation_time
+	FROM relevant_forecasts
+	ORDER BY 
+		lid, 
+		pe, 
+		product_time, 
+		value DESC
+),
+
+forecast_max_status AS (
+	SELECT 
+		fmv.lid,
+		pe,
+		ts,
+		product_time,
+		max_timestep,
+		max_value,
+		fmv.units,
+		CASE
+			WHEN major IS NOT NULL AND fmv.max_value >= major
+			THEN 'major'
+			WHEN moderate IS NOT NULL AND fmv.max_value >= moderate
+			THEN 'moderate'
+			WHEN minor IS NOT NULL AND fmv.max_value >= minor
+			THEN 'minor'
+			WHEN action IS NOT NULL AND fmv.max_value >= action
+			THEN 'action'
+			ELSE 'no_flooding'
+		END as max_status,
+		generation_time
+	FROM forecast_max_value AS fmv
+	LEFT JOIN relevant_thresholds
+		ON relevant_thresholds.lid = fmv.lid
+		AND relevant_thresholds.units = fmv.units
+),
+
+flood_data_base AS (
+    SELECT
+		lid,
+		pe,
+		ts,
+		product_time,
+		generation_time,
+		max_timestep,
+		max_value,
+		max_status,
+		units
+    FROM forecast_max_status fms
+    LEFT JOIN derived.ahps_restricted_sites restricted
+        ON restricted.nws_lid = fms.lid
+    WHERE restricted.nws_lid IS NULL 
+        AND fms.max_status != 'no_flooding'
+),
+
+flood_forecasts AS (
+	SELECT relevant_forecasts.*
+	FROM relevant_forecasts
+	JOIN flood_data_base flood
+		ON flood.lid = relevant_forecasts.lid
+		AND flood.pe = relevant_forecasts.pe
+		AND flood.product_time = relevant_forecasts.product_time
+),
+
+forecast_initial_values AS (
+	SELECT DISTINCT ON (lid, pe, product_time)
+		lid,
+		pe,
+		product_time,
+		value,
+		units,
+		valid_time as timestep
+	FROM flood_forecasts
+	ORDER BY
+		lid,
+		pe,
+		product_time,
+		valid_time
+),
+
+forecast_initial_status AS (
+	SELECT 
+		fiv.lid,
+		pe,
+		product_time,
+		timestep,
+		value,
+		fiv.units,
+		CASE
+			WHEN major IS NOT NULL AND fiv.value >= major
+			THEN 'major'
+			WHEN moderate IS NOT NULL AND fiv.value >= moderate
+			THEN 'moderate'
+			WHEN minor IS NOT NULL AND fiv.value >= minor
+			THEN 'minor'
+			WHEN action IS NOT NULL AND fiv.value >= action
+			THEN 'action'
+			ELSE 'no_flooding'
+		END as status
+		FROM forecast_initial_values AS fiv
+		LEFT JOIN relevant_thresholds
+			ON relevant_thresholds.lid = fiv.lid
+),
+
+forecast_min_value AS (
+	SELECT DISTINCT ON (lid, pe, product_time)
+		lid,
+		pe,
+		product_time,
+		value,
+		units,
+		valid_time as timestep
+	FROM flood_forecasts
+	ORDER BY
+		lid,
+		pe,
+		product_time,
+		value
+),
+
+forecast_min_status AS (
+	SELECT 
+		fmv.lid,
+		pe,
+		product_time,
+		timestep,
+		value,
+		fmv.units,
+		CASE
+			WHEN major IS NOT NULL AND fmv.value >= major
+			THEN 'major'
+			WHEN moderate IS NOT NULL AND fmv.value >= moderate
+			THEN 'moderate'
+			WHEN minor IS NOT NULL AND fmv.value >= minor
+			THEN 'minor'
+			WHEN action IS NOT NULL AND fmv.value >= action
+			THEN 'action'
+			ELSE 'no_flooding'
+		END as status
+		FROM forecast_min_value AS fmv
+		LEFT JOIN relevant_thresholds
+			ON relevant_thresholds.lid = fmv.lid
+),
+
+forecast_point_xwalk AS (
+	SELECT 
+		station.nws_station_id, 
+		station.name as nws_name,
+		station.hsa as issuer,
+		station.rfc as producer,
+		xwalk.gage_id as usgs_site_code,
+		gage.name as usgs_name,
+		xwalk.nwm_feature_id as feature_id,
+		ST_TRANSFORM(station.geo_point, 3857) AS geom
+	FROM flood_data_base base
+	LEFT JOIN external.nws_station station
+		ON station.nws_station_id = base.lid
+	LEFT JOIN (
+		SELECT DISTINCT ON (nws_station_id) * 
+		FROM external.full_crosswalk_view 
+		ORDER BY 
+			nws_station_id,
+			nws_usgs_crosswalk_dataset_id DESC NULLS LAST,
+			location_nwm_crosswalk_dataset_id DESC NULLS LAST
+	) AS xwalk ON xwalk.nws_station_id = base.lid
+	LEFT JOIN external.usgs_gage gage
+		ON gage.usgs_gage_id = xwalk.gage_id
+),
+
+service_data AS (
+	SELECT DISTINCT
+		base.lid::text as nws_lid,
+		base.pe,  -- NOT USED IN SERVICE, BUT NEEDED FOR RNR
+		base.ts,  -- NOT USED IN SERVICE, BUT NEEDED FOR RNR
+		to_char(base.product_time, 'YYYY-MM-DD HH24:MI:SS UTC') AS issued_time,
+		to_char(base.generation_time, 'YYYY-MM-DD HH24:MI:SS UTC') AS generation_time,
+		CASE
+			WHEN initial.value = 0 THEN 'increasing'
+			WHEN ((base.max_value - initial.value) / initial.value) > .05 THEN 'increasing'
+			WHEN ((min.value - initial.value) / initial.value) < -.05 THEN 'decreasing'
+			WHEN base.max_status::flood_status > initial.status::flood_status THEN 'increasing'
+			WHEN base.max_status::flood_status < initial.status::flood_status THEN 'decreasing'
+			ELSE 'constant'
+		END AS forecast_trend,
+		cats.record IS NOT NULL AND base.max_value > cats.record AS is_record_forecast,
+		to_char(initial.timestep, 'YYYY-MM-DD HH24:MI:SS UTC') AS initial_value_timestep,
+		initial.value as initial_value,
+		initial.status as initial_status,
+		to_char(min.timestep, 'YYYY-MM-DD HH24:MI:SS UTC') as min_value_timestep,
+		min.value as min_value,
+		min.status as min_status,
+		to_char(base.max_timestep, 'YYYY-MM-DD HH24:MI:SS UTC') as max_value_timestep,
+		base.max_value,
+		base.max_status,
+		xwalk.usgs_site_code,
+		xwalk.feature_id,
+		xwalk.nws_name,
+		xwalk.usgs_name,
+		xwalk.producer::text,
+		xwalk.issuer::text,
+		xwalk.geom,
+		cats.action as action_threshold,
+		cats.minor as minor_threshold,
+		cats.moderate as moderate_threshold,
+		cats.major as major_threshold,
+		cats.record as record_threshold,
+		base.units,
+		'https://water.weather.gov/resources/hydrographs/' || LOWER(base.lid) || '_hg.png' AS hydrograph_link,
+		'https://water.weather.gov/ahps2/rfc/' || base.lid || '.shortrange.hefs.png' as hefs_link,
+		to_char(NOW(), 'YYYY-MM-DD HH24:MI:SS UTC') as update_time
+	FROM flood_data_base base
+	LEFT JOIN forecast_initial_status initial
+		ON initial.lid = base.lid AND initial.pe = base.pe
+	LEFT JOIN forecast_min_status min
+		ON min.lid = base.lid AND min.pe = base.pe
+	LEFT JOIN forecast_point_xwalk xwalk
+		ON xwalk.nws_station_id = base.lid
+	LEFT JOIN relevant_thresholds cats
+		ON cats.lid = base.lid AND cats.units = base.units
+	ORDER BY nws_lid
+)
+
+SELECT *
 INTO publish.rfc_max_forecast
-FROM ingest.ahps_metadata as metadata
-JOIN max_stage ON max_stage.nws_lid = metadata.nws_lid
-JOIN min_stage ON min_stage.nws_lid = metadata.nws_lid
-JOIN initial_stage ON initial_stage.nws_lid = metadata.nws_lid
-WHERE metadata."issuedTime"::timestamp without time zone > ('1900-01-01 00:00:00'::timestamp without time zone - INTERVAL '26 hours') AND metadata.nws_lid NOT IN (SELECT nws_lid FROM derived.ahps_restricted_sites);
+FROM service_data;

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/rfc/rfc_max_forecast.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/rfc/rfc_max_forecast.sql
@@ -1,3 +1,27 @@
+/*
+Most column names of the WRDS forecast database tables follow the SHEF Code naming conventions. These are largely clear
+and understood for those largely unfamiliar with the conventions. However, there are a few single- or double-digit
+column names that would be near impossible to discern for first-time viewers. Namely: "pe", "d", "t", "s", "e", and "p".
+These are explained below in an excerpt from the SHEF Code Manual (see 
+https://www.weather.gov/media/mdl/SHEF_CodeManual_5July2012.pdf).
+
+In SHEF messages, different types of data are keyed by a sevencharacter parameter code represented 
+by the character string “PEDTSEP.” The string is broken down as follows:
+
+PE = Physical Element (gage height, precipitation, etc.)
+D = Duration Code (instantaneous, hourly, daily, etc.)
+T = Type Code (observed, forecast, etc.)
+S = Source Code (a further refinement of type code which may indicate how data was
+created or transmitted)
+E = Extremum Code (maximum, minimum, etc.)
+P = Probability Code (90 percent, 10 percent, etc.)
+
+The parameter code string, when fully specified, contains six keys for database identification. In
+order to reduce manual entry and communications requirements, standard defaults for each key
+(except PE) reduce identification of most hydrometeorological data to a minimum key of two
+characters. The full key is used primarily in the transmission of unique hydrometeorological data.
+*/
+
 DROP TABLE IF EXISTS publish.rfc_max_forecast;
 
 WITH

--- a/Core/LAMBDA/viz_functions/viz_initialize_pipeline/lambda_function.py
+++ b/Core/LAMBDA/viz_functions/viz_initialize_pipeline/lambda_function.py
@@ -185,6 +185,8 @@ class viz_lambda_pipeline:
             if self.start_event.get('reference_time'):
                 self.reference_time = datetime.datetime.strptime(self.start_event.get('reference_time'), '%Y-%m-%d %H:%M:%S')
                 self.configuration = configuration(start_event.get('configuration'), reference_time=self.reference_time, input_bucket=start_event.get('bucket'))
+            elif self.start_event.get('configuration') and self.start_event.get('configuration') == 'rfc':
+                self.configuration = configuration('rfc', reference_time=datetime.datetime.utcnow().replace(second=0, microsecond=0))
             # If no reference time was specified, we get the most recent file available on S3 for the specified configruation, and use that.
             else:
                 most_recent_file = s3_file.get_most_recent_from_configuration(configuration_name=start_event.get('configuration'), bucket=start_event.get('bucket'))

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/rfc/rfc_max_forecast.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/rfc/rfc_max_forecast.mapx
@@ -7,10 +7,9 @@
     "name" : "RFC Max Stage Forecast",
     "uRI" : "CIMPATH=map/map.xml",
     "sourceModifiedTime" : {
-      "type" : "TimeInstant",
-      "start" : 978307200000
+      "type" : "TimeInstant"
     },
-    "metadataURI" : "CIMPATH=Metadata/5c375a972b3700d71bdd0b258872d95d.xml",
+    "metadataURI" : "CIMPATH=Metadata/09f79039c3172d78e1f15353d35d1bf8.xml",
     "useSourceMetadata" : true,
     "illumination" : {
       "type" : "CIMIlluminationProperties",
@@ -27,78 +26,18 @@
     },
     "layers" : [
       "CIMPATH=rfc_max_forecast_forecast/max_status___forecast_trend.xml",
-      "CIMPATH=ahps_max_stage_forecast/maximum_status___forecast_trend.xml"
+      "CIMPATH=ahps_max_value_forecast/maximum_status___forecast_trend.xml"
     ],
     "defaultViewingMode" : "Map",
     "mapType" : "Map",
-    "customFullExtent" : {
-      "rings" : [
-        [
-          [
-            1461297.49225695338,
-            -681897.843323865905
-          ],
-          [
-            2885768.27730376506,
-            1597768.26308573037
-          ],
-          [
-            7179521.98532605823,
-            824373.868930706754
-          ],
-          [
-            7719043.36909858882,
-            -1809048.09699437954
-          ],
-          [
-            1461297.49225695338,
-            -681897.843323865905
-          ]
-        ]
-      ],
-      "spatialReference" : {
-        "wkid" : 3587,
-        "latestWkid" : 3587
-      }
-    },
-    "datumTransforms" : [
-      {
-        "type" : "CIMDatumTransform",
-        "forward" : true,
-        "geoTransformation" : {
-          "geoTransforms" : [
-            {
-              "wkid" : 15931,
-              "latestWkid" : 15931,
-              "transformForward" : false,
-              "name" : "NAD_1983_NSRS2007_To_WGS_1984_1"
-            }
-          ]
-        }
-      },
-      {
-        "type" : "CIMDatumTransform",
-        "forward" : false,
-        "geoTransformation" : {
-          "geoTransforms" : [
-            {
-              "wkid" : 15931,
-              "latestWkid" : 15931,
-              "transformForward" : false,
-              "name" : "NAD_1983_NSRS2007_To_WGS_1984_1"
-            }
-          ]
-        }
-      }
-    ],
     "defaultExtent" : {
-      "xmin" : 2067455.53342193644,
-      "ymin" : -1886735.70271008671,
-      "xmax" : 7700296.5388222253,
-      "ymax" : 2079032.8727831312,
+      "xmin" : -14653391.4020208828,
+      "ymin" : 903438.768891409971,
+      "xmax" : -6739868.60789241642,
+      "ymax" : 8184582.38302292768,
       "spatialReference" : {
-        "wkid" : 3587,
-        "latestWkid" : 3587
+        "wkid" : 102100,
+        "latestWkid" : 3857
       }
     },
     "elevationSurfaces" : [
@@ -107,7 +46,7 @@
         "elevationMode" : "BaseGlobeSurface",
         "name" : "Ground",
         "verticalExaggeration" : 1,
-        "mapElevationID" : "{BA983530-794C-4D31-A84A-05EA0F26A66A}",
+        "mapElevationID" : "{F2DDA1E7-58A6-4E30-BF89-9E14A119E929}",
         "color" : {
           "type" : "CIMRGBColor",
           "values" : [
@@ -157,8 +96,8 @@
       "isZSnappingEnabled" : true
     },
     "spatialReference" : {
-      "wkid" : 3587,
-      "latestWkid" : 3587
+      "wkid" : 102100,
+      "latestWkid" : 3857
     },
     "timeDisplay" : {
       "type" : "CIMMapTimeDisplay",
@@ -192,7 +131,7 @@
       "description" : "egdb.hydrovis.Maximum Status - Forecast Trend",
       "layerElevation" : {
         "type" : "CIMLayerElevationSurface",
-        "mapElevationID" : "{BA983530-794C-4D31-A84A-05EA0F26A66A}"
+        "mapElevationID" : "{F2DDA1E7-58A6-4E30-BF89-9E14A119E929}"
       },
       "expanded" : true,
       "layerType" : "Operational",
@@ -243,7 +182,7 @@
           {
             "type" : "CIMFieldDescription",
             "alias" : "USGS Site Code",
-            "fieldName" : "usgs_sitecode",
+            "fieldName" : "usgs_site_code",
             "visible" : true,
             "searchMode" : "Exact"
           },
@@ -360,7 +299,7 @@
           {
             "type" : "CIMFieldDescription",
             "alias" : "Forecast Initial Stage",
-            "fieldName" : "initial_stage",
+            "fieldName" : "initial_value",
             "numberFormat" : {
               "type" : "CIMNumericFormat",
               "alignmentOption" : "esriAlignRight",
@@ -381,14 +320,14 @@
           {
             "type" : "CIMFieldDescription",
             "alias" : "Forecast Initial Stage Timestep",
-            "fieldName" : "initial_stage_timestep",
+            "fieldName" : "initial_value_timestep",
             "visible" : true,
             "searchMode" : "Exact"
           },
           {
             "type" : "CIMFieldDescription",
             "alias" : "Forecast Min Stage",
-            "fieldName" : "min_stage",
+            "fieldName" : "min_value",
             "numberFormat" : {
               "type" : "CIMNumericFormat",
               "alignmentOption" : "esriAlignRight",
@@ -410,14 +349,14 @@
           {
             "type" : "CIMFieldDescription",
             "alias" : "Forecast Min Stage Timestep",
-            "fieldName" : "min_stage_timestep",
+            "fieldName" : "min_value_timestep",
             "visible" : true,
             "searchMode" : "Exact"
           },
           {
             "type" : "CIMFieldDescription",
             "alias" : "Forecast Max Stage",
-            "fieldName" : "max_stage",
+            "fieldName" : "max_value",
             "numberFormat" : {
               "type" : "CIMNumericFormat",
               "alignmentOption" : "esriAlignRight",
@@ -439,7 +378,7 @@
           {
             "type" : "CIMFieldDescription",
             "alias" : "Forecast Max Stage Timestep",
-            "fieldName" : "max_stage_timestep",
+            "fieldName" : "max_value_timestep",
             "visible" : true,
             "searchMode" : "Exact"
           },
@@ -453,7 +392,7 @@
           {
             "type" : "CIMFieldDescription",
             "alias" : "Record Forecast",
-            "fieldName" : "record_forecast",
+            "fieldName" : "is_record_forecast",
             "visible" : true,
             "searchMode" : "Exact"
           },
@@ -502,11 +441,11 @@
         ],
         "dataConnection" : {
           "type" : "CIMSqlQueryDataConnection",
-          "workspaceConnectionString" : "SERVER=rds-egis.hydrovis.internal;INSTANCE=sde:postgresql:rds-egis.hydrovis.internal;DBCLIENT=postgresql;DB_CONNECTION_PROPERTIES=rds-egis.hydrovis.internal;DATABASE=hydrovis;USER=hydrovis;AUTHENTICATION_MODE=DBMS",
+          "workspaceConnectionString" : "ENCRYPTED_PASSWORD=00022e6867502f493636474b764d76564c4c5043476a7378625171366a484733715648483632694531386970514d7544454e737878675254745a356232396c714c5561552a00;SERVER=rds-egis.hydrovis.internal;INSTANCE=sde:postgresql:rds-egis.hydrovis.internal;DBCLIENT=postgresql;DB_CONNECTION_PROPERTIES=rds-egis.hydrovis.internal;DATABASE=hydrovis;USER=hydrovis;AUTHENTICATION_MODE=DBMS",
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.services.%Maximum Status - Forecast Trend_1_1_1_1_1",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select nws_lid,initial_stage,initial_status,initial_stage_timestep,min_stage,min_status,min_stage_timestep,max_stage,max_status,max_stage_timestep,forecast_trend,producer,issuer,issued_time,generation_time,usgs_sitecode,feature_id::text,nws_name,usgs_name,geom,action_threshold,minor_threshold,moderate_threshold,major_threshold,CASE WHEN record_forecast IS true THEN 'true'::TEXT ELSE 'false'::TEXT END AS record_forecast,record_threshold,units,hydrograph_link,hefs_link,update_time,oid from hydrovis.services.rfc_max_forecast",
+          "sqlQuery" : "select nws_lid,initial_value,initial_status,initial_value_timestep,min_value,min_status,min_value_timestep,max_value,max_status,max_value_timestep,forecast_trend,producer,issuer,issued_time,generation_time,usgs_site_code,feature_id::text,nws_name,usgs_name,geom,action_threshold,minor_threshold,moderate_threshold,major_threshold,CASE WHEN is_record_forecast IS true THEN 'true'::TEXT ELSE 'false'::TEXT END AS is_record_forecast,record_threshold,units,hydrograph_link,hefs_link,update_time,oid from hydrovis.services.rfc_max_forecast",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -522,9 +461,9 @@
               "length" : 5
             },
             {
-              "name" : "initial_stage",
+              "name" : "initial_value",
               "type" : "esriFieldTypeDouble",
-              "alias" : "initial_stage"
+              "alias" : "initial_value"
             },
             {
               "name" : "initial_status",
@@ -533,15 +472,15 @@
               "length" : 15
             },
             {
-              "name" : "initial_stage_timestep",
+              "name" : "initial_value_timestep",
               "type" : "esriFieldTypeString",
-              "alias" : "initial_stage_timestep",
+              "alias" : "initial_value_timestep",
               "length" : 25
             },
             {
-              "name" : "min_stage",
+              "name" : "min_value",
               "type" : "esriFieldTypeDouble",
-              "alias" : "min_stage"
+              "alias" : "min_value"
             },
             {
               "name" : "min_status",
@@ -550,15 +489,15 @@
               "length" : 15
             },
             {
-              "name" : "min_stage_timestep",
+              "name" : "min_value_timestep",
               "type" : "esriFieldTypeString",
-              "alias" : "min_stage_timestep",
+              "alias" : "min_value_timestep",
               "length" : 25
             },
             {
-              "name" : "max_stage",
+              "name" : "max_value",
               "type" : "esriFieldTypeDouble",
-              "alias" : "max_stage"
+              "alias" : "max_value"
             },
             {
               "name" : "max_status",
@@ -567,9 +506,9 @@
               "length" : 15
             },
             {
-              "name" : "max_stage_timestep",
+              "name" : "max_value_timestep",
               "type" : "esriFieldTypeString",
-              "alias" : "max_stage_timestep",
+              "alias" : "max_value_timestep",
               "length" : 25
             },
             {
@@ -603,9 +542,9 @@
               "length" : 25
             },
             {
-              "name" : "usgs_sitecode",
+              "name" : "usgs_site_code",
               "type" : "esriFieldTypeString",
-              "alias" : "usgs_sitecode",
+              "alias" : "usgs_site_code",
               "length" : 25
             },
             {
@@ -662,9 +601,9 @@
               "alias" : "major_threshold"
             },
             {
-              "name" : "record_forecast",
+              "name" : "is_record_forecast",
               "type" : "esriFieldTypeString",
-              "alias" : "record_forecast",
+              "alias" : "is_record_forecast",
               "length" : 60000
             },
             {
@@ -2319,7 +2258,7 @@
     {
       "type" : "CIMFeatureLayer",
       "name" : "Record Forecasts",
-      "uRI" : "CIMPATH=ahps_max_stage_forecast/maximum_status___forecast_trend.xml",
+      "uRI" : "CIMPATH=ahps_max_value_forecast/maximum_status___forecast_trend.xml",
       "sourceModifiedTime" : {
         "type" : "TimeInstant",
         "start" : 978307200000
@@ -2329,7 +2268,7 @@
       "description" : "egdb.hydrovis.Maximum Status - Forecast Trend",
       "layerElevation" : {
         "type" : "CIMLayerElevationSurface",
-        "mapElevationID" : "{BA983530-794C-4D31-A84A-05EA0F26A66A}"
+        "mapElevationID" : "{F2DDA1E7-58A6-4E30-BF89-9E14A119E929}"
       },
       "expanded" : true,
       "layerType" : "Operational",
@@ -2346,13 +2285,13 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "definitionExpression" : "record_forecast = 'true'",
+        "definitionExpression" : "is_record_forecast = 'true'",
         "definitionExpressionName" : "Query 1",
         "definitionFilterChoices" : [
           {
             "type" : "CIMDefinitionFilter",
             "name" : "Query 1",
-            "definitionExpression" : "record_forecast = 'true'"
+            "definitionExpression" : "is_record_forecast = 'true'"
           }
         ],
         "displayField" : "nws_name",
@@ -2389,7 +2328,7 @@
           {
             "type" : "CIMFieldDescription",
             "alias" : "USGS Site Code",
-            "fieldName" : "usgs_sitecode",
+            "fieldName" : "usgs_site_code",
             "visible" : true,
             "searchMode" : "Exact"
           },
@@ -2506,7 +2445,7 @@
           {
             "type" : "CIMFieldDescription",
             "alias" : "Forecast Initial Stage",
-            "fieldName" : "initial_stage",
+            "fieldName" : "initial_value",
             "numberFormat" : {
               "type" : "CIMNumericFormat",
               "alignmentOption" : "esriAlignRight",
@@ -2527,14 +2466,14 @@
           {
             "type" : "CIMFieldDescription",
             "alias" : "Forecast Initial Stage Timestep",
-            "fieldName" : "initial_stage_timestep",
+            "fieldName" : "initial_value_timestep",
             "visible" : true,
             "searchMode" : "Exact"
           },
           {
             "type" : "CIMFieldDescription",
             "alias" : "Forecast Min Stage",
-            "fieldName" : "min_stage",
+            "fieldName" : "min_value",
             "numberFormat" : {
               "type" : "CIMNumericFormat",
               "alignmentOption" : "esriAlignRight",
@@ -2556,14 +2495,14 @@
           {
             "type" : "CIMFieldDescription",
             "alias" : "Forecast Min Stage Timestep",
-            "fieldName" : "min_stage_timestep",
+            "fieldName" : "min_value_timestep",
             "visible" : true,
             "searchMode" : "Exact"
           },
           {
             "type" : "CIMFieldDescription",
             "alias" : "Forecast Max Stage",
-            "fieldName" : "max_stage",
+            "fieldName" : "max_value",
             "numberFormat" : {
               "type" : "CIMNumericFormat",
               "alignmentOption" : "esriAlignRight",
@@ -2585,7 +2524,7 @@
           {
             "type" : "CIMFieldDescription",
             "alias" : "Forecast Max Stage Timestep",
-            "fieldName" : "max_stage_timestep",
+            "fieldName" : "max_value_timestep",
             "visible" : true,
             "searchMode" : "Exact"
           },
@@ -2599,7 +2538,7 @@
           {
             "type" : "CIMFieldDescription",
             "alias" : "Record Forecast",
-            "fieldName" : "record_forecast",
+            "fieldName" : "is_record_forecast",
             "visible" : true,
             "searchMode" : "Exact"
           },
@@ -2648,11 +2587,11 @@
         ],
         "dataConnection" : {
           "type" : "CIMSqlQueryDataConnection",
-          "workspaceConnectionString" : "SERVER=hv-ti-egis-rds-pg-egdb.c4vzypepnkx3.us-east-1.rds.amazonaws.com;INSTANCE=sde:postgresql:hv-ti-egis-rds-pg-egdb.c4vzypepnkx3.us-east-1.rds.amazonaws.com;DBCLIENT=postgresql;DB_CONNECTION_PROPERTIES=hv-ti-egis-rds-pg-egdb.c4vzypepnkx3.us-east-1.rds.amazonaws.com;DATABASE=hydrovis;USER=hydrovis;AUTHENTICATION_MODE=DBMS",
+          "workspaceConnectionString" : "ENCRYPTED_PASSWORD=00022e6867502f493636474b764d76564c4c5043476a7378625171366a484733715648483632694531386970514d7544454e737878675254745a356232396c714c5561552a00;SERVER=rds-egis.hydrovis.internal;INSTANCE=sde:postgresql:rds-egis.hydrovis.internal;DBCLIENT=postgresql;DB_CONNECTION_PROPERTIES=rds-egis.hydrovis.internal;DATABASE=hydrovis;USER=hydrovis;AUTHENTICATION_MODE=DBMS",
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.services.%Maximum Status - Forecast Trend_1_1_1_1_1",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select nws_lid,initial_stage,initial_status,initial_stage_timestep,min_stage,min_status,min_stage_timestep,max_stage,max_status,max_stage_timestep,forecast_trend,producer,issuer,issued_time,generation_time,usgs_sitecode,feature_id::text,nws_name,usgs_name,geom,action_threshold,minor_threshold,moderate_threshold,major_threshold,CASE WHEN record_forecast IS true THEN 'true'::TEXT ELSE 'false'::TEXT END AS record_forecast,record_threshold,units,hydrograph_link,hefs_link,update_time,oid from hydrovis.services.rfc_max_forecast",
+          "sqlQuery" : "select nws_lid,initial_value,initial_status,initial_value_timestep,min_value,min_status,min_value_timestep,max_value,max_status,max_value_timestep,forecast_trend,producer,issuer,issued_time,generation_time,usgs_site_code,feature_id::text,nws_name,usgs_name,geom,action_threshold,minor_threshold,moderate_threshold,major_threshold,CASE WHEN is_record_forecast IS true THEN 'true'::TEXT ELSE 'false'::TEXT END AS is_record_forecast,record_threshold,units,hydrograph_link,hefs_link,update_time,oid from hydrovis.services.rfc_max_forecast",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -2668,9 +2607,9 @@
               "length" : 5
             },
             {
-              "name" : "initial_stage",
+              "name" : "initial_value",
               "type" : "esriFieldTypeDouble",
-              "alias" : "initial_stage"
+              "alias" : "initial_value"
             },
             {
               "name" : "initial_status",
@@ -2679,15 +2618,15 @@
               "length" : 15
             },
             {
-              "name" : "initial_stage_timestep",
+              "name" : "initial_value_timestep",
               "type" : "esriFieldTypeString",
-              "alias" : "initial_stage_timestep",
+              "alias" : "initial_value_timestep",
               "length" : 25
             },
             {
-              "name" : "min_stage",
+              "name" : "min_value",
               "type" : "esriFieldTypeDouble",
-              "alias" : "min_stage"
+              "alias" : "min_value"
             },
             {
               "name" : "min_status",
@@ -2696,15 +2635,15 @@
               "length" : 15
             },
             {
-              "name" : "min_stage_timestep",
+              "name" : "min_value_timestep",
               "type" : "esriFieldTypeString",
-              "alias" : "min_stage_timestep",
+              "alias" : "min_value_timestep",
               "length" : 25
             },
             {
-              "name" : "max_stage",
+              "name" : "max_value",
               "type" : "esriFieldTypeDouble",
-              "alias" : "max_stage"
+              "alias" : "max_value"
             },
             {
               "name" : "max_status",
@@ -2713,9 +2652,9 @@
               "length" : 15
             },
             {
-              "name" : "max_stage_timestep",
+              "name" : "max_value_timestep",
               "type" : "esriFieldTypeString",
-              "alias" : "max_stage_timestep",
+              "alias" : "max_value_timestep",
               "length" : 25
             },
             {
@@ -2749,9 +2688,9 @@
               "length" : 25
             },
             {
-              "name" : "usgs_sitecode",
+              "name" : "usgs_site_code",
               "type" : "esriFieldTypeString",
-              "alias" : "usgs_sitecode",
+              "alias" : "usgs_site_code",
               "length" : 25
             },
             {
@@ -2808,9 +2747,9 @@
               "alias" : "major_threshold"
             },
             {
-              "name" : "record_forecast",
+              "name" : "is_record_forecast",
               "type" : "esriFieldTypeString",
-              "alias" : "record_forecast",
+              "alias" : "is_record_forecast",
               "length" : 5
             },
             {
@@ -3513,8 +3452,8 @@
   "binaryReferences" : [
     {
       "type" : "CIMBinaryReference",
-      "uRI" : "CIMPATH=Metadata/5c375a972b3700d71bdd0b258872d95d.xml",
-      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20220209</CreaDate><CreaTime>17051700</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>Map</resTitle></idCitation></dataIdInfo><Binary><Thumbnail><Data EsriPropertyType=\"PictureX\">/9j/4AAQSkZJRgABAQEAAAAAAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a\r\nHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy\r\nMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCADIASwDAREA\r\nAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA\r\nAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3\r\nODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm\r\np6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA\r\nAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx\r\nBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK\r\nU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3\r\nuLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3+gAo\r\nAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgA\r\noAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgDzabxh4p/tuWwisdJ8xb4WqW7SS+\r\naUJJEnQDGwFs+xFcTxbWKWH5Hte+lrFcvu81z0mu0kKACgAoAKACgAoAKACgAoAKACgAoAKACgAo\r\nAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAz20bT5NbTWGtIzqCQm3W4x8wjz\r\nnb9Mk/mfWgDQoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAo\r\nAKACgAoAKACgAoAKACgBrEhSVALY4BOM0AeZT/FDULS2tJrnw/An2iUw+UupbpI2Bwd48rC4OAST\r\njketecsxpurUpcsrwV3pp8tdTWNJyaSe5raV48u7/XrTS5dBeBrncfMW7WTYqjJYjA46D8RV4TMa\r\nOKbVO+nka4jCVMOk59Tua7jlCgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgA\r\noAKACgAoAKACgAoAKACgAoA5vxXr9x4d0+3uoLFLlZJhC7SSlFiyDgsQrHBOB06kVlXqKlTc2m7d\r\nty6VP2k1BO1+55HqeqTL4ovZtZurq3iu4zcQRWuq3JEe1QCmAUGCclQB6ivBrZhiMTFTwTas0mml\r\n169fmerTwlKi+XE2fVavp9x6x4G0m60nw1El7PcSXNwxuZFuJ3lMRYDCAuScAAd+uT3r6CCkopTd\r\n33PJm05NxVkTXHg7Rbm61eeW0DSatD5F0dx5XGMqP4SeMkd1B7VVluSVPCXhFvD0l1c3t2b6+mPl\r\nJOw5SBSdq+xOcsR1OPQVz4fC0sPFxpKybubVq86zTmzra6TEKACgAoAKACgAoAKACgAoAKACgAoA\r\nKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKAK8t3bQMFmuIo2IyA7gH9aAGXlra6rps1\r\nrOqTWtzGUcdQykUbgc14Z8EW2i2cq6g8ep3kkyP9omiB2iPHlBQc4243Z/vEmsaFGnRjyU1Zb/ea\r\nVas6suabOwrYzCgDzLxTqnibTvEc2nWuqTRy36K2kxx2sTIzZ2urllJGzKsTn7p9q4MTLFRrU/Yp\r\nOD+K/T/hyly2dz0a2SSO1iSaTzZVQB327dzY5OO2a7ySegAoAKACgAoAKACgAoAKACgAoAKACgAo\r\nAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAy113TX199FFyp1BIfPaHB4TOM56Z5HHXkUrq9gNS\r\nmBwvjTw3d3+oW+oabYW15cPF9jmFxtxGhbKyjd12EsSByQe9efj8H9aUUpuNnfTquqLhLlOr0jTY\r\ndI0i006D/VW0SxqT3wOtegtCC/QAUAFAEbRozqzIpZfukjkfSgDhvE/iXUrTxC+m2epWOmRW9mLs\r\ny3sJYTklhtByAFGBnHPzDFeVmWPng+TkpufM7adDSEFK92dP4b1ObWfDWm6ncW/2ea7to5nj/ull\r\nB/KvVMzWoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoA8/g\r\n8CarFe21y+uW/mw3zXrXC2jec5bIZSxkI2lDtxtwAB6VwxwUY4l4nnd2rW0tb0t+pXN7vKdvdz/Z\r\nbOe4EUk3lRs4jiG5nwM4A7k13EnnHgvV9WbxMBd2Gut/aitJdNd2M0UNtKu5l2s6gBduEwOpVT3N\r\ncOHniXUqe2jaN/d1W3n+fzKly2Vj1Cu4kKACgAoAKAKd5plhqOz7bZwXPlnKedGG2n2zQBbAAAAG\r\nAKAFoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoA\r\nKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAo\r\nAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgA\r\noAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACg\r\nAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKAC\r\ngAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgBpIAJJwB1JoAzdM1/SNZeZNN1O0vHhOJBBMrlfrj\r\nt70AalABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAF\r\nABQAUAFABQAUAZ+tae2q6Jfaesxha6geESAZ27gRn9aAOR8M+GNZtvEFrqOqW+nWSWFm9nEunyM3\r\n2jcVJZgVXao25C88nPbnzMvy36k6kudy5nfXoXOfNbQ76vTICgAoAKACgAoAKACgAoAKACgAoAKA\r\nCgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoA4Lxlr+r6DqQZbyO3sZbf/RsWwkaScZ/dcsOW\r\n+Xbx61wYytiKXJ7CCld2fl5+ncqKT3Ou0f8AtD+x7T+1TEdQMS/aPKGF345xXeSX6ACgAoAKACgA\r\noAKAOF8aa3qehahDKt/9l02WBgrLbCQmcHhMnoWB49wa4MdVxNKMXhoKTbs79L9SoqL3On0P+0Do\r\nlmdWZGv2iDT7F2gMecY9ume+M8V3K9tSTTpgFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQA\r\nUAFABQAUAFABQAUAFABQBBPbwT7PPhjk8txIm9Q21h0YZ6EetAE9ABQAUAFABQAUAFABQBFLDHMm\r\nyWNXXIO1hkZByD+dAEtABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFA\r\nBQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAF\r\nABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUA\r\nFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAU\r\nAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQA\r\nUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQ\r\nAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFAB\r\nQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFA\r\nBQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAF\r\nABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUA\r\nFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAU\r\nAFABQAUAFABQAUAFABQAUAFABQAUAFABQBxfjW+1HSjZXy39xa6Uu6O7e2jRnRjjYx3K2V4KnpyR\r\nXDjpYmNFywyTkuj6r5NFRUW/eNbwmNVPh22l1idpLybMp3qAyKxyinAAyFwDx1zXXDm5Vz79fUlm\r\n9Vgf/9k=</Data></Thumbnail></Binary></metadata>\r\n"
+      "uRI" : "CIMPATH=Metadata/09f79039c3172d78e1f15353d35d1bf8.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20231221</CreaDate><CreaTime>21165500</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>Map</resTitle></idCitation></dataIdInfo></metadata>\r\n"
     },
     {
       "type" : "CIMBinaryReference",

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/rfc/rfc_max_forecast.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/rfc/rfc_max_forecast.mapx
@@ -4,7 +4,7 @@
   "build" : 26828,
   "mapDefinition" : {
     "type" : "CIMMap",
-    "name" : "RFC Max Stage Forecast",
+    "name" : "RFC Max Value Forecast",
     "uRI" : "CIMPATH=map/map.xml",
     "sourceModifiedTime" : {
       "type" : "TimeInstant"
@@ -298,7 +298,7 @@
           },
           {
             "type" : "CIMFieldDescription",
-            "alias" : "Forecast Initial Stage",
+            "alias" : "Forecast Initial Value",
             "fieldName" : "initial_value",
             "numberFormat" : {
               "type" : "CIMNumericFormat",
@@ -319,14 +319,14 @@
           },
           {
             "type" : "CIMFieldDescription",
-            "alias" : "Forecast Initial Stage Timestep",
+            "alias" : "Forecast Initial Value Timestep",
             "fieldName" : "initial_value_timestep",
             "visible" : true,
             "searchMode" : "Exact"
           },
           {
             "type" : "CIMFieldDescription",
-            "alias" : "Forecast Min Stage",
+            "alias" : "Forecast Min Value",
             "fieldName" : "min_value",
             "numberFormat" : {
               "type" : "CIMNumericFormat",
@@ -348,14 +348,14 @@
           },
           {
             "type" : "CIMFieldDescription",
-            "alias" : "Forecast Min Stage Timestep",
+            "alias" : "Forecast Min Value Timestep",
             "fieldName" : "min_value_timestep",
             "visible" : true,
             "searchMode" : "Exact"
           },
           {
             "type" : "CIMFieldDescription",
-            "alias" : "Forecast Max Stage",
+            "alias" : "Forecast Max Value",
             "fieldName" : "max_value",
             "numberFormat" : {
               "type" : "CIMNumericFormat",
@@ -377,7 +377,7 @@
           },
           {
             "type" : "CIMFieldDescription",
-            "alias" : "Forecast Max Stage Timestep",
+            "alias" : "Forecast Max Value Timestep",
             "fieldName" : "max_value_timestep",
             "visible" : true,
             "searchMode" : "Exact"
@@ -2444,7 +2444,7 @@
           },
           {
             "type" : "CIMFieldDescription",
-            "alias" : "Forecast Initial Stage",
+            "alias" : "Forecast Initial Value",
             "fieldName" : "initial_value",
             "numberFormat" : {
               "type" : "CIMNumericFormat",
@@ -2465,14 +2465,14 @@
           },
           {
             "type" : "CIMFieldDescription",
-            "alias" : "Forecast Initial Stage Timestep",
+            "alias" : "Forecast Initial Value Timestep",
             "fieldName" : "initial_value_timestep",
             "visible" : true,
             "searchMode" : "Exact"
           },
           {
             "type" : "CIMFieldDescription",
-            "alias" : "Forecast Min Stage",
+            "alias" : "Forecast Min Value",
             "fieldName" : "min_value",
             "numberFormat" : {
               "type" : "CIMNumericFormat",
@@ -2494,14 +2494,14 @@
           },
           {
             "type" : "CIMFieldDescription",
-            "alias" : "Forecast Min Stage Timestep",
+            "alias" : "Forecast Min Value Timestep",
             "fieldName" : "min_value_timestep",
             "visible" : true,
             "searchMode" : "Exact"
           },
           {
             "type" : "CIMFieldDescription",
-            "alias" : "Forecast Max Stage",
+            "alias" : "Forecast Max Value",
             "fieldName" : "max_value",
             "numberFormat" : {
               "type" : "CIMNumericFormat",
@@ -2523,7 +2523,7 @@
           },
           {
             "type" : "CIMFieldDescription",
-            "alias" : "Forecast Max Stage Timestep",
+            "alias" : "Forecast Max Value Timestep",
             "fieldName" : "max_value_timestep",
             "visible" : true,
             "searchMode" : "Exact"


### PR DESCRIPTION
This PR, if merged, will replace the existing "rfc_max_forecast" service with a new version of the service whose backend data is now produced by direct access to the WRDS RFC Forecast database as opposed to the WRDS API. As a result:

* The `every_five_minute` EventBridge rule that triggered the `viz-wrds-api-handler` Lambda has been modified to instead trigger the `initialize-viz-pipeline` Lambda directly. The viz-wrds-api-handler code is now deprecated and can be eventually removed.
  * The `initialize-viz-pipeline` Lambda code had to be modified to allow the "rfc" pipeline to be kicked off without referencing any input files - as there are none. This allows it to act on more of a "cron" basis and less of a "file-driven-event" basis.
* The new `products/rfc/rfc_max_forecast.sql` query relies upon a few new database structures:
  * Two new ENUM types - `flood_status` and `forecast_ts` - are used for assigning trend and prioritizing "duplicate" forecasts. These are now created in the RDS Bastion `postgresql_setup.sh.tftpl` script.
  * Two new database views - `rnr.stage_thresholds` and `rnr.flow_thresholds` - reorganize data in the external/foreign WRDS Ingest DB threshold table (external.threshold) for more efficient use here and eventually in other places (e.g. RnR). The SQL for these views was committed for the record in the `Core/LAMBDA/rnr_functions/rnr_domain_generator/sql/dba_stuff.sql` file, but I believe this view should get copied over with the dump of the RnR schema on deployments and thus should not need to be recreated manually.
* Forecasts that are distributed as flow-only (i.e. have no associated rating curve to produce stage) are now also included as a value-added win (addressing issue #312). As a result of this:
  * The DB table produced by `rfc_max_forecast.sql` has new/modified column names, replacing every occurrence of "stage" with "value" (i.e. `max_stage_timestamp` to `max_value_timestamp`).
    * The  `rfc_max_forecast.mapx` file was thus also modified to replace every occurrence of "stage" with "value" in both the "fieldName" and "alias" fields (i.e. `max_stage_timestamp` to `max_value_timestamp` and "Forecast Min Stage Timestamp" to "Forecast Min Value Timestamp")

This work will also allow the Replace and Route to be somewhat redesigned to be completely in-sync with this new rfc_max_forecast service - likely using the underlying `publish.rfc_max_forecast` table as its starting point.