### PR TITLE
Viz rds parameter group tuning

### DIFF
--- a/Core/LAMBDA/layers/viz_lambda_shared_funcs/python/viz_classes.py
+++ b/Core/LAMBDA/layers/viz_lambda_shared_funcs/python/viz_classes.py
@@ -91,14 +91,14 @@ class database: #TODO: Should we be creating a connection/engine upon initializa
     ###################################
     def run_sql_file_in_db(self, sql_file):
         sql = open(sql_file, 'r').read()
-        with self.connection as db_connection:
+        with self.connection:
             try:
-                cur = db_connection.cursor()
-                print(f"---> Running {sql_file}")
-                cur.execute(sql)
-                db_connection.commit()
+                with self.connection.cursor() as cur:
+                    print(f"---> Running {sql_file}")
+                    cur.execute(sql)
             except Exception as e:
                 raise e
+        self.connection.close()
                 
     ###################################                
     def run_sql_in_db(self, sql, return_geodataframe=False):
@@ -119,21 +119,23 @@ class database: #TODO: Should we be creating a connection/engine upon initializa
     ###################################
     def get_est_row_count_in_table(self, table):
         print(f"Getting estimated total rows in {table}.")
-        with self.connection as db_connection:
+        with self.connection:
             try:
-                cur = db_connection.cursor()
-                sql = f"""
-                SELECT (CASE WHEN c.reltuples < 0 THEN NULL -- never vacuumed
-                            WHEN c.relpages = 0 THEN float8 '0' -- empty table
-                            ELSE c.reltuples / c.relpages END
-                    * (pg_catalog.pg_relation_size(c.oid) / pg_catalog.current_setting('block_size')::int))::bigint
-                FROM   pg_catalog.pg_class c
-                WHERE  c.oid = '{table}'::regclass; -- schema-qualified table here
-                """
-                cur.execute(sql)
-                rows = cur.fetchone()[0]
+                with self.connection.cursor() as cur:
+                    sql = f"""
+                    SELECT (CASE WHEN c.reltuples < 0 THEN NULL -- never vacuumed
+                                WHEN c.relpages = 0 THEN float8 '0' -- empty table
+                                ELSE c.reltuples / c.relpages END
+                        * (pg_catalog.pg_relation_size(c.oid) / pg_catalog.current_setting('block_size')::int))::bigint
+                    FROM   pg_catalog.pg_class c
+                    WHERE  c.oid = '{table}'::regclass; -- schema-qualified table here
+                    """
+                    cur.execute(sql)
+                    rows = cur.fetchone()[0]
             except Exception as e:
                 raise e
+        self.connection.close()
+
         return rows
     
     ###################################

--- a/Core/LAMBDA/rnr_functions/rnr_domain_generator/lambda_function.py
+++ b/Core/LAMBDA/rnr_functions/rnr_domain_generator/lambda_function.py
@@ -33,11 +33,12 @@ def lambda_handler(event, context):
     if step == 'domain':
         print(f'Executing {step}.sql...')
         
-        with viz_db.get_db_connection() as connection:
-            cur = connection.cursor()
-            cur.execute(sql)
-            result = cur.fetchone()
-            connection.commit()
+        connection = viz_db.get_db_connection()
+        with connection:
+            with connection.cursor() as cur:
+                cur.execute(sql)
+                result = cur.fetchone()
+        connection.close()
 
         reference_time = dt.datetime.strptime(result[0], '%Y-%m-%d %H:%M:%S UTC').strftime(DT_FORMAT)
         run_time_obj = dt.datetime.strptime(event['run_time'], '%Y-%m-%dT%H:%M:%SZ')

--- a/Core/LAMBDA/viz_functions/image_based/viz_hand_fim_processing/lambda_function.py
+++ b/Core/LAMBDA/viz_functions/image_based/viz_hand_fim_processing/lambda_function.py
@@ -1,7 +1,8 @@
-import boto3
+# import boto3
 import rasterio
 import numpy as np
 import pandas as pd
+import awswrangler as wr
 import geopandas as gpd
 import os
 import time
@@ -14,7 +15,7 @@ FIM_BUCKET = os.environ['FIM_BUCKET']
 FIM_PREFIX = os.environ['FIM_PREFIX']
 FIM_VERSION = re.findall("[/_]?(\d*_\d*_\d*_\d*)/?", FIM_PREFIX)[0]
 
-s3 = boto3.client("s3")
+# s3 = boto3.client("s3")
 
 class HANDDatasetReadError(Exception):
     """ my custom exception class """
