### PR TITLE
Fixes bug with viz_db_ingest Lambda

### DIFF
--- a/Core/LAMBDA/viz_functions/viz_db_ingest/lambda_function.py
+++ b/Core/LAMBDA/viz_functions/viz_db_ingest/lambda_function.py
@@ -56,81 +56,76 @@ def lambda_handler(event, context):
         return json.dumps(dump_dict)
     
     viz_db = database(db_type="viz")
-    with viz_db.get_db_connection() as connection:
-        cursor = connection.cursor()
+    nwm_version = 0
+
+    if file.endswith('.nc'):
+        ds = xr.open_dataset(download_path)
+        ds_vars = [var for var in ds.variables]
+
+        if not target_cols:
+            target_cols = ds_vars
+
         try:
-            nwm_version = 0
-
-            if file.endswith('.nc'):
-                ds = xr.open_dataset(download_path)
-                ds_vars = [var for var in ds.variables]
-
-                if not target_cols:
-                    target_cols = ds_vars
-
-                try:
-                    if "hawaii" in file:
-                        ds['forecast_hour'] = int(int(re.findall("(\d{8})/[a-z0-9_]*/.*t(\d{2})z.*[ftm](\d*)\.", file)[0][-1])/100)
-                    else:
-                        ds['forecast_hour'] = int(re.findall("(\d{8})/[a-z0-9_]*/.*t(\d{2})z.*[ftm](\d*)\.", file)[0][-1])
-                    if 'forecast_hour' not in target_cols:
-                        target_cols.append('forecast_hour')
-                except:
-                    print("Regex pattern for the forecast hour didn't match the netcdf file")
-                
-                try:
-                    ds['nwm_vers'] = float(ds.NWM_version_number.replace("v",""))
-                    if 'nwm_vers' not in target_cols:
-                        target_cols.append('nwm_vers')
-                except:
-                    print("NWM_version_number property is not available in the netcdf file")
-
-                drop_vars = [var for var in ds_vars if var not in target_cols]
-                df = ds.to_dataframe().reset_index()
-                df = df.drop(columns=drop_vars)
-                ds.close()
-                if 'streamflow' in target_cols:
-                    df = df.loc[df['streamflow'] >= keep_flows_at_or_above].round({'streamflow': 2}).copy()  # noqa
-                df = df[target_cols]
-
-            elif file.endswith('.csv'):
-                df = pd.read_csv(download_path)
-                for column in df:  # Replace any 'None' strings with nulls
-                    df[column].replace('None', np.nan, inplace=True)
-                df = df.copy()
+            if "hawaii" in file:
+                ds['forecast_hour'] = int(int(re.findall("(\d{8})/[a-z0-9_]*/.*t(\d{2})z.*[ftm](\d*)\.", file)[0][-1])/100)
             else:
-                print("File format not supported.")
-                exit()
+                ds['forecast_hour'] = int(re.findall("(\d{8})/[a-z0-9_]*/.*t(\d{2})z.*[ftm](\d*)\.", file)[0][-1])
+            if 'forecast_hour' not in target_cols:
+                target_cols.append('forecast_hour')
+        except:
+            print("Regex pattern for the forecast hour didn't match the netcdf file")
+        
+        try:
+            ds['nwm_vers'] = float(ds.NWM_version_number.replace("v",""))
+            if 'nwm_vers' not in target_cols:
+                target_cols.append('nwm_vers')
+        except:
+            print("NWM_version_number property is not available in the netcdf file")
 
-            print(f"--> Preparing and Importing {file}")
-            f = StringIO()  # Use StringIO to store the temporary text file in memory (faster than on disk)
-            df.to_csv(f, sep='\t', index=False, header=False)
+        drop_vars = [var for var in ds_vars if var not in target_cols]
+        df = ds.to_dataframe().reset_index()
+        df = df.drop(columns=drop_vars)
+        ds.close()
+        if 'streamflow' in target_cols:
+            df = df.loc[df['streamflow'] >= keep_flows_at_or_above].round({'streamflow': 2}).copy()  # noqa
+        df = df[target_cols]
+
+    elif file.endswith('.csv'):
+        df = pd.read_csv(download_path)
+        for column in df:  # Replace any 'None' strings with nulls
+            df[column].replace('None', np.nan, inplace=True)
+        df = df.copy()
+    else:
+        print("File format not supported.")
+        exit()
+
+    print(f"--> Preparing and Importing {file}")
+    f = StringIO()  # Use StringIO to store the temporary text file in memory (faster than on disk)
+    df.to_csv(f, sep='\t', index=False, header=False)
+    f.seek(0)
+    try:
+        with viz_db.get_db_connection() as connection:
+            cursor = connection.cursor()
+            cursor.copy_expert(f"COPY {target_table} FROM STDIN WITH DELIMITER E'\t' null as ''", f)
+            connection.commit()
+        connection.close()
+    except (UndefinedTable, BadCopyFileFormat, InvalidTextRepresentation):
+        if not create_table:
+            raise
+
+        print("Error encountered. Recreating table now and retrying import...")
+        create_table_df = df.head(0)
+        schema, table = target_table.split('.')
+        create_table_df.to_sql(con=viz_db.engine, schema=schema, name=table, index=False, if_exists='replace')
+        with viz_db.get_db_connection() as connection:
             f.seek(0)
-            try:
-                with viz_db.get_db_connection() as connection:
-                    cursor = connection.cursor()
-                    cursor.copy_expert(f"COPY {target_table} FROM STDIN WITH DELIMITER E'\t' null as ''", f)
-                    connection.commit()
-            except (UndefinedTable, BadCopyFileFormat, InvalidTextRepresentation):
-                if not create_table:
-                    raise
+            cursor = connection.cursor()
+            cursor.copy_expert(f"COPY {target_table} FROM STDIN WITH DELIMITER E'\t' null as ''", f)
+            connection.commit()
+        connection.close()
 
-                print("Error encountered. Recreating table now and retrying import...")
-                create_table_df = df.head(0)
-                schema, table = target_table.split('.')
-                create_table_df.to_sql(con=viz_db.engine, schema=schema, name=table, index=False, if_exists='replace')
-                with viz_db.get_db_connection() as connection:
-                    cursor = connection.cursor()
-                    cursor.copy_expert(f"COPY {target_table} FROM STDIN WITH DELIMITER E'\t' null as ''", f)
-                    connection.commit()
-
-            print(f"--> Import of {len(df)} rows Complete. Removing {download_path} and closing db connection.")
-            os.remove(download_path)
-    
-        except Exception as e:
-            print(f"Error: {e}")
-            raise e
-    
+    print(f"--> Import of {len(df)} rows Complete. Removing {download_path} and closing db connection.")
+    os.remove(download_path)
     dump_dict = {
                         "file": file,
                         "target_table": target_table,


### PR DESCRIPTION
I found a bug while attempting to execute an archive case, and while fixing it also noticed another messy section of code that I cleaned up. 

The bug was that if a CSV file failed to upload, it would supposedly work on the retry, but turns out it wasn't actually working, but failing silently. This is because the end of the in-memory file object was being reached just prior to failing, and so on the retry, there is nothing left of the file to load without first doing a `f.seek(0)`. 

The messy part of the code was an unnecessary `with` context surrounding a large block of code in which the actual couple of lines that did need the `with` context had what was essentially a duplicate context. I deleted the outer, unnecessary context and thus indented everything back one level.