### PR TITLE
Updates rnr to rely upon rfc_max_forecast service

### DIFF
--- a/Core/LAMBDA/rnr_functions/rnr_domain_generator/sql/domain.sql
+++ b/Core/LAMBDA/rnr_functions/rnr_domain_generator/sql/domain.sql
@@ -1,92 +1,112 @@
 ----------------------------------------------------------------
 ----------------------------------------------------------------
--- GET ALL FLOW FORECASTS (NATIVE AND RATING-CURVE CONVERTED) --
+---------------- MAKE COPY OF RFC_MAX_FOREACST -----------------
 ----------------------------------------------------------------
 ----------------------------------------------------------------
+-- This copy is necessary to ensure that the data (e.g. max_status)
+-- stays the same between when it's executed here and then again
+-- from rfc_based_5day_max_streamflow.sql
+DROP TABLE IF EXISTS rnr.rfc_max_forecast_copy;
+SELECT * INTO rnr.rfc_max_forecast_copy FROM publish.rfc_max_forecast;
 
-DROP TABLE IF EXISTS rnr.temporal_domain_flow_forecasts;
+----------------------------------------------------------------
+----------------------------------------------------------------
+------------------ GET ALL RELEVANT FORECASTS ------------------
+----------------------------------------------------------------
+----------------------------------------------------------------
+DROP TABLE IF EXISTS rnr.domain_forecasts;
 
-WITH 
+WITH
 
