### PR TITLE
Adds MRF and SRF reservoir data feeds

### DIFF
--- a/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/medium_range_mem1/mrf_reservoirs.yml
+++ b/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/medium_range_mem1/mrf_reservoirs.yml
@@ -1,0 +1,12 @@
+product: mrf_reservoirs
+configuration: medium_range_mem1
+product_type: "vector" # Needed to not fail, but obviously there's nothing more than an ingest going on here
+run: true
+
+ingest_files:
+    - file_format: common/data/model/com/nwm/{{variable:NWM_DATAFLOW_VERSION}}/nwm.{{datetime:%Y%m%d}}/medium_range_mem1/nwm.t{{datetime:%H}}z.medium_range.reservoir_1.f{{range:1,241,1,%03d}}.conus.nc
+      file_step: None
+      file_window: None
+      target_table: ingest.nwm_reservoir_mrf
+      target_cols: ['feature_id', 'water_sfc_elev', 'outflow']
+      target_keys: (feature_id)

--- a/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/short_range/srf_reservoirs.yml
+++ b/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/short_range/srf_reservoirs.yml
@@ -1,0 +1,12 @@
+product: srf_reservoirs
+configuration: short_range
+product_type: "vector" # Needed to not fail, but obviously there's nothing more than an ingest going on here
+run: true
+
+ingest_files:
+    - file_format: common/data/model/com/nwm/{{variable:NWM_DATAFLOW_VERSION}}/nwm.{{datetime:%Y%m%d}}/short_range/nwm.t{{datetime:%H}}z.short_range.reservoir.f{{range:1,19,1,%03d}}.conus.nc
+      file_step: None
+      file_window: None
+      target_table: ingest.nwm_reservoir_srf
+      target_cols: ['feature_id', 'water_sfc_elev', 'outflow']
+      target_keys: (feature_id)


### PR DESCRIPTION
This adds two product config files to the viz_initialie_pipeline Lambda: one each for MRF and SRF reservoirs. It can be argued whether this change should be temporary or long-term. Namely, since any specific products/services that are developed using this data would eventually need their own product config file to incorporate the associated processing into the pipeline - at which point, the configuration of the dependent ingest data should be incorporated into each of these files as well, making these original two configuration files superfluous.

Anyhow, either way, it's not a big deal. This way is probably ideal and somewhat necessary to ensure that any product/service developers have the feed already in place so they aren't bothered by the overhead of fetching or configuring it themselves and can rather focus on the product/service development itself.