### PR TITLE
Hotfix: Remove "huc8" field from coastal extent services

### DIFF
--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/mrf_gfs_10day_max_coastal_inundation_atlgulf_psurge.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/mrf_gfs_10day_max_coastal_inundation_atlgulf_psurge.sql
@@ -1,5 +1,5 @@
 INSERT INTO ingest.mrf_gfs_10day_max_coastal_inundation_atlgulf_psurge (
-	geom, reference_time, huc8)
+	geom, reference_time)
 	VALUES (NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), '-9999');
 
 DROP TABLE IF EXISTS publish.mrf_gfs_10day_max_coastal_inundation_atlgulf_psurge;

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/mrf_gfs_3day_max_coastal_inundation_atlgulf_psurge.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/mrf_gfs_3day_max_coastal_inundation_atlgulf_psurge.sql
@@ -1,5 +1,5 @@
 INSERT INTO ingest.mrf_gfs_3day_max_coastal_inundation_atlgulf_psurge (
-	geom, reference_time, huc8)
+	geom, reference_time)
 	VALUES (NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), '-9999');
 
 DROP TABLE IF EXISTS publish.mrf_gfs_3day_max_coastal_inundation_atlgulf_psurge;

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/mrf_gfs_5day_max_coastal_inundation_atlgulf_psurge.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/mrf_gfs_5day_max_coastal_inundation_atlgulf_psurge.sql
@@ -1,5 +1,5 @@
 INSERT INTO ingest.mrf_gfs_5day_max_coastal_inundation_atlgulf_psurge (
-	geom, reference_time, huc8)
+	geom, reference_time)
 	VALUES (NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), '-9999');
 
 DROP TABLE IF EXISTS publish.mrf_gfs_5day_max_coastal_inundation_atlgulf_psurge;

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/mrf_nbm_10day_max_coastal_inundation_atlgulf_psurge.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/mrf_nbm_10day_max_coastal_inundation_atlgulf_psurge.sql
@@ -1,5 +1,5 @@
 INSERT INTO ingest.mrf_nbm_10day_max_coastal_inundation_atlgulf_psurge (
-	geom, reference_time, huc8)
+	geom, reference_time)
 	VALUES (NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), '-9999');
 
 DROP TABLE IF EXISTS publish.mrf_nbm_10day_max_coastal_inundation_atlgulf_psurge;

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/mrf_nbm_3day_max_coastal_inundation_atlgulf_psurge.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/mrf_nbm_3day_max_coastal_inundation_atlgulf_psurge.sql
@@ -1,5 +1,5 @@
 INSERT INTO ingest.mrf_nbm_3day_max_coastal_inundation_atlgulf_psurge (
-	geom, reference_time, huc8)
+	geom, reference_time)
 	VALUES (NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), '-9999');
 
 DROP TABLE IF EXISTS publish.mrf_nbm_3day_max_coastal_inundation_atlgulf_psurge;

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/mrf_nbm_5day_max_coastal_inundation_atlgulf_psurge.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/mrf_nbm_5day_max_coastal_inundation_atlgulf_psurge.sql
@@ -1,5 +1,5 @@
 INSERT INTO ingest.mrf_nbm_5day_max_coastal_inundation_atlgulf_psurge (
-	geom, reference_time, huc8)
+	geom, reference_time)
 	VALUES (NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), '-9999');
 
 DROP TABLE IF EXISTS publish.mrf_nbm_5day_max_coastal_inundation_atlgulf_psurge;

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/srf_18hr_max_coastal_inundation_atlgulf_psurge.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/srf_18hr_max_coastal_inundation_atlgulf_psurge.sql
@@ -1,5 +1,5 @@
 INSERT INTO ingest.srf_18hr_max_coastal_inundation_atlgulf_psurge (
-	geom, reference_time, huc8)
+	geom, reference_time)
 	VALUES (NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), '-9999');
 
 DROP TABLE IF EXISTS publish.srf_18hr_max_coastal_inundation_atlgulf_psurge;

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal/ana_coastal_inundation_extent_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal/ana_coastal_inundation_extent_noaa.mapx
@@ -271,16 +271,9 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "displayField" : "huc8",
+        "displayField" : "oid",
         "editable" : true,
         "fieldDescriptions" : [
-          {
-            "type" : "CIMFieldDescription",
-            "alias" : "USGS HUC8",
-            "fieldName" : "huc8",
-            "visible" : true,
-            "searchMode" : "Exact"
-          },
           {
             "type" : "CIMFieldDescription",
             "alias" : "Reference Time",
@@ -331,7 +324,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.hydrovis.%analysis_assim_inundation_extent_schism",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select geom,huc8,reference_time,update_time,valid_time,oid from hydrovis.services.ana_coastal_inundation",
+          "sqlQuery" : "select geom,reference_time,update_time,valid_time,oid from hydrovis.services.ana_coastal_inundation",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -364,12 +357,6 @@
                   "latestWkid" : 3857
                 }
               }