-ref_time AS (
-	SELECT reference_time
-	FROM ingest.nwm_channel_rt_ana
-	ORDER BY reference_time DESC LIMIT 1
+flood_forecasts AS (
+	SELECT DISTINCT ON (
+		fcst.lid, 
+		fcst.pe, 
+		fcst.d, 
+		fcst.ts, 
+		fcst.e, 
+		fcst.p, 
+		fcst.product_time, 
+		fcst.start_time, 
+		fcst.valid_time
+	)
+		fcst.lid,
+		fcst.product_time,
+		fcst.valid_time,
+		fcst.pe,
+		fcst.ts,
+		fcst.value,
+		fcst.units
+	FROM wrds_rfcfcst.last_forecast_view fcst
+	JOIN rnr.rfc_max_forecast_copy service
+ 		ON service.nws_lid = fcst.lid AND service.pe = fcst.pe 
+ 		AND service.ts = fcst.ts  AND service.issued_time::timestamp with time zone = fcst.product_time
+		AND service.initial_flood_value_timestep::timestamp with time zone <= (SELECT DISTINCT reference_time::timestamp with time zone + INTERVAL '5 days' FROM ingest.nwm_channel_rt_ana)
+	ORDER BY 
+		fcst.lid, 
+		fcst.pe, 
+		fcst.d, 
+		fcst.ts, 
+		fcst.e, 
+		fcst.p, 
+		fcst.product_time DESC, 
+		fcst.start_time, 
+		fcst.valid_time, 
+		fcst.generation_time DESC
 ),
 
-temporal_domain_forecasts AS (
-	SELECT 
-		lid, 
-		pe,
-		pe_priority,
-		product_time,
-		valid_time,
-	CASE 
-		WHEN units = 'KCFS' 
-		THEN value * 1000
-		ELSE value
-	END as value,
-	CASE
-		WHEN units = 'KCFS'
-		THEN 'CFS'
-		ELSE units
-	END AS units
-FROM wrds_rfcfcst.last_generated_forecast_view
-WHERE product_time >= (SELECT reference_time::timestamp with time zone - INTERVAL '24 hours' FROM ref_time)
-	AND (pe LIKE 'H%' OR pe LIKE 'Q%')
-	AND pe != 'QI'
-	AND value > 0
-	AND valid_time >= (SELECT reference_time::timestamp with time zone FROM ref_time)
-	AND valid_time <= (SELECT reference_time::timestamp with time zone + INTERVAL '120 hours' FROM ref_time)
-),
-
-native_flood_forecasts AS (
+native_flow_forecasts AS (
 	SELECT 
 		*
-	FROM temporal_domain_forecasts
+	FROM flood_forecasts
 	WHERE pe LIKE 'Q%'
 ),
 
-native_stage_flood_fcsts AS (
+native_stage_forecasts AS (
 	SELECT 
 		*
-	FROM temporal_domain_forecasts
+	FROM flood_forecasts
 	WHERE pe LIKE 'H%'
-	AND lid NOT IN (SELECT lid FROM native_flood_forecasts)
 ),
 
-flow_fcsts_from_rating_curve AS (
+flow_fcsts_from_usgs_rating_curve AS (
 	SELECT 
 		f.lid,
 		f.product_time,
 		f.valid_time,
-		curve.flow + ((curve.next_higher_point_flow - curve.flow) / (curve.next_higher_point_stage - curve.stage) * (f.value - curve.stage)) as flow_from_curve,
-		f.units, -- CFS
-		f.value as orig_stage,
-		curve.flow as lower_point_flow,
-		curve.next_higher_point_flow as higher_point_flow,
-		curve.stage as lower_point_stage,
-		curve.next_higher_point_stage as higher_point_stage
-	FROM native_stage_flood_fcsts f
-	JOIN (SELECT DISTINCT ON (nws_station_id) * FROM rnr.nwm_crosswalk WHERE gage_id IS NOT NULL) as xwalk
-		ON xwalk.nws_station_id = f.lid
-	JOIN external.rating rating
-		ON rating.location_id = xwalk.gage_id
-	JOIN rnr.staggered_curves curve
-		ON curve.rating_id = rating.rating_id
+		curve.flow + ((curve.next_higher_point_flow - curve.flow) / (curve.next_higher_point_stage - curve.stage) * (f.value - curve.stage)) as flow_from_curve
+	FROM native_stage_forecasts f
+	JOIN rnr.staggered_curves_usgs curve
+		ON curve.nws_station_id = f.lid
 		AND (curve.stage = f.value 
 			OR (curve.stage < f.value 
 				AND curve.next_higher_point_stage > f.value))
 ),
 
-all_flow_forecasts AS (
+flow_fcsts_from_nrldb_rating_curve AS (
+	SELECT 
+		f.lid,
+		f.product_time,
+		f.valid_time,
+		curve.flow + ((curve.next_higher_point_flow - curve.flow) / (curve.next_higher_point_stage - curve.stage) * (f.value - curve.stage)) as flow_from_curve
+	FROM native_stage_forecasts f
+	JOIN rnr.staggered_curves_nrldb curve
+		ON curve.nws_station_id = f.lid
+		AND (curve.stage = f.value 
+			OR (curve.stage < f.value 
+				AND curve.next_higher_point_stage > f.value))
+	WHERE lid NOT IN (SELECT DISTINCT lid FROM flow_fcsts_from_usgs_rating_curve)
+),
+
+domain_forecasts AS (
 	SELECT
 		lid,
 		product_time,
 		valid_time,
-		flow_from_curve as flow_cfs,
-		flow_from_curve * 0.028316847 as flow_cms
-	FROM flow_fcsts_from_rating_curve
+		ROUND(flow_from_curve::numeric) as flow_cfs,
+		ROUND((flow_from_curve * 0.028316847)::numeric) as flow_cms,
+		'USGS' as rating_curve_source
+	FROM flow_fcsts_from_usgs_rating_curve
 
 	UNION
 
@@ -94,186 +114,24 @@ all_flow_forecasts AS (
 		lid,
 		product_time,
 		valid_time,
-		value as flow_cfs,
-		value * 0.028316847 as flow_cms
-	FROM native_flood_forecasts
-	WHERE pe LIKE 'Q%'
-)
+		ROUND(flow_from_curve::numeric) as flow_cfs,
+		ROUND((flow_from_curve * 0.028316847)::numeric) as flow_cms,
+		'NRLDB' as rating_curve_source
+	FROM flow_fcsts_from_nrldb_rating_curve
 
-SELECT 
-    *
-INTO rnr.temporal_domain_flow_forecasts
-FROM all_flow_forecasts;
-
------------------------------------------------------------------
------------------------------------------------------------------
-------------- CREATE DOMAIN LIDS WITH STATUS TABLE  -------------
------------------------------------------------------------------
------------------------------------------------------------------
-
-DROP TABLE IF EXISTS rnr.domain_lids_with_status;
-
-WITH RECURSIVE 
-
-ref_time AS (
-	SELECT reference_time
-	FROM ingest.nwm_channel_rt_ana
-	ORDER BY reference_time DESC LIMIT 1	
-),
-
-max_flow AS (
-	SELECT 
-		lid, 
-		MAX(flow_cfs) as max_flow_cfs
-	FROM rnr.temporal_domain_flow_forecasts
-	GROUP BY lid
-),
-
-max_stage AS (
-	SELECT DISTINCT ON (lid)
-		lid, 
-		MAX(value) as max_stage_ft
-	FROM wrds_rfcfcst.last_generated_forecast_view
-	WHERE product_time >= (SELECT reference_time::timestamp with time zone - INTERVAL '24 hours' FROM ref_time)
-		AND (pe LIKE 'H%' OR pe LIKE 'Q%')
-		AND value > 0
-		AND valid_time >= (SELECT reference_time::timestamp with time zone FROM ref_time)
-		AND valid_time <= (SELECT reference_time::timestamp with time zone + INTERVAL '120 hours' FROM ref_time)
-	GROUP BY lid, pe, pe_priority, units
-	ORDER BY lid, pe_priority
-),
-
-native_threshold AS (
-	SELECT DISTINCT ON (location_id)
-		location_id as nws_station_id,
-		rating_source,
-		action_stage,
-		minor_stage,
-		moderate_stage,
-		major_stage,
-		record_stage,
-		action_flow,
-		minor_flow,
-		moderate_flow,
-		major_flow,
-		record_flow
-	FROM external.threshold
-	WHERE rating_source = 'NONE'
-), usgs_threshold AS (
-	SELECT DISTINCT ON (location_id) 
-		location_id as nws_station_id,
-		rating_source,
-		action_stage,
-		minor_stage,
-		moderate_stage,
-		major_stage,
-		record_stage,
-		action_flow_calc as action_flow,
-		minor_flow_calc as minor_flow,
-		moderate_flow_calc as moderate_flow,
-		major_flow_calc as major_flow,
-		record_flow_calc as record_flow
-	FROM external.threshold
-	WHERE rating_source = 'USGS Rating Depot' AND location_id NOT IN (SELECT nws_station_id FROM native_threshold)
-), nrldb_threshold AS (
-	SELECT DISTINCT ON (location_id)
-		location_id as nws_station_id,
-		rating_source,
-		action_stage,
-		minor_stage,
-		moderate_stage,
-		major_stage,
-		record_stage,
-		action_flow_calc as action_flow,
-		minor_flow_calc as minor_flow,
-		moderate_flow_calc as moderate_flow,
-		major_flow_calc as major_flow,
-		record_flow_calc as record_flow
-	FROM external.threshold
-	WHERE rating_source = 'NRLDB' AND location_id NOT IN (SELECT nws_station_id FROM native_threshold UNION SELECT nws_station_id FROM usgs_threshold)
-), threshold AS (
-	SELECT * FROM native_threshold
 	UNION
-	SELECT * FROM usgs_threshold
-	UNION
-	SELECT * FROM nrldb_threshold
-),
 
-max_status_flow AS (
-	SELECT 
-		lid,
-		CASE
-			WHEN th.major_flow IS NOT NULL AND mf.max_flow_cfs >= th.major_flow
-			THEN 'major'
-			WHEN th.moderate_flow IS NOT NULL AND mf.max_flow_cfs >= th.moderate_flow
-			THEN 'moderate'
-			WHEN th.minor_flow IS NOT NULL AND mf.max_flow_cfs >= th.minor_flow
-			THEN 'minor'
-			WHEN th.action_flow IS NOT NULL AND mf.max_flow_cfs >= th.action_flow
-			THEN 'action'
-			WHEN th.major_flow IS NULL AND th.moderate_flow IS NULL AND th.minor_flow IS NULL AND th.action_flow IS NULL
-			THEN CASE 
-					WHEN th.record_flow IS NOT NULL AND mf.max_flow_cfs >= th.record_flow
-					THEN 'record'
-					ELSE 'all thresholds undefined'
-				 END
-			ELSE 'no flooding'
-		END as status,
-		rating_source
-	FROM max_flow AS mf
-	LEFT JOIN threshold AS th
-		ON th.nws_station_id = mf.lid
-),
-
-max_status_stage AS (
-	SELECT 
-		lid,
-		CASE
-			WHEN th.major_stage IS NOT NULL AND mf.max_stage_ft >= th.major_stage
-			THEN 'major'
-			WHEN th.moderate_stage IS NOT NULL AND mf.max_stage_ft >= th.moderate_stage
-			THEN 'moderate'
-			WHEN th.minor_stage IS NOT NULL AND mf.max_stage_ft >= th.minor_stage
-			THEN 'minor'
-			WHEN th.action_stage IS NOT NULL AND mf.max_stage_ft >= th.action_stage
-			THEN 'action'
-			WHEN th.major_stage IS NULL AND th.moderate_stage IS NULL AND th.minor_stage IS NULL AND th.action_stage IS NULL
-			THEN CASE 
-					WHEN th.record_stage IS NOT NULL AND mf.max_stage_ft >= th.record_stage
-					THEN 'record'
-					ELSE 'all thresholds undefined'
-				 END
-			ELSE 'no flooding'
-		END as status,
-		rating_source
-	FROM max_stage AS mf
-	LEFT JOIN threshold AS th
-		ON th.nws_station_id = mf.lid
-),
-
-lid_status AS (
 	SELECT
 		lid,
-		status,
-		rating_source
-	FROM max_status_stage
-	
-	UNION
-	
-	SELECT
-		lid,
-		status,
-		rating_source
-	FROM max_status_flow
-	WHERE lid NOT IN (SELECT lid FROM max_status_stage)
+		product_time,
+		valid_time,
+		ROUND(value::numeric) as flow_cfs,
+		ROUND((value * 0.028316847)::numeric) as flow_cms,
+		'None' as rating_curve_source
+	FROM native_flow_forecasts
 )
 
-SELECT *
-INTO rnr.domain_lids_with_status
-FROM lid_status
-LEFT JOIN derived.ahps_restricted_sites restricted
-	ON restricted.nws_lid = lid_status.lid
-WHERE restricted.nws_lid IS NULL;
+SELECT * INTO rnr.domain_forecasts FROM domain_forecasts;
 
 -------------------------------------------------------
 -------------------------------------------------------
@@ -283,18 +141,17 @@ WHERE restricted.nws_lid IS NULL;
 
 DROP TABLE IF EXISTS rnr.domain_routelink;
 
-WITH RECURSIVE flood_lid AS (
-	SELECT
-		lid
-	FROM rnr.domain_lids_with_status
-	WHERE status IN ('action', 'minor', 'moderate', 'major')
+WITH RECURSIVE 
+
+flood_lids AS (
+	SELECT DISTINCT lid FROM rnr.domain_forecasts
 ),
 
 flood_xwalk AS (
-    SELECT 
+	SELECT
         flood.lid, 
         xwalk.nwm_feature_id
-    FROM flood_lid flood
+    FROM flood_lids flood
     JOIN rnr.nwm_crosswalk AS xwalk
 		ON xwalk.nws_station_id = flood.lid
 	WHERE xwalk.nws_station_id IS NOT NULL AND xwalk.nwm_feature_id IS NOT NULL
@@ -327,23 +184,6 @@ FROM rnr.nwm_routelink rl
 JOIN downstream_trace tr
 	ON tr.link = rl.link
 ORDER BY order_index;
-
--------------------------------------------------------
--------------------------------------------------------
--------------------------------------------------------
--------------------------------------------------------
--------------------------------------------------------
-
-DROP TABLE IF EXISTS rnr.domain_forecasts;
-
-SELECT DISTINCT ON (fcst.*)
-	fcst.*
-INTO rnr.domain_forecasts
-FROM rnr.temporal_domain_flow_forecasts fcst
-JOIN rnr.nwm_crosswalk xwalk
-	ON xwalk.nws_station_id = fcst.lid
-JOIN rnr.domain_routelink rl
-	ON rl.link = xwalk.nwm_feature_id;
 
 -------------------------------------------------------
 -------------------------------------------------------
@@ -398,4 +238,4 @@ ORDER BY base.nws_station_id;
 -------------------------------------------------------------
 SELECT reference_time
 FROM ingest.nwm_channel_rt_ana
-ORDER BY reference_time DESC LIMIT 1
+ORDER BY reference_time DESC LIMIT 1;

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/replace_route/rfc_based_5day_max_streamflow.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/replace_route/rfc_based_5day_max_streamflow.sql
@@ -31,86 +31,17 @@ max_flows_station_xwalk AS (
 		ON station.nws_station_id = xwalk.nws_station_id
 ),
 
-max_flows_station_xwalk_with_rc_stage AS (
-	SELECT
-		main.*, 
-		ROUND((curve.stage + ((curve.next_higher_point_stage - curve.stage) / (curve.next_higher_point_flow - curve.flow) * (main.streamflow - curve.flow)))::numeric, 2) as stage_from_curve
-	FROM max_flows_station_xwalk main
-	LEFT JOIN external.rating rating
-		ON rating.location_id = main.gage_id
-	LEFT JOIN rnr.staggered_curves curve
-		ON curve.rating_id = rating.rating_id
-		AND (curve.flow = main.streamflow
-			OR (curve.flow < main.streamflow 
-				AND curve.next_higher_point_flow > main.streamflow))
-),
-
-native_threshold AS (
-	SELECT DISTINCT ON (location_id)
-		location_id as nws_station_id,
-		rating_source,
-		action_stage,
-		minor_stage,
-		moderate_stage,
-		major_stage,
-		record_stage,
-		action_flow,
-		minor_flow,
-		moderate_flow,
-		major_flow,
-		record_flow
-	FROM external.threshold
-	WHERE rating_source = 'NONE'
-), usgs_threshold AS (
-	SELECT DISTINCT ON (location_id) 
-		location_id as nws_station_id,
-		rating_source,
-		action_stage,
-		minor_stage,
-		moderate_stage,
-		major_stage,
-		record_stage,
-		action_flow_calc as action_flow,
-		minor_flow_calc as minor_flow,
-		moderate_flow_calc as moderate_flow,
-		major_flow_calc as major_flow,
-		record_flow_calc as record_flow
-	FROM external.threshold
-	WHERE rating_source = 'USGS Rating Depot' AND location_id NOT IN (SELECT nws_station_id FROM native_threshold)
-), nrldb_threshold AS (
-	SELECT DISTINCT ON (location_id)
-		location_id as nws_station_id,
-		rating_source,
-		action_stage,
-		minor_stage,
-		moderate_stage,
-		major_stage,
-		record_stage,
-		action_flow_calc as action_flow,
-		minor_flow_calc as minor_flow,
-		moderate_flow_calc as moderate_flow,
-		major_flow_calc as major_flow,
-		record_flow_calc as record_flow
-	FROM external.threshold
-	WHERE rating_source = 'NRLDB' AND location_id NOT IN (SELECT nws_station_id FROM native_threshold UNION SELECT nws_station_id FROM usgs_threshold)
-), threshold AS (
-	SELECT * FROM native_threshold
-	UNION
-	SELECT * FROM usgs_threshold
-	UNION
-	SELECT * FROM nrldb_threshold
-),
-
 fcst_meta AS (
 	SELECT DISTINCT ON (lid, product_time) 
 		lid, 
-		product_time as issue_time
+		product_time as issue_time,
+		rating_curve_source
 	FROM rnr.domain_forecasts
 ),
 
 root_status_trace_reaches AS (
 	SELECT DISTINCT ON (feature_id)
-		feature_id, 
+		mf.feature_id, 
 		mf.nws_station_id,
 		rfc_defined_fcst_point,
 		downstream_feature_id,
@@ -118,13 +49,12 @@ root_status_trace_reaches AS (
 		stream_length,
 		is_waterbody,
 		fcst_meta.issue_time,
-		status.rating_source,
-		INITCAP(status.status) as max_status
-	FROM max_flows_station_xwalk_with_rc_stage mf
+		INITCAP(rmf.max_status) as max_status
+	FROM max_flows_station_xwalk mf
 	LEFT JOIN fcst_meta
 		ON fcst_meta.lid = mf.nws_station_id
-	LEFT JOIN rnr.domain_lids_with_status status
-		ON status.lid = mf.nws_station_id
+	LEFT JOIN rnr.rfc_max_forecast_copy rmf
+		ON rmf.nws_lid = mf.nws_station_id
 	WHERE rfc_defined_fcst_point IS TRUE OR issue_time IS NOT NULL
 	ORDER BY feature_id, issue_time, rfc_defined_fcst_point DESC
 ),
@@ -141,7 +71,6 @@ status_trace AS (
 		stream_order AS root_stream_order,
 		stream_order,
 		max_status,
-		rating_source,
 		stream_length,
 		SUM(CAST(0 as float)) as distance_from_forecast_point
 	FROM root_status_trace_reaches
@@ -155,7 +84,6 @@ status_trace AS (
 		root_stream_order, 
 		stream_order, 
 		max_status,
-		rating_source,
 		stream_length
 
 	UNION
@@ -171,7 +99,6 @@ status_trace AS (
 		root.root_stream_order, 
 		iter.stream_order,
 		root.max_status,
-		root.rating_source,
 		iter.stream_length, 
 		root.distance_from_forecast_point + iter.stream_length as distance_from_forecast_point
 	FROM max_flows_station_xwalk iter
@@ -193,7 +120,7 @@ agg_trace AS (
 				WHEN max_status = 'All Thresholds Undefined'
 				THEN max_status || ' at ' || influential_forecast_point || ' (' || root_feature_id || ' [' || root_stream_order || ']) despite forecast issued ' || issue_time || ' ' || ROUND(CAST(distance_from_forecast_point * 0.000621 as numeric), 1) || ' miles upstream'
 				WHEN issue_time IS NOT NULL
-				THEN max_status || ' issued ' || issue_time || ' at ' || influential_forecast_point || ' (' || root_feature_id || ' [' || root_stream_order || ']) ' || ROUND(CAST(distance_from_forecast_point * 0.000621 as numeric), 1) || ' miles upstream'
+				THEN max_status || ' issued ' || issue_time || ' at ' || influential_forecast_point || ' (' || root_feature_id || ' [order ' || root_stream_order || ']) ' || ROUND(CAST(distance_from_forecast_point * 0.000621 as numeric), 1) || ' miles upstream'
 				ELSE max_status || ' at ' || influential_forecast_point || ' (' || root_feature_id || ' [' || root_stream_order || ']) ' || ROUND(CAST(distance_from_forecast_point * 0.000621 as numeric), 1) || ' miles upstream'
 			END,
 			'; '
@@ -222,6 +149,7 @@ SELECT DISTINCT ON (mf.feature_id)
 	mf.reference_time,
 	mf.streamflow,
 	mf.streamflow_cms,
+	fcst_meta.rating_curve_source,
 	mf.stream_order,
 	CASE WHEN agg.is_waterbody THEN 'yes' ELSE 'no' END AS is_waterbody,
 	CASE WHEN agg.is_below_waterbody THEN 'yes' ELSE 'no' END as is_downstream_of_waterbody,
@@ -238,4 +166,6 @@ FROM max_flows_station_xwalk mf
 LEFT JOIN agg_trace agg
 	ON agg.trace_feature_id = mf.feature_id
 LEFT JOIN derived.channels_conus channel 
-	ON channel.feature_id = mf.feature_id;
+	ON channel.feature_id = mf.feature_id
+LEFT JOIN fcst_meta
+	ON fcst_meta.lid = mf.nws_station_id;

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/replace_route/rfc_based_5day_max_streamflow.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/replace_route/rfc_based_5day_max_streamflow.sql
@@ -49,7 +49,7 @@ root_status_trace_reaches AS (
 		stream_length,
 		is_waterbody,
 		fcst_meta.issue_time,
-		INITCAP(rmf.max_status) as max_status
+		COALESCE(INITCAP(rmf.max_status), 'No flooding') as max_status
 	FROM max_flows_station_xwalk mf
 	LEFT JOIN fcst_meta
 		ON fcst_meta.lid = mf.nws_station_id

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/replace_route/rfc_based_5day_max_streamflow.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/replace_route/rfc_based_5day_max_streamflow.mapx
@@ -952,6 +952,13 @@
           },
           {
             "type" : "CIMFieldDescription",
+            "alias" : "Rating Curve Source",
+            "fieldName" : "rating_curve_source",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
             "alias" : "Influential Forecasts",
             "fieldName" : "influential_forecasts",
             "visible" : true,
@@ -1008,7 +1015,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.services.%rfc_based_5day_max_streamflow",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select feature_id_str AS feature_id,nws_station_id,has_forecast_point,name,huc6,reference_time,time_of_max,streamflow,stream_order,is_waterbody,is_downstream_of_waterbody,influental_forecast_text as influential_forecasts,viz_status,update_time,geom,oid from hydrovis.services.rfc_based_5day_max_streamflow",
+          "sqlQuery" : "select feature_id_str AS feature_id,nws_station_id,has_forecast_point,name,huc6,reference_time,time_of_max,streamflow,stream_order,is_waterbody,is_downstream_of_waterbody,rating_curve_source,influental_forecast_text as influential_forecasts,viz_status,update_time,geom,oid from hydrovis.services.rfc_based_5day_max_streamflow",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -1090,6 +1097,12 @@
               "type" : "esriFieldTypeString",
               "alias" : "Is Downstream of Waterbody",
               "length" : 3
+            },
+            {
+              "name" : "rating_curve_source",
+              "type" : "esriFieldTypeString",
+              "alias" : "Rating Curve Source",
+              "length" : 5
             },
             {
               "name" : "influential_forecasts",
@@ -1796,6 +1809,13 @@
           },
           {
             "type" : "CIMFieldDescription",
+            "alias" : "Rating Curve Source",
+            "fieldName" : "rating_curve_source",
+            "visible" : true,
+            "searchMode" : "Exact"
+          },
+          {
+            "type" : "CIMFieldDescription",
             "alias" : "Influential Forecasts",
             "fieldName" : "influential_forecasts",
             "visible" : true,
@@ -1851,7 +1871,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.services.%rfc_based_5day_max_streamflow",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select feature_id_str AS feature_id,nws_station_id,has_forecast_point,name,huc6,reference_time,time_of_max,streamflow,stream_order,is_waterbody,is_downstream_of_waterbody,influental_forecast_text as influential_forecasts,viz_status,update_time,geom,oid from hydrovis.services.rfc_based_5day_max_streamflow",
+          "sqlQuery" : "select feature_id_str AS feature_id,nws_station_id,has_forecast_point,name,huc6,reference_time,time_of_max,streamflow,stream_order,is_waterbody,is_downstream_of_waterbody,rating_curve_source,influental_forecast_text as influential_forecasts,viz_status,update_time,geom,oid from hydrovis.services.rfc_based_5day_max_streamflow",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -1933,6 +1953,12 @@
               "type" : "esriFieldTypeString",
               "alias" : "Is Downstream of Waterbody",
               "length" : 3
+            },
+            {
+              "name" : "rating_curve_source",
+              "type" : "esriFieldTypeString",
+              "alias" : "Rating Curve Source",
+              "length" : 5
             },
             {
               "name" : "influential_forecasts",


### PR DESCRIPTION
The rfc_max_forecast service was just re-designed to rely directly upon the WRDS database rather than the API. This came with some value-added updates and bug-fixes. With those in place, it made sense to also re-design the Replace and Route workflow to now rely fully upon the rfc_max_forecast service data rather than essentially recreating that foundation itself.

This completely aligns the RnR domain with the RFC Max Forecast domain - although the RnR domain will still be a subset of that. But before, there was a chance for a point being in RnR that was not in RFC Max Forecast in the case of flow-only forecasts.

A new column, rating_curve_source, is also added to the rfc_based_5day_max_forecast service, which will indicate which rating curve, if any, was used to produce the flows at each forecast point.