@@ -437,14 +438,18 @@ def create_inundation_output(huc8, branch, stage_lookup, reference_time, input_v
     return df_final
 
 def s3_csv_to_df(bucket, key):
-    basename = os.path.basename(key)
-    local_file = f"/tmp/{basename}"
+    # basename = os.path.basename(key)
+    # local_file = f"/tmp/{basename}"
 
-    print(f"Downloading {key} from {bucket}")
-    s3.download_file(bucket, key, local_file)
-    df = pd.read_csv(local_file)
-    os.remove(local_file)
+    # print(f"Downloading {key} from {bucket}")
+    # s3.download_file(bucket, key, local_file)
+    # df = pd.read_csv(local_file)
+    # os.remove(local_file)
     
+    print(f"Reading {key} from {bucket} into DataFrame")
+    df = wr.s3.read_csv(path=f"s3://{bucket}/{key}")
+    print("DataFrame creation Successful")
+
     return df
 
 def calculate_stage_values(hydrotable_key, subsetted_streams_bucket, subsetted_streams, huc8_branch):

--- a/Core/LAMBDA/viz_functions/image_based/viz_hand_fim_processing/requirements.txt
+++ b/Core/LAMBDA/viz_functions/image_based/viz_hand_fim_processing/requirements.txt
@@ -3,3 +3,5 @@ geopandas==0.11.1
 SQLAlchemy==1.4.40
 GeoAlchemy2==0.12.3
 psycopg2-binary==2.9.3
+pandas==2.1.4
+awswrangler

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/lambda_function.py
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/lambda_function.py
@@ -103,13 +103,15 @@ def run_sql(sql_path_or_str, sql_replace=None):
         sql = re.sub(re.escape(word), replacement, sql, flags=re.IGNORECASE).replace('utc', 'UTC')
 
     viz_db = database(db_type="viz")
-    with viz_db.get_db_connection() as connection:
-        cur = connection.cursor()
-        cur.execute(sql)
-        try:
-            result = cur.fetchone()
-        except:
-            pass
-        connection.commit()
+    connection = viz_db.get_db_connection()
+    with connection:
+        with connection.cursor() as cur:
+            cur.execute(sql)
+            try:
+                result = cur.fetchone()
+            except:
+                pass
+    connection.close()
+
     print(f"Finished executing the SQL statement above.")
     return result

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/ana_inundation/building_footprints_fimpact.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/ana_inundation/building_footprints_fimpact.sql
@@ -1,5 +1,3 @@
--- We'll temporarily increase work_mem to 512MB, to help with performance on PostGIS spatial joins (default is 4MB)
-SET work_mem TO '512MB';
 --------------- Building Footprints ---------------
 DROP TABLE IF EXISTS publish.ana_inundation_building_footprints;
 SELECT

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/ana_inundation_hi/building_footprints_fimpact.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/ana_inundation_hi/building_footprints_fimpact.sql
@@ -1,5 +1,3 @@
--- We'll temporarily increase work_mem to 512MB, to help with performance on PostGIS spatial joins (default is 4MB)
-SET work_mem TO '512MB';
 --------------- Building Footprints ---------------
 DROP TABLE IF EXISTS publish.ana_inundation_building_footprints_hi;
 SELECT

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/ana_inundation_prvi/building_footprints_fimpact.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/ana_inundation_prvi/building_footprints_fimpact.sql
@@ -1,5 +1,3 @@
--- We'll temporarily increase work_mem to 512MB, to help with performance on PostGIS spatial joins (default is 4MB)
-SET work_mem TO '512MB';
 --------------- Building Footprints ---------------
 DROP TABLE IF EXISTS publish.ana_inundation_building_footprints_prvi;
 SELECT

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/ana_past_14day_max_inundation/14day_building_footprints_fimpact.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/ana_past_14day_max_inundation/14day_building_footprints_fimpact.sql
@@ -1,5 +1,3 @@
--- We'll temporarily increase work_mem to 512MB, to help with performance on PostGIS spatial joins (default is 4MB)
-SET work_mem TO '512MB';
 --------------- Building Footprints ---------------
 DROP TABLE IF EXISTS publish.ana_past_14day_max_inundation_building_footprints;
 SELECT

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/ana_past_14day_max_inundation/7day_building_footprints_fimpact.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/ana_past_14day_max_inundation/7day_building_footprints_fimpact.sql
@@ -1,5 +1,3 @@
--- We'll temporarily increase work_mem to 512MB, to help with performance on PostGIS spatial joins (default is 4MB)
-SET work_mem TO '512MB';
 --------------- Building Footprints ---------------
 DROP TABLE IF EXISTS publish.ana_past_7day_max_inundation_building_footprints;
 SELECT

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/mrf_gfs_10day_max_inundation/10day_building_footprints_fimpact.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/mrf_gfs_10day_max_inundation/10day_building_footprints_fimpact.sql
@@ -1,5 +1,3 @@
--- We'll temporarily increase work_mem to 512MB, to help with performance on PostGIS spatial joins (default is 4MB)
-SET work_mem TO '512MB';
 --------------- Building Footprints ---------------
 DROP TABLE IF EXISTS publish.mrf_gfs_max_inundation_10day_building_footprints;
 SELECT

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/mrf_gfs_10day_max_inundation/3day_building_footprints_fimpact.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/mrf_gfs_10day_max_inundation/3day_building_footprints_fimpact.sql
@@ -1,5 +1,3 @@
--- We'll temporarily increase work_mem to 512MB, to help with performance on PostGIS spatial joins (default is 4MB)
-SET work_mem TO '512MB';
 --------------- Building Footprints ---------------
 DROP TABLE IF EXISTS publish.mrf_gfs_max_inundation_3day_building_footprints;
 SELECT

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/mrf_gfs_10day_max_inundation/5day_building_footprints_fimpact.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/mrf_gfs_10day_max_inundation/5day_building_footprints_fimpact.sql
@@ -1,5 +1,3 @@
--- We'll temporarily increase work_mem to 512MB, to help with performance on PostGIS spatial joins (default is 4MB)
-SET work_mem TO '512MB';
 --------------- Building Footprints ---------------
 DROP TABLE IF EXISTS publish.mrf_gfs_max_inundation_5day_building_footprints;
 SELECT

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/mrf_gfs_10day_max_inundation/5day_public_subset.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/mrf_gfs_10day_max_inundation/5day_public_subset.sql
@@ -1,6 +1,3 @@
--- We'll temporarily increase work_mem to 512MB, to help with performance on PostGIS spatial joins (default is 4MB)
-SET work_mem TO '512MB';
---
 DROP TABLE IF EXISTS publish.mrf_gfs_max_inundation_5day_public;
 
 SELECT

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/mrf_nbm_10day_max_inundation/10day_building_footprints_fimpact.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/mrf_nbm_10day_max_inundation/10day_building_footprints_fimpact.sql
@@ -1,5 +1,3 @@
--- We'll temporarily increase work_mem to 512MB, to help with performance on PostGIS spatial joins (default is 4MB)
-SET work_mem TO '512MB';
 --------------- Building Footprints ---------------
 DROP TABLE IF EXISTS publish.mrf_nbm_max_inundation_10day_building_footprints;
 SELECT

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/mrf_nbm_10day_max_inundation/3day_building_footprints_fimpact.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/mrf_nbm_10day_max_inundation/3day_building_footprints_fimpact.sql
@@ -1,5 +1,3 @@
--- We'll temporarily increase work_mem to 512MB, to help with performance on PostGIS spatial joins (default is 4MB)
-SET work_mem TO '512MB';
 --------------- Building Footprints ---------------
 DROP TABLE IF EXISTS publish.mrf_nbm_max_inundation_3day_building_footprints;
 SELECT

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/mrf_nbm_10day_max_inundation/5day_building_footprints_fimpact.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/mrf_nbm_10day_max_inundation/5day_building_footprints_fimpact.sql
@@ -1,5 +1,3 @@
--- We'll temporarily increase work_mem to 512MB, to help with performance on PostGIS spatial joins (default is 4MB)
-SET work_mem TO '512MB';
 --------------- Building Footprints ---------------
 DROP TABLE IF EXISTS publish.mrf_nbm_max_inundation_5day_building_footprints;
 SELECT

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/rfc_based_5day_max_inundation/building_footprints_fimpact.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/rfc_based_5day_max_inundation/building_footprints_fimpact.sql
@@ -1,5 +1,3 @@
--- We'll temporarily increase work_mem to 512MB, to help with performance on PostGIS spatial joins (default is 4MB)
-SET work_mem TO '512MB';
 --------------- Building Footprints ---------------
 DROP TABLE IF EXISTS publish.rfc_based_5day_max_inundation_building_footprints;
 SELECT

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/srf_18hr_max_inundation/building_footprints_fimpact.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/srf_18hr_max_inundation/building_footprints_fimpact.sql
@@ -1,5 +1,3 @@
--- We'll temporarily increase work_mem to 512MB, to help with performance on PostGIS spatial joins (default is 4MB)
-SET work_mem TO '512MB';
 --------------- Building Footprints ---------------
 DROP TABLE IF EXISTS publish.srf_18hr_max_inundation_building_footprints;
 SELECT

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/srf_48hr_max_inundation_hi/building_footprints_fimpact.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/srf_48hr_max_inundation_hi/building_footprints_fimpact.sql
@@ -1,5 +1,3 @@
--- We'll temporarily increase work_mem to 512MB, to help with performance on PostGIS spatial joins (default is 4MB)
-SET work_mem TO '512MB';
 --------------- Building Footprints ---------------
 DROP TABLE IF EXISTS publish.srf_48hr_max_inundation_building_footprints_hi;
 SELECT

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/srf_48hr_max_inundation_prvi/building_footprints_fimpact.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/summaries/srf_48hr_max_inundation_prvi/building_footprints_fimpact.sql
@@ -1,5 +1,3 @@
--- We'll temporarily increase work_mem to 512MB, to help with performance on PostGIS spatial joins (default is 4MB)
-SET work_mem TO '512MB';
 --------------- Building Footprints ---------------
 DROP TABLE IF EXISTS publish.srf_48hr_max_inundation_building_footprints_prvi;
 SELECT

--- a/Core/LAMBDA/viz_functions/viz_initialize_pipeline/lambda_function.py
+++ b/Core/LAMBDA/viz_functions/viz_initialize_pipeline/lambda_function.py
@@ -73,14 +73,14 @@ def lambda_handler(event, context):
                                         "medium_range_blend.forcing.f240.alaska.nc",
 
                                         ## Coastal ##
-                                        "analysis_assim_coastal.total_water.tm00.atlgulf.nc",
-                                        "analysis_assim_coastal.total_water.tm00.hawaii.nc",
-                                        "analysis_assim_coastal.total_water.tm00.puertorico.nc",
-                                        "medium_range_coastal.total_water.f240.atlgulf.nc",
-                                        "medium_range_blend_coastal.total_water.f240.atlgulf.nc",
-                                        "short_range_coastal.total_water.f018.atlgulf.nc",
-                                        "short_range_coastal.total_water.f048.puertorico.nc",
-                                        "short_range_coastal.total_water.f048.hawaii.nc"
+                                        # "analysis_assim_coastal.total_water.tm00.atlgulf.nc",
+                                        # "analysis_assim_coastal.total_water.tm00.hawaii.nc",
+                                        # "analysis_assim_coastal.total_water.tm00.puertorico.nc",
+                                        # "medium_range_coastal.total_water.f240.atlgulf.nc",
+                                        # "medium_range_blend_coastal.total_water.f240.atlgulf.nc",
+                                        # "short_range_coastal.total_water.f018.atlgulf.nc",
+                                        # "short_range_coastal.total_water.f048.puertorico.nc",
+                                        # "short_range_coastal.total_water.f048.hawaii.nc"
                                         ]
         s3_event = json.loads(event.get('Records')[0].get('Sns').get('Message'))
         if s3_event.get('Records')[0].get('s3').get('object').get('key'):

