### PR TITLE
Adds support for ingesting NWM v1.2 outputs

### DIFF
--- a/Core/LAMBDA/viz_functions/viz_db_ingest/lambda_function.py
+++ b/Core/LAMBDA/viz_functions/viz_db_ingest/lambda_function.py
@@ -76,7 +76,13 @@ def lambda_handler(event, context):
             print("Regex pattern for the forecast hour didn't match the netcdf file")
         
         try:
-            ds['nwm_vers'] = float(ds.NWM_version_number.replace("v",""))
+            try:
+                ds['nwm_vers'] = float(ds.NWM_version_number.replace("v",""))
+            except:
+                try:
+                    ds['nwm_vers'] = float(ds.model_version.replace("NWM ",""))
+                except:
+                    raise
             if 'nwm_vers' not in target_cols:
                 target_cols.append('nwm_vers')
         except:


### PR DESCRIPTION
For archive requests, there was a column that was differently named causing issues with service processing steps for NWM v1.2. This fixes this problem in db ingest.

Also changes some lines for the viz_cache_csvs_to_clipped_geospatial so that the paths would run correctly in my dev environment
