### PR TITLE
Fixes to get SCHISM FIM and new services to work in UAT/Prod

### DIFF
--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/analysis_assim_alaska/ana_high_flow_magnitude_ak.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/analysis_assim_alaska/ana_high_flow_magnitude_ak.sql
@@ -42,6 +42,6 @@ SELECT channels.feature_id,
 	high_flow_mag.flow_50yr,
 	to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS update_time,
 	channels.geom
-INTO publish.ana_high_flow_magnitude
+INTO publish.ana_high_flow_magnitude_ak
 FROM derived.channels_CONUS channels
 JOIN high_flow_mag ON channels.feature_id = high_flow_mag.feature_id;

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/analysis_assim_alaska/ana_high_flow_magnitude_ak.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/analysis_assim_alaska/ana_high_flow_magnitude_ak.sql
@@ -1,47 +1,47 @@
 DROP TABLE IF EXISTS publish.ana_high_flow_magnitude_ak;
 WITH high_flow_mag AS
 	(SELECT maxflows.feature_id,
-			maxflows.discharge_cfs AS max_flow,
-			maxflows.reference_time,
-			maxflows.nwm_vers,
-			CASE
-                WHEN maxflows.discharge_cfs >= thresholds.rf_50_0_17c THEN '2'::text
-				WHEN maxflows.discharge_cfs >= thresholds.rf_25_0_17c THEN '4'::text
-				WHEN maxflows.discharge_cfs >= thresholds.rf_10_0_17c THEN '10'::text
-                WHEN maxflows.discharge_cfs >= thresholds.rf_5_0_17c THEN '20'::text
-	 			WHEN maxflows.discharge_cfs >= thresholds.rf_2_0_17c THEN '50'::text
-                WHEN maxflows.discharge_cfs >= thresholds.high_water_threshold THEN '>50'::text
-							ELSE NULL::text
-			END AS recur_cat,
-        thresholds.high_water_threshold AS high_water_threshold,
-		thresholds.rf_2_0_17c AS flow_2yr,   
-		thresholds.rf_5_0_17c AS flow_5yr,
-        thresholds.rf_10_0_17c AS flow_10yr,
-		thresholds.rf_25_0_17c AS flow_25yr,
-		thresholds.rf_50_0_17c AS flow_50yr
-		FROM cache.max_flows_ana maxflows
-		JOIN derived.recurrence_flows_CONUS thresholds ON maxflows.feature_id = thresholds.feature_id
-		WHERE (thresholds.high_water_threshold > 0::double precision)
-			AND maxflows.discharge_cfs >= thresholds.high_water_threshold)
+                maxflows.discharge_cfs AS max_flow,
+                maxflows.reference_time,
+                maxflows.nwm_vers,
+                CASE
+                    WHEN maxflows.discharge_cfs >= thresholds.rf_50_0_17c THEN '2'::text
+                    WHEN maxflows.discharge_cfs >= thresholds.rf_25_0_17c THEN '4'::text
+                    WHEN maxflows.discharge_cfs >= thresholds.rf_10_0_17c THEN '10'::text
+                    WHEN maxflows.discharge_cfs >= thresholds.rf_5_0_17c THEN '20'::text
+                    WHEN maxflows.discharge_cfs >= thresholds.rf_2_0_17c THEN '50'::text
+                    WHEN maxflows.discharge_cfs >= thresholds.high_water_threshold THEN '>50'::text
+                    ELSE NULL::text
+                END AS recur_cat,
+                thresholds.high_water_threshold AS high_water_threshold,
+                thresholds.rf_2_0_17c AS flow_2yr,
+                thresholds.rf_5_0_17c AS flow_5yr,
+                thresholds.rf_10_0_17c AS flow_10yr,
+                thresholds.rf_25_0_17c AS flow_25yr,
+                thresholds.rf_50_0_17c AS flow_50yr
+       FROM cache.max_flows_ana_ak maxflows
+       JOIN derived.recurrence_flows_ak thresholds ON maxflows.feature_id = thresholds.feature_id
+       WHERE (thresholds.high_water_threshold > 0::double precision)
+       AND maxflows.discharge_cfs >= thresholds.high_water_threshold)
 SELECT channels.feature_id,
-	channels.feature_id::TEXT AS feature_id_str,
-	channels.strm_order,
-	channels.name,
-	channels.state,
-	channels.huc6,
-	high_flow_mag.nwm_vers,
-	high_flow_mag.reference_time,
-	high_flow_mag.reference_time AS valid_time,
-	high_flow_mag.max_flow,
-	high_flow_mag.recur_cat,
-	high_flow_mag.high_water_threshold,
-	high_flow_mag.flow_2yr,
-	high_flow_mag.flow_5yr,
-	high_flow_mag.flow_10yr,
-	high_flow_mag.flow_25yr,
-	high_flow_mag.flow_50yr,
-	to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS update_time,
-	channels.geom
+       channels.feature_id::TEXT AS feature_id_str,
+       channels.strm_order,
+       channels.name,
+       channels.huc6,
+       'AK' as state,
+       high_flow_mag.nwm_vers,
+       high_flow_mag.reference_time,
+       high_flow_mag.reference_time AS valid_time,
+       high_flow_mag.max_flow,
+       high_flow_mag.recur_cat,
+       high_flow_mag.high_water_threshold,
+       high_flow_mag.flow_2yr,
+       high_flow_mag.flow_5yr,
+       high_flow_mag.flow_10yr,
+       high_flow_mag.flow_25yr,
+       high_flow_mag.flow_50yr,
+       to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS update_time,
+       channels.geom
 INTO publish.ana_high_flow_magnitude_ak