-            },
-            {
-              "name" : "huc8",
-              "type" : "esriFieldTypeString",
-              "alias" : "huc8",
-              "length" : 8
             },
             {
               "name" : "reference_time",
@@ -409,7 +396,7 @@
         {
           "type" : "CIMLabelClass",
           "expressionTitle" : "Custom",
-          "expression" : "$feature.huc8",
+          "expression" : "$feature.oid",
           "expressionEngine" : "Arcade",
           "featuresToLabel" : "AllVisibleFeatures",
           "maplexLabelPlacementProperties" : {

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal_hawaii/ana_coastal_inundation_extent_hi_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal_hawaii/ana_coastal_inundation_extent_hi_noaa.mapx
@@ -271,16 +271,9 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "displayField" : "huc8",
+        "displayField" : "oid",
         "editable" : true,
         "fieldDescriptions" : [
-          {
-            "type" : "CIMFieldDescription",
-            "alias" : "USGS HUC8",
-            "fieldName" : "huc8",
-            "visible" : true,
-            "searchMode" : "Exact"
-          },
           {
             "type" : "CIMFieldDescription",
             "alias" : "Reference Time",
@@ -331,7 +324,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.hydrovis.%analysis_assim_inundation_extent_schism",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select geom,huc8,reference_time,update_time,valid_time,oid from hydrovis.services.ana_coastal_inundation_hi",
+          "sqlQuery" : "select geom,reference_time,update_time,valid_time,oid from hydrovis.services.ana_coastal_inundation_hi",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -364,12 +357,6 @@
                   "latestWkid" : 3857
                 }
               }
-            },
-            {
-              "name" : "huc8",
-              "type" : "esriFieldTypeString",
-              "alias" : "huc8",
-              "length" : 8
             },
             {
               "name" : "reference_time",
@@ -409,7 +396,7 @@
         {
           "type" : "CIMLabelClass",
           "expressionTitle" : "Custom",
-          "expression" : "$feature.huc8",
+          "expression" : "$feature.oid",
           "expressionEngine" : "Arcade",
           "featuresToLabel" : "AllVisibleFeatures",
           "maplexLabelPlacementProperties" : {

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal_puertorico/ana_coastal_inundation_extent_prvi_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal_puertorico/ana_coastal_inundation_extent_prvi_noaa.mapx
@@ -271,16 +271,9 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "displayField" : "huc8",
+        "displayField" : "oid",
         "editable" : true,
         "fieldDescriptions" : [
-          {
-            "type" : "CIMFieldDescription",
-            "alias" : "USGS HUC8",
-            "fieldName" : "huc8",
-            "visible" : true,
-            "searchMode" : "Exact"
-          },
           {
             "type" : "CIMFieldDescription",
             "alias" : "Reference Time",
@@ -331,7 +324,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.hydrovis.%analysis_assim_inundation_extent_schism",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select geom,huc8,reference_time,update_time,valid_time,oid from hydrovis.services.ana_coastal_inundation_prvi",
+          "sqlQuery" : "select geom,reference_time,update_time,valid_time,oid from hydrovis.services.ana_coastal_inundation_prvi",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -364,12 +357,6 @@
                   "latestWkid" : 3857
                 }
               }
-            },
-            {
-              "name" : "huc8",
-              "type" : "esriFieldTypeString",
-              "alias" : "huc8",
-              "length" : 8
             },
             {
               "name" : "reference_time",
@@ -409,7 +396,7 @@
         {
           "type" : "CIMLabelClass",
           "expressionTitle" : "Custom",
-          "expression" : "$feature.huc8",
+          "expression" : "$feature.oid",
           "expressionEngine" : "Arcade",
           "featuresToLabel" : "AllVisibleFeatures",
           "maplexLabelPlacementProperties" : {

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_blend_coastal/mrf_nbm_10day_max_coastal_inundation_extent_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_blend_coastal/mrf_nbm_10day_max_coastal_inundation_extent_noaa.mapx
@@ -278,16 +278,9 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "displayField" : "huc8",
+        "displayField" : "oid",
         "editable" : true,
         "fieldDescriptions" : [
-          {
-            "type" : "CIMFieldDescription",
-            "alias" : "USGS HUC8",
-            "fieldName" : "huc8",
-            "visible" : true,
-            "searchMode" : "Exact"
-          },
           {
             "type" : "CIMFieldDescription",
             "alias" : "Reference Time",
@@ -331,7 +324,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.hydrovis.%analysis_assim_inundation_extent_schism_3",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select huc8,reference_time,geom,update_time,oid from hydrovis.services.mrf_nbm_3day_max_coastal_inundation",
+          "sqlQuery" : "select reference_time,geom,update_time,oid from hydrovis.services.mrf_nbm_3day_max_coastal_inundation",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -350,12 +343,6 @@
             }
           },
           "queryFields" : [
-            {
-              "name" : "huc8",
-              "type" : "esriFieldTypeString",
-              "alias" : "huc8",
-              "length" : 60000
-            },
             {
               "name" : "reference_time",
               "type" : "esriFieldTypeString",
@@ -403,7 +390,7 @@
         {
           "type" : "CIMLabelClass",
           "expressionTitle" : "Custom",
-          "expression" : "$feature.huc8",
+          "expression" : "$feature.oid",
           "expressionEngine" : "Arcade",
           "featuresToLabel" : "AllVisibleFeatures",
           "maplexLabelPlacementProperties" : {
@@ -688,16 +675,9 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "displayField" : "huc8",
+        "displayField" : "oid",
         "editable" : true,
         "fieldDescriptions" : [
-          {
-            "type" : "CIMFieldDescription",
-            "alias" : "USGS HUC8",
-            "fieldName" : "huc8",
-            "visible" : true,
-            "searchMode" : "Exact"
-          },
           {
             "type" : "CIMFieldDescription",
             "alias" : "Reference Time",
@@ -741,7 +721,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.hydrovis.%analysis_assim_inundation_extent_schism_3_psurge",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select huc8,reference_time,geom,update_time,oid from hydrovis.services.mrf_nbm_3day_max_coastal_inundation_atlgulf_psurge",
+          "sqlQuery" : "select reference_time,geom,update_time,oid from hydrovis.services.mrf_nbm_3day_max_coastal_inundation_atlgulf_psurge",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -760,12 +740,6 @@
             }
           },
           "queryFields" : [
-            {
-              "name" : "huc8",
-              "type" : "esriFieldTypeString",
-              "alias" : "huc8",
-              "length" : 60000
-            },
             {
               "name" : "reference_time",
               "type" : "esriFieldTypeString",
@@ -813,7 +787,7 @@
         {
           "type" : "CIMLabelClass",
           "expressionTitle" : "Custom",
-          "expression" : "$feature.huc8",
+          "expression" : "$feature.oid",
           "expressionEngine" : "Arcade",
           "featuresToLabel" : "AllVisibleFeatures",
           "maplexLabelPlacementProperties" : {
@@ -1098,16 +1072,9 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "displayField" : "huc8",
+        "displayField" : "oid",
         "editable" : true,
         "fieldDescriptions" : [
-          {
-            "type" : "CIMFieldDescription",
-            "alias" : "USGS HUC8",
-            "fieldName" : "huc8",
-            "visible" : true,
-            "searchMode" : "Exact"
-          },
           {
             "type" : "CIMFieldDescription",
             "alias" : "Reference Time",
@@ -1151,7 +1118,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.hydrovis.%analysis_assim_inundation_extent_schism",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select huc8,reference_time,geom,update_time,oid from hydrovis.services.mrf_nbm_5day_max_coastal_inundation",
+          "sqlQuery" : "select reference_time,geom,update_time,oid from hydrovis.services.mrf_nbm_5day_max_coastal_inundation",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -1170,12 +1137,6 @@
             }
           },
           "queryFields" : [
-            {
-              "name" : "huc8",
-              "type" : "esriFieldTypeString",
-              "alias" : "huc8",
-              "length" : 60000
-            },
             {
               "name" : "reference_time",
               "type" : "esriFieldTypeString",
@@ -1223,7 +1184,7 @@
         {
           "type" : "CIMLabelClass",
           "expressionTitle" : "Custom",
-          "expression" : "$feature.huc8",
+          "expression" : "$feature.oid",
           "expressionEngine" : "Arcade",
           "featuresToLabel" : "AllVisibleFeatures",
           "maplexLabelPlacementProperties" : {
@@ -1508,16 +1469,9 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "displayField" : "huc8",
+        "displayField" : "oid",
         "editable" : true,
         "fieldDescriptions" : [
-          {
-            "type" : "CIMFieldDescription",
-            "alias" : "USGS HUC8",
-            "fieldName" : "huc8",
-            "visible" : true,
-            "searchMode" : "Exact"
-          },
           {
             "type" : "CIMFieldDescription",
             "alias" : "Reference Time",
@@ -1561,7 +1515,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.hydrovis.%analysis_assim_inundation_extent_schism_psurge",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select huc8,reference_time,geom,update_time,oid from hydrovis.services.mrf_nbm_5day_max_coastal_inundation_atlgulf_psurge",
+          "sqlQuery" : "select reference_time,geom,update_time,oid from hydrovis.services.mrf_nbm_5day_max_coastal_inundation_atlgulf_psurge",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -1580,12 +1534,6 @@
             }
           },
           "queryFields" : [
-            {
-              "name" : "huc8",
-              "type" : "esriFieldTypeString",
-              "alias" : "huc8",
-              "length" : 60000
-            },
             {
               "name" : "reference_time",
               "type" : "esriFieldTypeString",
@@ -1633,7 +1581,7 @@
         {
           "type" : "CIMLabelClass",
           "expressionTitle" : "Custom",
-          "expression" : "$feature.huc8",
+          "expression" : "$feature.oid",
           "expressionEngine" : "Arcade",
           "featuresToLabel" : "AllVisibleFeatures",
           "maplexLabelPlacementProperties" : {
@@ -1918,16 +1866,9 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "displayField" : "huc8",
+        "displayField" : "oid",
         "editable" : true,
         "fieldDescriptions" : [
-          {
-            "type" : "CIMFieldDescription",
-            "alias" : "USGS HUC8",
-            "fieldName" : "huc8",
-            "visible" : true,
-            "searchMode" : "Exact"
-          },
           {
             "type" : "CIMFieldDescription",
             "alias" : "Reference Time",
@@ -1971,7 +1912,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.hydrovis.%analysis_assim_inundation_extent_schism_3",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select huc8,reference_time,geom,update_time,oid from hydrovis.services.mrf_nbm_10day_max_coastal_inundation",
+          "sqlQuery" : "select reference_time,geom,update_time,oid from hydrovis.services.mrf_nbm_10day_max_coastal_inundation",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -1990,12 +1931,6 @@
             }
           },
           "queryFields" : [
-            {
-              "name" : "huc8",
-              "type" : "esriFieldTypeString",
-              "alias" : "huc8",
-              "length" : 60000
-            },
             {
               "name" : "reference_time",
               "type" : "esriFieldTypeString",
@@ -2043,7 +1978,7 @@
         {
           "type" : "CIMLabelClass",
           "expressionTitle" : "Custom",
-          "expression" : "$feature.huc8",
+          "expression" : "$feature.oid",
           "expressionEngine" : "Arcade",
           "featuresToLabel" : "AllVisibleFeatures",
           "maplexLabelPlacementProperties" : {
@@ -2328,16 +2263,9 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "displayField" : "huc8",
+        "displayField" : "oid",
         "editable" : true,
         "fieldDescriptions" : [
-          {
-            "type" : "CIMFieldDescription",
-            "alias" : "USGS HUC8",
-            "fieldName" : "huc8",
-            "visible" : true,
-            "searchMode" : "Exact"
-          },
           {
             "type" : "CIMFieldDescription",
             "alias" : "Reference Time",
@@ -2381,7 +2309,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.hydrovis.%analysis_assim_inundation_extent_schism_3_psurge",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select huc8,reference_time,geom,update_time,oid from hydrovis.services.mrf_nbm_10day_max_coastal_inundation_atlgulf_psurge",
+          "sqlQuery" : "select reference_time,geom,update_time,oid from hydrovis.services.mrf_nbm_10day_max_coastal_inundation_atlgulf_psurge",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -2400,12 +2328,6 @@
             }
           },
           "queryFields" : [
-            {
-              "name" : "huc8",
-              "type" : "esriFieldTypeString",
-              "alias" : "huc8",
-              "length" : 60000
-            },
             {
               "name" : "reference_time",
               "type" : "esriFieldTypeString",
@@ -2453,7 +2375,7 @@
         {
           "type" : "CIMLabelClass",
           "expressionTitle" : "Custom",
-          "expression" : "$feature.huc8",
+          "expression" : "$feature.oid",
           "expressionEngine" : "Arcade",
           "featuresToLabel" : "AllVisibleFeatures",
           "maplexLabelPlacementProperties" : {

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_coastal_mem1/mrf_gfs_10day_max_coastal_inundation_extent_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_coastal_mem1/mrf_gfs_10day_max_coastal_inundation_extent_noaa.mapx
@@ -278,16 +278,9 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "displayField" : "huc8",
+        "displayField" : "oid",
         "editable" : true,
         "fieldDescriptions" : [
-          {
-            "type" : "CIMFieldDescription",
-            "alias" : "USGS HUC8",
-            "fieldName" : "huc8",
-            "visible" : true,
-            "searchMode" : "Exact"
-          },
           {
             "type" : "CIMFieldDescription",
             "alias" : "Reference Time",
@@ -331,7 +324,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.hydrovis.%analysis_assim_inundation_extent_schism_3",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select huc8,reference_time,geom,update_time,oid from hydrovis.services.mrf_gfs_3day_max_coastal_inundation",
+          "sqlQuery" : "select reference_time,geom,update_time,oid from hydrovis.services.mrf_gfs_3day_max_coastal_inundation",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -350,12 +343,6 @@
             }
           },
           "queryFields" : [
-            {
-              "name" : "huc8",
-              "type" : "esriFieldTypeString",
-              "alias" : "huc8",
-              "length" : 60000
-            },
             {
               "name" : "reference_time",
               "type" : "esriFieldTypeString",
@@ -403,7 +390,7 @@
         {
           "type" : "CIMLabelClass",
           "expressionTitle" : "Custom",
-          "expression" : "$feature.huc8",
+          "expression" : "$feature.oid",
           "expressionEngine" : "Arcade",
           "featuresToLabel" : "AllVisibleFeatures",
           "maplexLabelPlacementProperties" : {
@@ -688,16 +675,9 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "displayField" : "huc8",
+        "displayField" : "oid",
         "editable" : true,
         "fieldDescriptions" : [
-          {
-            "type" : "CIMFieldDescription",
-            "alias" : "USGS HUC8",
-            "fieldName" : "huc8",
-            "visible" : true,
-            "searchMode" : "Exact"
-          },
           {
             "type" : "CIMFieldDescription",
             "alias" : "Reference Time",
@@ -741,7 +721,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.hydrovis.%analysis_assim_inundation_extent_schism_3_psurge",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select huc8,reference_time,geom,update_time,oid from hydrovis.services.mrf_gfs_3day_max_coastal_inundation_atlgulf_psurge",
+          "sqlQuery" : "select reference_time,geom,update_time,oid from hydrovis.services.mrf_gfs_3day_max_coastal_inundation_atlgulf_psurge",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -760,12 +740,6 @@
             }
           },
           "queryFields" : [
-            {
-              "name" : "huc8",
-              "type" : "esriFieldTypeString",
-              "alias" : "huc8",
-              "length" : 60000
-            },
             {
               "name" : "reference_time",
               "type" : "esriFieldTypeString",
@@ -813,7 +787,7 @@
         {
           "type" : "CIMLabelClass",
           "expressionTitle" : "Custom",
-          "expression" : "$feature.huc8",
+          "expression" : "$feature.oid",
           "expressionEngine" : "Arcade",
           "featuresToLabel" : "AllVisibleFeatures",
           "maplexLabelPlacementProperties" : {
@@ -1098,16 +1072,9 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "displayField" : "huc8",
+        "displayField" : "oid",
         "editable" : true,
         "fieldDescriptions" : [
-          {
-            "type" : "CIMFieldDescription",
-            "alias" : "USGS HUC8",
-            "fieldName" : "huc8",
-            "visible" : true,
-            "searchMode" : "Exact"
-          },
           {
             "type" : "CIMFieldDescription",
             "alias" : "Reference Time",
@@ -1151,7 +1118,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.hydrovis.%analysis_assim_inundation_extent_schism",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select huc8,reference_time,geom,update_time,oid from hydrovis.services.mrf_gfs_5day_max_coastal_inundation",
+          "sqlQuery" : "select reference_time,geom,update_time,oid from hydrovis.services.mrf_gfs_5day_max_coastal_inundation",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -1170,12 +1137,6 @@
             }
           },
           "queryFields" : [
-            {
-              "name" : "huc8",
-              "type" : "esriFieldTypeString",
-              "alias" : "huc8",
-              "length" : 60000
-            },
             {
               "name" : "reference_time",
               "type" : "esriFieldTypeString",
@@ -1223,7 +1184,7 @@
         {
           "type" : "CIMLabelClass",
           "expressionTitle" : "Custom",
-          "expression" : "$feature.huc8",
+          "expression" : "$feature.oid",
           "expressionEngine" : "Arcade",
           "featuresToLabel" : "AllVisibleFeatures",
           "maplexLabelPlacementProperties" : {
@@ -1508,16 +1469,9 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "displayField" : "huc8",
+        "displayField" : "oid",
         "editable" : true,
         "fieldDescriptions" : [
-          {
-            "type" : "CIMFieldDescription",
-            "alias" : "USGS HUC8",
-            "fieldName" : "huc8",
-            "visible" : true,
-            "searchMode" : "Exact"
-          },
           {
             "type" : "CIMFieldDescription",
             "alias" : "Reference Time",
@@ -1561,7 +1515,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.hydrovis.%analysis_assim_inundation_extent_schism_psurge",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select huc8,reference_time,geom,update_time,oid from hydrovis.services.mrf_gfs_5day_max_coastal_inundation_atlgulf_psurge",
+          "sqlQuery" : "select reference_time,geom,update_time,oid from hydrovis.services.mrf_gfs_5day_max_coastal_inundation_atlgulf_psurge",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -1580,12 +1534,6 @@
             }
           },
           "queryFields" : [
-            {
-              "name" : "huc8",
-              "type" : "esriFieldTypeString",
-              "alias" : "huc8",
-              "length" : 60000
-            },
             {
               "name" : "reference_time",
               "type" : "esriFieldTypeString",
@@ -1633,7 +1581,7 @@
         {
           "type" : "CIMLabelClass",
           "expressionTitle" : "Custom",
-          "expression" : "$feature.huc8",
+          "expression" : "$feature.oid",
           "expressionEngine" : "Arcade",
           "featuresToLabel" : "AllVisibleFeatures",
           "maplexLabelPlacementProperties" : {
@@ -1918,16 +1866,9 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "displayField" : "huc8",
+        "displayField" : "oid",
         "editable" : true,
         "fieldDescriptions" : [
-          {
-            "type" : "CIMFieldDescription",
-            "alias" : "USGS HUC8",
-            "fieldName" : "huc8",
-            "visible" : true,
-            "searchMode" : "Exact"
-          },
           {
             "type" : "CIMFieldDescription",
             "alias" : "Reference Time",
@@ -1971,7 +1912,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.hydrovis.%analysis_assim_inundation_extent_schism_3",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select huc8,reference_time,geom,update_time,oid from hydrovis.services.mrf_gfs_10day_max_coastal_inundation",
+          "sqlQuery" : "select reference_time,geom,update_time,oid from hydrovis.services.mrf_gfs_10day_max_coastal_inundation",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -1990,12 +1931,6 @@
             }
           },
           "queryFields" : [
-            {
-              "name" : "huc8",
-              "type" : "esriFieldTypeString",
-              "alias" : "huc8",
-              "length" : 60000
-            },
             {
               "name" : "reference_time",
               "type" : "esriFieldTypeString",
@@ -2043,7 +1978,7 @@
         {
           "type" : "CIMLabelClass",
           "expressionTitle" : "Custom",
-          "expression" : "$feature.huc8",
+          "expression" : "$feature.oid",
           "expressionEngine" : "Arcade",
           "featuresToLabel" : "AllVisibleFeatures",
           "maplexLabelPlacementProperties" : {
@@ -2328,16 +2263,9 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "displayField" : "huc8",
+        "displayField" : "oid",
         "editable" : true,
         "fieldDescriptions" : [
-          {
-            "type" : "CIMFieldDescription",
-            "alias" : "USGS HUC8",
-            "fieldName" : "huc8",
-            "visible" : true,
-            "searchMode" : "Exact"
-          },
           {
             "type" : "CIMFieldDescription",
             "alias" : "Reference Time",
@@ -2381,7 +2309,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.hydrovis.%analysis_assim_inundation_extent_schism_3_psurge",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select huc8,reference_time,geom,update_time,oid from hydrovis.services.mrf_gfs_10day_max_coastal_inundation_atlgulf_psurge",
+          "sqlQuery" : "select reference_time,geom,update_time,oid from hydrovis.services.mrf_gfs_10day_max_coastal_inundation_atlgulf_psurge",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -2400,12 +2328,6 @@
             }
           },
           "queryFields" : [
-            {
-              "name" : "huc8",
-              "type" : "esriFieldTypeString",
-              "alias" : "huc8",
-              "length" : 60000
-            },
             {
               "name" : "reference_time",
               "type" : "esriFieldTypeString",
@@ -2453,7 +2375,7 @@
         {
           "type" : "CIMLabelClass",
           "expressionTitle" : "Custom",
-          "expression" : "$feature.huc8",
+          "expression" : "$feature.oid",
           "expressionEngine" : "Arcade",
           "featuresToLabel" : "AllVisibleFeatures",
           "maplexLabelPlacementProperties" : {

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal/srf_18hr_max_coastal_inundation_extent_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal/srf_18hr_max_coastal_inundation_extent_noaa.mapx
@@ -272,16 +272,9 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "displayField" : "huc8",
+        "displayField" : "oid",
         "editable" : true,
         "fieldDescriptions" : [
-          {
-            "type" : "CIMFieldDescription",
-            "alias" : "USGS HUC8",
-            "fieldName" : "huc8",
-            "visible" : true,
-            "searchMode" : "Exact"
-          },
           {
             "type" : "CIMFieldDescription",
             "alias" : "Reference Time",
@@ -325,7 +318,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.hydrovis.%srf_18hr_max_inundation_extent_schism",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select geom,huc8,reference_time,update_time,oid from hydrovis.services.srf_18hr_max_coastal_inundation",
+          "sqlQuery" : "select geom,reference_time,update_time,oid from hydrovis.services.srf_18hr_max_coastal_inundation",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -360,12 +353,6 @@
               }
             },
             {
-              "name" : "huc8",
-              "type" : "esriFieldTypeString",
-              "alias" : "huc8",
-              "length" : 8
-            },
-            {
               "name" : "reference_time",
               "type" : "esriFieldTypeString",
               "alias" : "reference_time",
@@ -397,7 +384,7 @@
         {
           "type" : "CIMLabelClass",
           "expressionTitle" : "Custom",
-          "expression" : "$feature.huc8",
+          "expression" : "$feature.oid",
           "expressionEngine" : "Arcade",
           "featuresToLabel" : "AllVisibleFeatures",
           "maplexLabelPlacementProperties" : {
@@ -680,16 +667,9 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "displayField" : "huc8",
+        "displayField" : "oid",
         "editable" : true,
         "fieldDescriptions" : [
-          {
-            "type" : "CIMFieldDescription",
-            "alias" : "USGS HUC8",
-            "fieldName" : "huc8",
-            "visible" : true,
-            "searchMode" : "Exact"
-          },
           {
             "type" : "CIMFieldDescription",
             "alias" : "Reference Time",
@@ -733,7 +713,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.hydrovis.%srf_18hr_max_inundation_extent_schism_psurge",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select geom,huc8,reference_time,update_time,oid from hydrovis.services.srf_18hr_max_coastal_inundation_atlgulf_psurge",
+          "sqlQuery" : "select geom,reference_time,update_time,oid from hydrovis.services.srf_18hr_max_coastal_inundation_atlgulf_psurge",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -768,12 +748,6 @@
               }
             },
             {
-              "name" : "huc8",
-              "type" : "esriFieldTypeString",
-              "alias" : "huc8",
-              "length" : 8
-            },
-            {
               "name" : "reference_time",
               "type" : "esriFieldTypeString",
               "alias" : "reference_time",
@@ -805,7 +779,7 @@
         {
           "type" : "CIMLabelClass",
           "expressionTitle" : "Custom",
-          "expression" : "$feature.huc8",
+          "expression" : "$feature.oid",
           "expressionEngine" : "Arcade",
           "featuresToLabel" : "AllVisibleFeatures",
           "maplexLabelPlacementProperties" : {

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal_hawaii/srf_48hr_max_coastal_inundation_extent_hi_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal_hawaii/srf_48hr_max_coastal_inundation_extent_hi_noaa.mapx
@@ -271,16 +271,9 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "displayField" : "huc8",
+        "displayField" : "oid",
         "editable" : true,
         "fieldDescriptions" : [
-          {
-            "type" : "CIMFieldDescription",
-            "alias" : "USGS HUC8",
-            "fieldName" : "huc8",
-            "visible" : true,
-            "searchMode" : "Exact"
-          },
           {
             "type" : "CIMFieldDescription",
             "alias" : "Reference Time",
@@ -324,7 +317,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.hydrovis.%analysis_assim_inundation_extent_schism",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select geom,huc8,reference_time,update_time,oid from hydrovis.services.srf_48hr_max_coastal_inundation_hi",
+          "sqlQuery" : "select geom,reference_time,update_time,oid from hydrovis.services.srf_48hr_max_coastal_inundation_hi",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -359,12 +352,6 @@
               }
             },
             {
-              "name" : "huc8",
-              "type" : "esriFieldTypeString",
-              "alias" : "huc8",
-              "length" : 8
-            },
-            {
               "name" : "reference_time",
               "type" : "esriFieldTypeString",
               "alias" : "reference_time",
@@ -396,7 +383,7 @@
         {
           "type" : "CIMLabelClass",
           "expressionTitle" : "Custom",
-          "expression" : "$feature.huc8",
+          "expression" : "$feature.oid",
           "expressionEngine" : "Arcade",
           "featuresToLabel" : "AllVisibleFeatures",
           "maplexLabelPlacementProperties" : {

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal_puertorico/srf_48hr_max_coastal_inundation_extent_prvi_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal_puertorico/srf_48hr_max_coastal_inundation_extent_prvi_noaa.mapx
@@ -271,16 +271,9 @@
       "featureElevationExpression" : "0",
       "featureTable" : {
         "type" : "CIMFeatureTable",
-        "displayField" : "huc8",
+        "displayField" : "oid",
         "editable" : true,
         "fieldDescriptions" : [
-          {
-            "type" : "CIMFieldDescription",
-            "alias" : "USGS HUC8",
-            "fieldName" : "huc8",
-            "visible" : true,
-            "searchMode" : "Exact"
-          },
           {
             "type" : "CIMFieldDescription",
             "alias" : "Reference Time",
@@ -324,7 +317,7 @@
           "workspaceFactory" : "SDE",
           "dataset" : "hydrovis.hydrovis.%analysis_assim_inundation_extent_schism",
           "datasetType" : "esriDTFeatureClass",
-          "sqlQuery" : "select geom,huc8,reference_time,update_time,oid from hydrovis.services.srf_48hr_max_coastal_inundation_prvi",
+          "sqlQuery" : "select geom,reference_time,update_time,oid from hydrovis.services.srf_48hr_max_coastal_inundation_prvi",
           "srid" : "3857",
           "spatialReference" : {
             "wkid" : 102100,
@@ -359,12 +352,6 @@
               }
             },
             {
-              "name" : "huc8",
-              "type" : "esriFieldTypeString",
-              "alias" : "huc8",
-              "length" : 8
-            },
-            {
               "name" : "reference_time",
               "type" : "esriFieldTypeString",
               "alias" : "reference_time",
@@ -396,7 +383,7 @@
         {
           "type" : "CIMLabelClass",
           "expressionTitle" : "Custom",
-          "expression" : "$feature.huc8",
+          "expression" : "$feature.oid",
           "expressionEngine" : "Arcade",
           "featuresToLabel" : "AllVisibleFeatures",
           "maplexLabelPlacementProperties" : {


### PR DESCRIPTION
The latest updates to the coastal FIM services had removed the huc8 field from the underlying tables that all of the coastal extent services look at since we no longer process by huc8, but rather by randomly generated raster tiles. Unfortunately, the deletion of the huc8 field hadn't been thoroughly refactored in all of the necessary places. Namely, it was kept in a few dummy row inserts for PSURGE tables as well as the extent service .mapx files. This was causing all of the pipelines that attempt to process PSURGE data to fail, and preventing all coastal FIM extent services from drawing. Those issues are now resolved herein.