### PR TITLE
Fixes FIM issues in UAT

### DIFF
--- a/Core/LAMBDA/rnr_functions/rnr_domain_generator/sql/dba_stuff.sql
+++ b/Core/LAMBDA/rnr_functions/rnr_domain_generator/sql/dba_stuff.sql
@@ -103,7 +103,7 @@ LEFT JOIN a AS b
 	ON b.location_id = a.location_id
 	AND b.row_num = a.row_num + 1;
 
--- CREATE VIZ-OFFICIAL CROSSWALK TABLE
+-- CREATE VIZ-OFFICIAL CROSSWALK TABLE AND ADD OVERRIDES
 SELECT DISTINCT ON (nwm_feature_id, nws_station_id) 
 	* 
 INTO rnr.nwm_crosswalk
@@ -113,6 +113,10 @@ ORDER BY
 	nws_station_id,
 	nws_usgs_crosswalk_dataset_id DESC NULLS LAST,
 	location_nwm_crosswalk_dataset_id DESC NULLS LAST;
+
+UPDATE rnr.nwm_crosswalk
+SET nwm_feature_id = 11050844
+WHERE nws_station_id = 'PTTP1';
 
 -- CREATE FLOW_THRESHOLDS VIEW
 -- Officially in Core\EC2\RDSBastion\scripts\utils\setup_foreign_tables.tftpl (for automatic execution on deployment), but duplicated here for reference

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim/ana_inundation_extent_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim/ana_inundation_extent_noaa.mapx
@@ -5056,7 +5056,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {
@@ -6099,7 +6099,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim/ana_past_14day_max_inundation_extent_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim/ana_past_14day_max_inundation_extent_noaa.mapx
@@ -5063,7 +5063,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {
@@ -6105,7 +6105,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {
@@ -11341,7 +11341,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {
@@ -12383,7 +12383,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim/ana_past_14day_max_inundation_extent_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim/ana_past_14day_max_inundation_extent_noaa.mapx
@@ -6065,13 +6065,6 @@
             "readOnly" : true,
             "visible" : false,
             "searchMode" : "Exact"
-          },
-          {
-            "type" : "CIMFieldDescription",
-            "alias" : "config",
-            "fieldName" : "config",
-            "visible" : false,
-            "searchMode" : "Exact"
           }
         ],
         "dataConnection" : {
@@ -6080,7 +6073,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.services.%ana_inundation_1_2_3_4_5_6_7_1_2",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select hydro_id_str AS hydro_id,streamflow_cfs,fim_stage_ft,feature_id_str AS nwm_feature_id,fim_version,reference_time,valid_time,update_time,branch,max_rc_stage_ft,max_rc_discharge_cfs,geom,huc8,strm_order,name,config,state,oid from hydrovis.services.ana_past_7day_max_inundation",
+          "sqlQuery" : "select hydro_id_str AS hydro_id,streamflow_cfs,fim_stage_ft,feature_id_str AS nwm_feature_id,fim_version,reference_time,valid_time,update_time,branch,max_rc_stage_ft,max_rc_discharge_cfs,geom,huc8,strm_order,name,state,oid from hydrovis.services.ana_past_7day_max_inundation",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -6198,12 +6191,6 @@
               "type" : "esriFieldTypeString",
               "alias" : "state",
               "length" : 2
-            },
-            {
-              "name" : "config",
-              "type" : "esriFieldTypeString",
-              "alias" : "config",
-              "length" : 10
             },
             {
               "name" : "oid",
@@ -12356,13 +12343,6 @@
             "readOnly" : true,
             "visible" : false,
             "searchMode" : "Exact"
-          },
-          {
-            "type" : "CIMFieldDescription",
-            "alias" : "config",
-            "fieldName" : "config",
-            "visible" : false,
-            "searchMode" : "Exact"
           }
         ],
         "dataConnection" : {
@@ -12371,7 +12351,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.services.%ana_inundation_1_2_3_4_5_6_7_8_2_1_3",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select hydro_id_str AS hydro_id,streamflow_cfs,fim_stage_ft,feature_id_str AS nwm_feature_id,fim_version,reference_time,valid_time,update_time,branch,max_rc_stage_ft,max_rc_discharge_cfs,geom,huc8,strm_order,name,config,state,oid from hydrovis.services.ana_past_14day_max_inundation",
+          "sqlQuery" : "select hydro_id_str AS hydro_id,streamflow_cfs,fim_stage_ft,feature_id_str AS nwm_feature_id,fim_version,reference_time,valid_time,update_time,branch,max_rc_stage_ft,max_rc_discharge_cfs,geom,huc8,strm_order,name,state,oid from hydrovis.services.ana_past_14day_max_inundation",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -12489,12 +12469,6 @@
               "type" : "esriFieldTypeString",
               "alias" : "state",
               "length" : 2
-            },
-            {
-              "name" : "config",
-              "type" : "esriFieldTypeString",
-              "alias" : "config",
-              "length" : 10
             },
             {
               "name" : "oid",

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_hawaii/ana_inundation_extent_hi_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_hawaii/ana_inundation_extent_hi_noaa.mapx
@@ -2584,7 +2584,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {
@@ -3625,7 +3625,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_puertorico/ana_inundation_extent_prvi_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_puertorico/ana_inundation_extent_prvi_noaa.mapx
@@ -2585,7 +2585,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {
@@ -3626,7 +3626,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_blend/mrf_nbm_10day_max_inundation_extent_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_blend/mrf_nbm_10day_max_inundation_extent_noaa.mapx
@@ -6051,13 +6051,6 @@
             "readOnly" : true,
             "visible" : false,
             "searchMode" : "Exact"
-          },
-          {
-            "type" : "CIMFieldDescription",
-            "alias" : "config",
-            "fieldName" : "config",
-            "visible" : false,
-            "searchMode" : "Exact"
           }
         ],
         "dataConnection" : {
@@ -6066,7 +6059,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.services.%ana_inundation_1_2_3_4_5_6_7_3",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select hydro_id_str AS hydro_id,streamflow_cfs,fim_stage_ft,feature_id_str AS feature_id,fim_version,reference_time,update_time,branch,max_rc_stage_ft,max_rc_discharge_cfs,geom,huc8,strm_order,name,config,state,oid from hydrovis.services.mrf_nbm_max_inundation_3day",
+          "sqlQuery" : "select hydro_id_str AS hydro_id,streamflow_cfs,fim_stage_ft,feature_id_str AS feature_id,fim_version,reference_time,update_time,branch,max_rc_stage_ft,max_rc_discharge_cfs,geom,huc8,strm_order,name,state,oid from hydrovis.services.mrf_nbm_max_inundation_3day",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -6178,12 +6171,6 @@
               "type" : "esriFieldTypeString",
               "alias" : "state",
               "length" : 2
-            },
-            {
-              "name" : "config",
-              "type" : "esriFieldTypeString",
-              "alias" : "config",
-              "length" : 10
             },
             {
               "name" : "oid",
@@ -12321,13 +12308,6 @@
             "readOnly" : true,
             "visible" : false,
             "searchMode" : "Exact"
-          },
-          {
-            "type" : "CIMFieldDescription",
-            "alias" : "config",
-            "fieldName" : "config",
-            "visible" : false,
-            "searchMode" : "Exact"
           }
         ],
         "dataConnection" : {
@@ -12336,7 +12316,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.services.%ana_inundation_1_2_3_4_5_6_7_8_2",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select hydro_id_str AS hydro_id,streamflow_cfs,fim_stage_ft,feature_id_str AS feature_id,fim_version,reference_time,update_time,branch,max_rc_stage_ft,max_rc_discharge_cfs,geom,huc8,strm_order,name,config,state,oid from hydrovis.services.mrf_nbm_max_inundation_5day",
+          "sqlQuery" : "select hydro_id_str AS hydro_id,streamflow_cfs,fim_stage_ft,feature_id_str AS feature_id,fim_version,reference_time,update_time,branch,max_rc_stage_ft,max_rc_discharge_cfs,geom,huc8,strm_order,name,state,oid from hydrovis.services.mrf_nbm_max_inundation_5day",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -12448,12 +12428,6 @@
               "type" : "esriFieldTypeString",
               "alias" : "state",
               "length" : 2
-            },
-            {
-              "name" : "config",
-              "type" : "esriFieldTypeString",
-              "alias" : "config",
-              "length" : 10
             },
             {
               "name" : "oid",
@@ -18592,13 +18566,6 @@
             "readOnly" : true,
             "visible" : false,
             "searchMode" : "Exact"
-          },
-          {
-            "type" : "CIMFieldDescription",
-            "alias" : "config",
-            "fieldName" : "config",
-            "visible" : false,
-            "searchMode" : "Exact"
           }
         ],
         "dataConnection" : {
@@ -18607,7 +18574,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.services.%ana_inundation_1_2_3_4_5_6_7_9_1",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select hydro_id_str AS hydro_id,streamflow_cfs,fim_stage_ft,feature_id_str AS feature_id,fim_version,reference_time,update_time,branch,max_rc_stage_ft,max_rc_discharge_cfs,geom,huc8,strm_order,name,config,state,oid from hydrovis.services.mrf_nbm_max_inundation_10day",
+          "sqlQuery" : "select hydro_id_str AS hydro_id,streamflow_cfs,fim_stage_ft,feature_id_str AS feature_id,fim_version,reference_time,update_time,branch,max_rc_stage_ft,max_rc_discharge_cfs,geom,huc8,strm_order,name,state,oid from hydrovis.services.mrf_nbm_max_inundation_10day",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -18719,12 +18686,6 @@
               "type" : "esriFieldTypeString",
               "alias" : "state",
               "length" : 2
-            },
-            {
-              "name" : "config",
-              "type" : "esriFieldTypeString",
-              "alias" : "config",
-              "length" : 10
             },
             {
               "name" : "oid",

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_blend/mrf_nbm_10day_max_inundation_extent_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_blend/mrf_nbm_10day_max_inundation_extent_noaa.mapx
@@ -5057,7 +5057,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {
@@ -6091,7 +6091,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {
@@ -11314,7 +11314,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {
@@ -12348,7 +12348,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {
@@ -17571,7 +17571,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {
@@ -18606,7 +18606,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_mem1/mrf_gfs_10day_max_inundation_extent_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_mem1/mrf_gfs_10day_max_inundation_extent_noaa.mapx
@@ -6051,13 +6051,6 @@
             "readOnly" : true,
             "visible" : false,
             "searchMode" : "Exact"
-          },
-          {
-            "type" : "CIMFieldDescription",
-            "alias" : "config",
-            "fieldName" : "config",
-            "visible" : false,
-            "searchMode" : "Exact"
           }
         ],
         "dataConnection" : {
@@ -6066,7 +6059,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.services.%ana_inundation_1_2_3_4_5_6_7_3",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select hydro_id_str AS hydro_id,streamflow_cfs,fim_stage_ft,feature_id_str AS feature_id,fim_version,reference_time,update_time,branch,max_rc_stage_ft,max_rc_discharge_cfs,geom,huc8,strm_order,name,config,state,oid from hydrovis.services.mrf_gfs_max_inundation_3day",
+          "sqlQuery" : "select hydro_id_str AS hydro_id,streamflow_cfs,fim_stage_ft,feature_id_str AS feature_id,fim_version,reference_time,update_time,branch,max_rc_stage_ft,max_rc_discharge_cfs,geom,huc8,strm_order,name,state,oid from hydrovis.services.mrf_gfs_max_inundation_3day",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -6178,12 +6171,6 @@
               "type" : "esriFieldTypeString",
               "alias" : "state",
               "length" : 2
-            },
-            {
-              "name" : "config",
-              "type" : "esriFieldTypeString",
-              "alias" : "config",
-              "length" : 10
             },
             {
               "name" : "oid",
@@ -12321,13 +12308,6 @@
             "readOnly" : true,
             "visible" : false,
             "searchMode" : "Exact"
-          },
-          {
-            "type" : "CIMFieldDescription",
-            "alias" : "config",
-            "fieldName" : "config",
-            "visible" : false,
-            "searchMode" : "Exact"
           }
         ],
         "dataConnection" : {
@@ -12336,7 +12316,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.services.%ana_inundation_1_2_3_4_5_6_7_8_2",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select hydro_id_str AS hydro_id,streamflow_cfs,fim_stage_ft,feature_id_str AS feature_id,fim_version,reference_time,update_time,branch,max_rc_stage_ft,max_rc_discharge_cfs,geom,huc8,strm_order,name,config,state,oid from hydrovis.services.mrf_gfs_max_inundation_5day",
+          "sqlQuery" : "select hydro_id_str AS hydro_id,streamflow_cfs,fim_stage_ft,feature_id_str AS feature_id,fim_version,reference_time,update_time,branch,max_rc_stage_ft,max_rc_discharge_cfs,geom,huc8,strm_order,name,state,oid from hydrovis.services.mrf_gfs_max_inundation_5day",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -12448,12 +12428,6 @@
               "type" : "esriFieldTypeString",
               "alias" : "state",
               "length" : 2
-            },
-            {
-              "name" : "config",
-              "type" : "esriFieldTypeString",
-              "alias" : "config",
-              "length" : 10
             },
             {
               "name" : "oid",
@@ -18592,13 +18566,6 @@
             "readOnly" : true,
             "visible" : false,
             "searchMode" : "Exact"
-          },
-          {
-            "type" : "CIMFieldDescription",
-            "alias" : "config",
-            "fieldName" : "config",
-            "visible" : false,
-            "searchMode" : "Exact"
           }
         ],
         "dataConnection" : {
@@ -18607,7 +18574,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.services.%ana_inundation_1_2_3_4_5_6_7_9_1",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select hydro_id_str AS hydro_id,streamflow_cfs,fim_stage_ft,feature_id_str AS feature_id,fim_version,reference_time,update_time,branch,max_rc_stage_ft,max_rc_discharge_cfs,geom,huc8,strm_order,name,config,state,oid from hydrovis.services.mrf_gfs_max_inundation_10day",
+          "sqlQuery" : "select hydro_id_str AS hydro_id,streamflow_cfs,fim_stage_ft,feature_id_str AS feature_id,fim_version,reference_time,update_time,branch,max_rc_stage_ft,max_rc_discharge_cfs,geom,huc8,strm_order,name,state,oid from hydrovis.services.mrf_gfs_max_inundation_10day",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -18719,12 +18686,6 @@
               "type" : "esriFieldTypeString",
               "alias" : "state",
               "length" : 2
-            },
-            {
-              "name" : "config",
-              "type" : "esriFieldTypeString",
-              "alias" : "config",
-              "length" : 10
             },
             {
               "name" : "oid",

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_mem1/mrf_gfs_10day_max_inundation_extent_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_mem1/mrf_gfs_10day_max_inundation_extent_noaa.mapx
@@ -5057,7 +5057,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {
@@ -6091,7 +6091,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {
@@ -11314,7 +11314,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {
@@ -12348,7 +12348,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {
@@ -17571,7 +17571,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {
@@ -18606,7 +18606,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/replace_route/rfc_based_5day_max_inundation_extent_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/replace_route/rfc_based_5day_max_inundation_extent_noaa.mapx
@@ -5065,7 +5065,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {
@@ -6115,7 +6115,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range/srf_18hr_max_inundation_extent_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range/srf_18hr_max_inundation_extent_noaa.mapx
@@ -5058,7 +5058,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {
@@ -6094,7 +6094,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_hawaii/srf_48hr_max_inundation_extent_hi_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_hawaii/srf_48hr_max_inundation_extent_hi_noaa.mapx
@@ -2585,7 +2585,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {
@@ -3619,7 +3619,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_puertorico/srf_48hr_max_inundation_extent_prvi_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_puertorico/srf_48hr_max_inundation_extent_prvi_noaa.mapx
@@ -2585,7 +2585,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {
@@ -3619,7 +3619,7 @@
             },
             {
               "name" : "fim_stage_ft",
-              "type" : "esriFieldTypeDouble",
+              "type" : "esriFieldTypeInteger",
               "alias" : "fim_stage_ft"
             },
             {


### PR DESCRIPTION
A few services were not drawing and all services were displaying "0" for all "FIM Stage (ft)" field values. This PR fixes both issues.

The "FIM Stage (ft)" issue was introduced because the new Cache FIM mechanism now produces FIM to the nearest foot, rather than partial (I cannot recall exactly) foot as it did before. The underlying data type of this field is thus now "esriFieldTypeInteger" rather than "esriFieldTypeDouble" and was never updated in the service MAPX files. I have updated all of those instance appropriately.

The following three services were not drawing due to the "config" field being configured in the service, but not existing in the underlying DB table:

ana_past_14day_max_inundation_extent_noaa
mrf_nbm_10day_max_inundation_extent_noaa
mrf_gfs_10day_max_inundation_extent_noaa

I have removed all references to this "config" field, which - although I couldn't find any trace of why it was in there in the first place - shouldn't be a problem since this field was configured to be invisible anyway (i.e. with "visible": false).