-FROM derived.channels_CONUS channels
+FROM derived.channels_alaska channels
 JOIN high_flow_mag ON channels.feature_id = high_flow_mag.feature_id;

--- a/Core/StepFunctions/main.tf
+++ b/Core/StepFunctions/main.tf
@@ -26,6 +26,10 @@ variable "schism_fim_job_queue_arn" {
   type        = string
 }
 
+variable "schism_fim_datasets_bucket" {
+  type        = string
+}
+
 variable "optimize_rasters_arn" {
   type        = string
 }
@@ -145,10 +149,11 @@ resource "aws_sfn_state_machine" "schism_fim_processing_step_function" {
     role_arn = var.viz_lambda_role
 
     definition = templatefile("${path.module}/schism_fim_processing.json.tftpl", {
-        db_postprocess_sql_arn = var.db_postprocess_sql_arn
-        schism_fim_job_definition_arn  = var.schism_fim_job_definition_arn
-        schism_fim_job_queue_arn  = var.schism_fim_job_queue_arn
-        optimize_rasters_arn      = var.optimize_rasters_arn
+        db_postprocess_sql_arn          = var.db_postprocess_sql_arn
+        schism_fim_job_definition_arn   = var.schism_fim_job_definition_arn
+        schism_fim_job_queue_arn        = var.schism_fim_job_queue_arn
+        optimize_rasters_arn            = var.optimize_rasters_arn
+        schism_fim_datasets_bucket      = var.schism_fim_datasets_bucket
     })
 }
 

--- a/Core/StepFunctions/schism_fim_processing.json.tftpl
+++ b/Core/StepFunctions/schism_fim_processing.json.tftpl
@@ -39,7 +39,7 @@
       "Type": "Task",
       "Next": "Iterate over Tiles",
       "Parameters": {
-        "Bucket": "hydrovis-ti-deployment-us-east-1",
+        "Bucket": "${schism_fim_datasets_bucket}",
         "Prefix.$": "States.Format('schism_fim/dems/{}/tiles/', States.ArrayGetItem(States.StringSplit($.fim_config.sql_file, '_'), 1))"
       },
       "Resource": "arn:aws:states:::aws-sdk:s3:listObjectsV2",

--- a/Core/main.tf
+++ b/Core/main.tf
@@ -642,6 +642,7 @@ module "step-functions" {
   hand_fim_processing_arn           = module.viz-lambda-functions.hand_fim_processing.arn
   schism_fim_job_definition_arn     = module.viz-lambda-functions.schism_fim.job_definition.arn
   schism_fim_job_queue_arn          = module.viz-lambda-functions.schism_fim.job_queue.arn
+  schism_fim_datasets_bucket        = module.s3.buckets["deployment"].bucket
   initialize_pipeline_arn           = module.viz-lambda-functions.initialize_pipeline.arn
   rnr_domain_generator_arn          = module.rnr-lambda-functions.rnr_domain_generator.arn
   email_sns_topics                  = module.sns.email_sns_topics


### PR DESCRIPTION
A few tweaks were required to get the latest SCHISM FIM updates to work in UAT (and eventually Prod). Most of these were manual tasks regardless (i.e. would have needed to be manual in the first place). But one change should have been handled by automation and thus warrants this official PR with a few code changes.

**Code-changes:** 
* Replace a hard-coded bucket name with a variable (see commit diff)

**Manual changes:**
* Change owner of all ingest.\*coastal\* tables from postgres to viz_proc_admin_rw_user

     ```sql
     /* Executed on the VIZ RDS instance in UAT es-east-1 */
     DO $$
       DECLARE row RECORD;
       BEGIN
         FOR row IN SELECT * FROM pg_tables 
           WHERE schemaname = 'ingest' and tableowner != 'viz_proc_admin_rw_user' LOOP
         EXECUTE FORMAT('ALTER TABLE %I.%I OWNER TO viz_proc_admin_rw_user', row.schemaname, row.tablename);
       END LOOP;
     END; 
     $$;
     ```
* Rename S3 folders:
  * hydrovis-uat-deployment-us-east-1/schism-fim/dems/hawaii to hydrovis-uat-deployment-us-east-1/schism-fim/dems/hi
  * hydrovis-uat-deployment-us-east-1/schism-fim/dems/puertorico to hydrovis-uat-deployment-us-east-1/schism-fim/dems/prvi
  * hydrovis-uat-deployment-us-east-1/schism-fim/masks/hawaii to hydrovis-uat-deployment-us-east-1/schism-fim/masks/hi
  * hydrovis-uat-deployment-us-east-1/schism-fim/masks/puertorico to hydrovis-uat-deployment-us-east-1/schism-fim/masks/prvi