--- a/Core/RDS/viz/main.tf
+++ b/Core/RDS/viz/main.tf
@@ -51,12 +51,6 @@ resource "aws_db_parameter_group" "hydrovis" {
   family = "postgres15"
 
   parameter {
-    name  = "shared_buffers"
-    value = "{DBInstanceClassMemory/10923}"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
     name         = "rds.custom_dns_resolution"
     value        = "1"
     apply_method = "pending-reboot"
@@ -92,13 +86,23 @@ resource "aws_db_parameter_group" "hydrovis" {
   }
 
   parameter {
+    name  = "checkpoint_completion_target"
+    value = "0.9"
+  }
+
+  parameter {
+    name  = "default_statistics_target"
+    value = "100"
+  }
+
+  parameter {
     name  = "effective_cache_size"
-    value = "25165824"
+    value = "24576"
   }
 
   parameter {
     name  = "effective_io_concurrency"
-    value = "100"
+    value = "200"
   }
 
   parameter {
@@ -107,8 +111,14 @@ resource "aws_db_parameter_group" "hydrovis" {
   }
 
   parameter {
+    name  = "huge_pages"
+    value = "try"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
     name  = "idle_in_transaction_session_timeout"
-    value = "3600"
+    value = "6000"
   }
 
   parameter {
@@ -117,7 +127,34 @@ resource "aws_db_parameter_group" "hydrovis" {
   }
 
   parameter {
+    name  = "max_connections"
+    value = "120"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name  = "maintenance_work_mem"
+    value = "2048"
+  }
+
+  parameter {
+    name  = "max_worker_processes"
+    value = "8"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
     name  = "max_parallel_workers_per_gather"
+    value = "4"
+  }
+
+  parameter {
+    name  = "max_parallel_workers"
+    value = "8"
+  }
+
+  parameter {
+    name  = "max_parallel_maintenance_workers"
     value = "4"
   }
 
@@ -135,22 +172,22 @@ resource "aws_db_parameter_group" "hydrovis" {
 
   parameter {
     name  = "max_wal_size"
-    value = "16777216"
+    value = "16384"
   }
 
   parameter {
     name  = "min_wal_size"
-    value = "4194304"
+    value = "4096"
   }
 
   parameter {
     name  = "random_page_cost"
-    value = "1.5"
+    value = "1.1"
   }
 
   parameter {
     name  = "shared_buffers"
-    value = "28672000"
+    value = "8040"
     apply_method = "pending-reboot"
   }
 
@@ -161,13 +198,18 @@ resource "aws_db_parameter_group" "hydrovis" {
 
   parameter {
     name  = "wal_buffers"
-    value = "262143"
+    value = "64"
     apply_method = "pending-reboot"
   }
 
   parameter {
+    name  = "wal_writer_flush_after"
+    value = "128000"
+  }
+
+  parameter {
     name  = "work_mem"
-    value = "25165824"
+    value = "68"
   }
 }
 

--- a/Core/RDS/viz/main.tf
+++ b/Core/RDS/viz/main.tf
@@ -88,6 +88,7 @@ resource "aws_db_parameter_group" "hydrovis" {
   parameter {
     name  = "checkpoint_completion_target"
     value = "0.9"
+    apply_method = "pending-reboot"
   }
 
   parameter {
@@ -108,12 +109,6 @@ resource "aws_db_parameter_group" "hydrovis" {
   parameter {
     name  = "geqo_threshold"
     value = "12"
-  }
-
-  parameter {
-    name  = "huge_pages"
-    value = "try"
-    apply_method = "pending-reboot"
   }
 
   parameter {
@@ -187,7 +182,7 @@ resource "aws_db_parameter_group" "hydrovis" {
 
   parameter {
     name  = "shared_buffers"
-    value = "8192000"
+    value = "6291456"
     apply_method = "pending-reboot"
   }
 

--- a/Core/RDS/viz/main.tf
+++ b/Core/RDS/viz/main.tf
@@ -50,11 +50,6 @@ resource "aws_db_parameter_group" "hydrovis" {
   name   = "hv-vpp-${var.environment}-viz-processing"
   family = "postgres15"
 
-
-  
-
-
-
   parameter {
     name  = "autovacuum"
     value = "1"
@@ -226,7 +221,7 @@ resource "aws_db_parameter_group" "hydrovis" {
 resource "aws_db_instance" "hydrovis" {
   identifier                   = "hv-vpp-${var.environment}-viz-processing"
   db_name                      = var.viz_db_name
-  instance_class               = "db.m6g.2xlarge"
+  instance_class               = "db.m5.4xlarge"
   allocated_storage            = 1024
   storage_type                 = "gp2"
   engine                       = "postgres"

--- a/Core/RDS/viz/main.tf
+++ b/Core/RDS/viz/main.tf
@@ -120,6 +120,7 @@ resource "aws_db_parameter_group" "hydrovis" {
   parameter {
     name  = "idle_in_transaction_session_timeout"
     value = "900000"
+    apply_method = "pending-reboot"
   }
 
   parameter {
@@ -188,7 +189,7 @@ resource "aws_db_parameter_group" "hydrovis" {
 
   parameter {
     name  = "shared_buffers"
-    value = "6291456"
+    value = "8192000"
     apply_method = "pending-reboot"
   }
 

--- a/Core/RDS/viz/main.tf
+++ b/Core/RDS/viz/main.tf
@@ -82,7 +82,7 @@ resource "aws_db_parameter_group" "hydrovis" {
 
   parameter {
     name  = "autovacuum_work_mem"
-    value = "8388608"
+    value = "128000"
   }
 
   parameter {
@@ -134,7 +134,7 @@ resource "aws_db_parameter_group" "hydrovis" {
 
   parameter {
     name  = "maintenance_work_mem"
-    value = "2048"
+    value = "1026332"
   }
 
   parameter {
@@ -177,7 +177,7 @@ resource "aws_db_parameter_group" "hydrovis" {
 
   parameter {
     name  = "min_wal_size"
-    value = "4096"
+    value = "2096"
   }
 
   parameter {
@@ -187,7 +187,7 @@ resource "aws_db_parameter_group" "hydrovis" {
 
   parameter {
     name  = "shared_buffers"
-    value = "8040"
+    value = "8192000"
     apply_method = "pending-reboot"
   }
 
@@ -198,7 +198,7 @@ resource "aws_db_parameter_group" "hydrovis" {
 
   parameter {
     name  = "wal_buffers"
-    value = "64"
+    value = "64192"
     apply_method = "pending-reboot"
   }
 
@@ -209,7 +209,7 @@ resource "aws_db_parameter_group" "hydrovis" {
 
   parameter {
     name  = "work_mem"
-    value = "68"
+    value = "68000"
   }
 }
 

--- a/Core/RDS/viz/main.tf
+++ b/Core/RDS/viz/main.tf
@@ -57,15 +57,117 @@ resource "aws_db_parameter_group" "hydrovis" {
   }
 
   parameter {
-    name  = "idle_in_transaction_session_timeout"
-    value = "900000"
-    apply_method = "pending-reboot"
-  }
-  
-  parameter {
     name         = "rds.custom_dns_resolution"
     value        = "1"
     apply_method = "pending-reboot"
+  }
+  
+
+
+
+  parameter {
+    name  = "autovacuum"
+    value = "1"
+  }
+
+  parameter {
+    name  = "autovacuum_analyze_scale_factor"
+    value = "0.005"
+  }
+
+  parameter {
+    name  = "autovacuum_max_workers"
+    value = "4"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name  = "autovacuum_vacuum_scale_factor"
+    value = "0.05"
+  }
+
+  parameter {
+    name  = "autovacuum_work_mem"
+    value = "8388608"
+  }
+
+  parameter {
+    name  = "effective_cache_size"
+    value = "25165824"
+  }
+
+  parameter {
+    name  = "effective_io_concurrency"
+    value = "100"
+  }
+
+  parameter {
+    name  = "geqo_threshold"
+    value = "12"
+  }
+
+  parameter {
+    name  = "idle_in_transaction_session_timeout"
+    value = "3600"
+  }
+
+  parameter {
+    name  = "log_autovacuum_min_duration"
+    value = "100"
+  }
+
+  parameter {
+    name  = "max_parallel_workers_per_gather"
+    value = "4"
+  }
+
+  parameter {
+    name  = "max_replication_slots"
+    value = "10"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name  = "max_wal_senders"
+    value = "10"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name  = "max_wal_size"
+    value = "16777216"
+  }
+
+  parameter {
+    name  = "min_wal_size"
+    value = "4194304"
+  }
+
+  parameter {
+    name  = "random_page_cost"
+    value = "1.5"
+  }
+
+  parameter {
+    name  = "shared_buffers"
+    value = "28672000"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name  = "track_wal_io_timing"
+    value = "0"
+  }
+
+  parameter {
+    name  = "wal_buffers"
+    value = "262143"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name  = "work_mem"
+    value = "25165824"
   }
 }
 

--- a/Core/RDS/viz/main.tf
+++ b/Core/RDS/viz/main.tf
@@ -82,7 +82,7 @@ resource "aws_db_parameter_group" "hydrovis" {
 
   parameter {
     name  = "autovacuum_work_mem"
-    value = "128000"
+    value = "2128000"
   }
 
   parameter {
@@ -98,7 +98,7 @@ resource "aws_db_parameter_group" "hydrovis" {
 
   parameter {
     name  = "effective_cache_size"
-    value = "24576"
+    value = "8576"
   }
 
   parameter {
@@ -112,8 +112,14 @@ resource "aws_db_parameter_group" "hydrovis" {
   }
 
   parameter {
+    name  = "huge_pages"
+    value = "off"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
     name  = "idle_in_transaction_session_timeout"
-    value = "6000"
+    value = "900000"
   }
 
   parameter {
@@ -123,13 +129,13 @@ resource "aws_db_parameter_group" "hydrovis" {
 
   parameter {
     name  = "max_connections"
-    value = "120"
+    value = "200"
     apply_method = "pending-reboot"
   }
 
   parameter {
     name  = "maintenance_work_mem"
-    value = "1026332"
+    value = "2526332"
   }
 
   parameter {
@@ -167,7 +173,7 @@ resource "aws_db_parameter_group" "hydrovis" {
 
   parameter {
     name  = "max_wal_size"
-    value = "16384"
+    value = "6384"
   }
 
   parameter {
@@ -193,7 +199,7 @@ resource "aws_db_parameter_group" "hydrovis" {
 
   parameter {
     name  = "wal_buffers"
-    value = "64192"
+    value = "262143"
     apply_method = "pending-reboot"
   }
 
@@ -204,7 +210,7 @@ resource "aws_db_parameter_group" "hydrovis" {
 
   parameter {
     name  = "work_mem"
-    value = "68000"
+    value = "2680000"
   }
 }
 

--- a/Core/RDS/viz/main.tf
+++ b/Core/RDS/viz/main.tf
@@ -51,131 +51,18 @@ resource "aws_db_parameter_group" "hydrovis" {
   family = "postgres15"
 
   parameter {
-    name  = "autovacuum"
-    value = "1"
-  }
-
-  parameter {
-    name  = "autovacuum_analyze_scale_factor"
-    value = "0.005"
-  }
-
-  parameter {
-    name  = "autovacuum_max_workers"
-    value = "4"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
-    name  = "autovacuum_vacuum_scale_factor"
-    value = "0.05"
-  }
-
-  parameter {
-    name  = "autovacuum_work_mem"
-    value = "2128000"
-  }
-
-  parameter {
-    name  = "checkpoint_completion_target"
-    value = "0.9"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
-    name  = "default_statistics_target"
-    value = "100"
-  }
-
-  parameter {
-    name  = "effective_cache_size"
-    value = "8576"
-  }
-
-  parameter {
-    name  = "effective_io_concurrency"
-    value = "200"
-  }
-
-  parameter {
-    name  = "geqo_threshold"
-    value = "12"
-  }
-
-  parameter {
-    name  = "huge_pages"
-    value = "off"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
-    name  = "idle_in_transaction_session_timeout"
-    value = "900000"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
-    name  = "log_autovacuum_min_duration"
-    value = "100"
-  }
-
-  parameter {
-    name  = "maintenance_work_mem"
-    value = "2526332"
-  }
-
-  parameter {
-    name  = "max_connections"
-    value = "400"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
-    name  = "max_parallel_maintenance_workers"
-    value = "4"
-  }
-  
-  parameter {
-    name  = "max_parallel_workers"
-    value = "8"
-  }
-
-  parameter {
-    name  = "max_parallel_workers_per_gather"
-    value = "4"
-  }
-
-  parameter {
-    name  = "max_replication_slots"
-    value = "10"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
-    name  = "max_wal_senders"
-    value = "10"
-    apply_method = "pending-reboot"
+    name  = "checkpoint_timeout"
+    value = "1800"
   }
 
   parameter {
     name  = "max_wal_size"
-    value = "6384"
-  }
-
-  parameter {
-    name  = "max_worker_processes"
-    value = "8"
-    apply_method = "pending-reboot"
+    value = var.environment == "ti" ? "4048" : "8048"
   }
 
   parameter {
     name  = "min_wal_size"
-    value = "2096"
-  }
-
-  parameter {
-    name  = "random_page_cost"
-    value = "1.1"
+    value = "2048"
   }
 
   parameter {
@@ -185,43 +72,21 @@ resource "aws_db_parameter_group" "hydrovis" {
   }
 
   parameter {
-    name         = "rds.rds_superuser_reserved_connections"
-    value        = "10"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
-    name  = "shared_buffers"
-    value = "4096000"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
-    name  = "track_wal_io_timing"
-    value = "0"
-  }
-
-  parameter {
     name  = "wal_buffers"
-    value = "262143"
+    value = var.environment == "ti" ? "64000" : "128000"
     apply_method = "pending-reboot"
-  }
-
-  parameter {
-    name  = "wal_writer_flush_after"
-    value = "128000"
   }
 
   parameter {
     name  = "work_mem"
-    value = "2680000"
+    value = var.environment == "ti" ? "262144" : "1048576"
   }
 }
 
 resource "aws_db_instance" "hydrovis" {
   identifier                   = "hv-vpp-${var.environment}-viz-processing"
   db_name                      = var.viz_db_name
-  instance_class               = "db.m5.4xlarge"
+  instance_class               = var.environment == "ti" ? "db.m5.2xlarge" : "db.m5.4xlarge"
   allocated_storage            = 1024
   storage_type                 = "gp2"
   engine                       = "postgres"

--- a/Core/RDS/viz/main.tf
+++ b/Core/RDS/viz/main.tf
@@ -50,11 +50,7 @@ resource "aws_db_parameter_group" "hydrovis" {
   name   = "hv-vpp-${var.environment}-viz-processing"
   family = "postgres15"
 
-  parameter {
-    name         = "rds.custom_dns_resolution"
-    value        = "1"
-    apply_method = "pending-reboot"
-  }
+
   
 
 
@@ -129,34 +125,28 @@ resource "aws_db_parameter_group" "hydrovis" {
   }
 
   parameter {
-    name  = "max_connections"
-    value = "200"
-    apply_method = "pending-reboot"
-  }
-
-  parameter {
     name  = "maintenance_work_mem"
     value = "2526332"
   }
 
   parameter {
-    name  = "max_worker_processes"
-    value = "8"
+    name  = "max_connections"
+    value = "400"
     apply_method = "pending-reboot"
   }
 
   parameter {
-    name  = "max_parallel_workers_per_gather"
+    name  = "max_parallel_maintenance_workers"
     value = "4"
   }
-
+  
   parameter {
     name  = "max_parallel_workers"
     value = "8"
   }
 
   parameter {
-    name  = "max_parallel_maintenance_workers"
+    name  = "max_parallel_workers_per_gather"
     value = "4"
   }
 
@@ -178,6 +168,12 @@ resource "aws_db_parameter_group" "hydrovis" {
   }
 
   parameter {
+    name  = "max_worker_processes"
+    value = "8"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
     name  = "min_wal_size"
     value = "2096"
   }
@@ -188,8 +184,20 @@ resource "aws_db_parameter_group" "hydrovis" {
   }
 
   parameter {
+    name         = "rds.custom_dns_resolution"
+    value        = "1"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name         = "rds.rds_superuser_reserved_connections"
+    value        = "10"
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
     name  = "shared_buffers"
-    value = "8192000"
+    value = "4096000"
     apply_method = "pending-reboot"
   }
 

--- a/Core/StepFunctions/main.tf
+++ b/Core/StepFunctions/main.tf
@@ -94,6 +94,10 @@ resource "aws_sfn_state_machine" "replace_route_step_function" {
         rnr_domain_generator_arn = var.rnr_domain_generator_arn
         rnr_ec2_instance = var.aws_instances_to_reboot[0]
     })
+
+    tags = {
+      "noaa:monitoring" : "true"
+    }
 }
 
 resource "aws_cloudwatch_event_target" "check_lambda_every_five_minutes" {
@@ -165,6 +169,10 @@ resource "aws_sfn_state_machine" "viz_pipeline_step_function" {
         hand_fim_processing_step_function_arn = aws_sfn_state_machine.hand_fim_processing_step_function.arn
         viz_processing_pipeline_log_group = var.viz_processing_pipeline_log_group
     })
+
+    tags = {
+      "noaa:monitoring" : "true"
+    }
 }
 
 ###############################################

--- a/Core/StepFunctions/viz_processing_pipeline.json.tftpl
+++ b/Core/StepFunctions/viz_processing_pipeline.json.tftpl
@@ -206,7 +206,10 @@
           },
           "Input Data Files": {
             "Type": "Map",
-            "Iterator": {
+            "ItemProcessor": {
+              "ProcessorConfig": {
+                "Mode": "INLINE"
+              },
               "StartAt": "Input Data Checker/Ingester",
               "States": {
                 "Input Data Checker/Ingester": {
@@ -265,6 +268,7 @@
               "keep_flows_at_or_above.$": "$.db_ingest_group.keep_flows_at_or_above",
               "iteration_index.$": "$$.Map.Item.Index"
             },
+            "MaxConcurrency": 5,
             "ItemsPath": "$.db_ingest_group.ingest_datasets"
           },
           "Postprocess SQL - Input Data Prep Finish": {
@@ -341,7 +345,10 @@
     },
     "DB Max Flows Processing": {
       "Type": "Map",
-      "Iterator": {
+      "ItemProcessor": {
+        "ProcessorConfig": {
+          "Mode": "INLINE"
+        },
         "StartAt": "Postprocess SQL - Max Flows",
         "States": {
           "Postprocess SQL - Max Flows": {
@@ -525,7 +532,10 @@
           "Map": {
             "Type": "Map",
             "Next": "Clean Up State Input",
-            "Iterator": {
+            "ItemProcessor": {
+              "ProcessorConfig": {
+                "Mode": "INLINE"
+              },
               "StartAt": "Optimize Rasters",
               "States": {
                 "Optimize Rasters": {
@@ -867,7 +877,10 @@
                 },
                 "HUC Processing Map": {
                   "Type": "Map",
-                  "Iterator": {
+                  "ItemProcessor": {
+                    "ProcessorConfig": {
+                      "Mode": "INLINE"
+                    },
                     "StartAt": "FIM HUC Processing State Machine",
                     "States": {
                       "FIM HUC Processing State Machine": {
@@ -1006,7 +1019,10 @@
           "Parallelize Summaries": {
             "Type": "Map",
             "Next": "Product Summaries Finished Log",
-            "Iterator": {
+            "ItemProcessor": {
+              "ProcessorConfig": {
+                "Mode": "INLINE"
+              },
               "StartAt": "Postprocess SQL - Summary",
               "States": {
                 "Postprocess SQL - Summary": {


### PR DESCRIPTION
- Upgraded viz-processing RDS Instance Type from "db.m5.2xlarge" to "db.m5.4xlarge".
- Adjusted various parameters in RDS Parameter group for viz-processing RDS Instance to better optimize memory usage.
- Added concurrency limit to the "Input Data Files" step of the viz processing pipeline Step Function.
- Updated all Lambda Functions and Viz Lambda Layer to better utilize and dispose of RDS database connections.
  - Updated all instances of DB connections and cursors to use context managers.
  - Explicitly closed all DB connections after they are no longer used.
  - Removed unneeded .commit() calls.
  - Removed any redundant and unused DB connections.
- Temporarily commented out the coastal services in the initialize pipeline Lambda function to stop them from updating.
- Fixed S3 Object downloading issue in hand fim processing Lambda by changing it to stream directly from the bucket and added retries for when it occasionally failed.