### PR TITLE
Remove high_water_threshold filter from RFC FIM processing

### DIFF
--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_flows/rfc_based_5day_max_inundation.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_flows/rfc_based_5day_max_inundation.sql
@@ -13,11 +13,8 @@ SELECT
     max_forecast.streamflow AS discharge_cfs,
     'Pending' AS prc_status
 FROM publish.rfc_based_5day_max_streamflow max_forecast
-JOIN derived.recurrence_flows_conus rf ON rf.feature_id=max_forecast.feature_id
 JOIN derived.fim4_featureid_crosswalk AS crosswalk ON max_forecast.feature_id = crosswalk.feature_id
 WHERE 
-    max_forecast.streamflow >= rf.high_water_threshold AND 
-    rf.high_water_threshold > 0::double precision AND
     crosswalk.huc8 IS NOT NULL AND 
     crosswalk.lake_id = -999 AND
 	max_forecast.is_waterbody = 'no' AND


### PR DESCRIPTION
This solves issue #760.

The three lines removed from rfc_based_5day_max_inundation.sql should have never been in there in the first place. They were added by oversight when refactoring code to use the new FIM Caching mechanism, as these lines are common to all NWM FIM products. However, since this is not a NWM FIM product, we should not be comparing the authoritative flood-status flows (from official RFC forecasts) to NWM recurrence flows.