### PR TITLE
Removes huc8 insertion values from coastal psurge services

### DIFF
--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/mrf_gfs_10day_max_coastal_inundation_atlgulf_psurge.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/mrf_gfs_10day_max_coastal_inundation_atlgulf_psurge.sql
@@ -1,6 +1,6 @@
 INSERT INTO ingest.mrf_gfs_10day_max_coastal_inundation_atlgulf_psurge (
 	geom, reference_time)
-	VALUES (NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), '-9999');
+	VALUES (NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'));
 
 DROP TABLE IF EXISTS publish.mrf_gfs_10day_max_coastal_inundation_atlgulf_psurge;
 

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/mrf_gfs_3day_max_coastal_inundation_atlgulf_psurge.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/mrf_gfs_3day_max_coastal_inundation_atlgulf_psurge.sql
@@ -1,6 +1,6 @@
 INSERT INTO ingest.mrf_gfs_3day_max_coastal_inundation_atlgulf_psurge (
 	geom, reference_time)
-	VALUES (NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), '-9999');
+	VALUES (NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'));
 
 DROP TABLE IF EXISTS publish.mrf_gfs_3day_max_coastal_inundation_atlgulf_psurge;
 

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/mrf_gfs_5day_max_coastal_inundation_atlgulf_psurge.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/mrf_gfs_5day_max_coastal_inundation_atlgulf_psurge.sql
@@ -1,6 +1,6 @@
 INSERT INTO ingest.mrf_gfs_5day_max_coastal_inundation_atlgulf_psurge (
 	geom, reference_time)
-	VALUES (NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), '-9999');
+	VALUES (NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'));
 
 DROP TABLE IF EXISTS publish.mrf_gfs_5day_max_coastal_inundation_atlgulf_psurge;
 

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/mrf_nbm_10day_max_coastal_inundation_atlgulf_psurge.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/mrf_nbm_10day_max_coastal_inundation_atlgulf_psurge.sql
@@ -1,6 +1,6 @@
 INSERT INTO ingest.mrf_nbm_10day_max_coastal_inundation_atlgulf_psurge (
 	geom, reference_time)
-	VALUES (NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), '-9999');
+	VALUES (NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'));
 
 DROP TABLE IF EXISTS publish.mrf_nbm_10day_max_coastal_inundation_atlgulf_psurge;
 

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/mrf_nbm_3day_max_coastal_inundation_atlgulf_psurge.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/mrf_nbm_3day_max_coastal_inundation_atlgulf_psurge.sql
@@ -1,6 +1,6 @@
 INSERT INTO ingest.mrf_nbm_3day_max_coastal_inundation_atlgulf_psurge (
 	geom, reference_time)
-	VALUES (NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), '-9999');
+	VALUES (NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'));
 
 DROP TABLE IF EXISTS publish.mrf_nbm_3day_max_coastal_inundation_atlgulf_psurge;
 

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/mrf_nbm_5day_max_coastal_inundation_atlgulf_psurge.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/mrf_nbm_5day_max_coastal_inundation_atlgulf_psurge.sql
@@ -1,6 +1,6 @@
 INSERT INTO ingest.mrf_nbm_5day_max_coastal_inundation_atlgulf_psurge (
 	geom, reference_time)
-	VALUES (NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), '-9999');
+	VALUES (NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'));
 
 DROP TABLE IF EXISTS publish.mrf_nbm_5day_max_coastal_inundation_atlgulf_psurge;
 

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/srf_18hr_max_coastal_inundation_atlgulf_psurge.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_configs/srf_18hr_max_coastal_inundation_atlgulf_psurge.sql
@@ -1,6 +1,6 @@
 INSERT INTO ingest.srf_18hr_max_coastal_inundation_atlgulf_psurge (
 	geom, reference_time)
-	VALUES (NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'), '-9999');
+	VALUES (NULL, to_char('1900-01-01 00:00:00'::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC'));
 
 DROP TABLE IF EXISTS publish.srf_18hr_max_coastal_inundation_atlgulf_psurge;
 


### PR DESCRIPTION
This wraps up what should have been fully implemented for PR #759. In that PR, I removed the huc8 column from all coastal FIM services. However, I failed to update the places in the code where a hard-coded dummy value is inserted for the huc8 column. This fixes the issue. These changes were hard-coded in place directly on UAT to confirm that the services now work as expected.