### PR TITLE
Hotfix to Puerto Rico Hawaii QPE descriptions

### DIFF
--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/forcing_analysis_assim_hawaii/ana_past_72hr_accum_precip_hi_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/forcing_analysis_assim_hawaii/ana_past_72hr_accum_precip_hi_noaa.yml
@@ -1,8 +1,7 @@
 service: ana_past_72hr_accum_precip_hi_noaa
-summary: NAM-NEST NWP Past 72-Hour Accumulated Precipitation for Hawaii
-description: 'Depicts accumulated precipitation totals over the past 72 hours derived from the NAM-NEST NWP forcing for 
-  the operational National Water Model (NWM) analysis and assimilation for the state of Hawaii. Updated hourly.'
-tags: nam-nest, nwp, accumulated, precipitation, national, water, model, nwm, hawaii, hi, precip
+summary: MRMS Past 72-Hour Accumulated Precipitation Analysis for Hawaii
+description: 'Depicts accumulated precipitation totals over the past 72 hours derived from the MRMS forcing for the operational National Water Model (NWM) analysis and assimilation for the state of Hawaii.  If MRMS forcing data is not available, forcing data from the NAM-Nest is used as a backup.  Updated hourly.'
+tags: mrms, accumulated, precipitation, national, water, model, nwm, hawaii, hi, precip
 credits: National Water Model, NOAA/NWS National Water Center
 egis_server: image
 egis_folder: nwm

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/forcing_analysis_assim_puertorico/ana_past_72hr_accum_precip_prvi_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/forcing_analysis_assim_puertorico/ana_past_72hr_accum_precip_prvi_noaa.yml
@@ -1,9 +1,7 @@
 service: ana_past_72hr_accum_precip_prvi_noaa
-summary: NAM-NEST NWP Past 72-Hour Accumulated Precipitationn for Puerto Rico and Virgin Islands
-description: 'Depicts accumulated precipitation totals over the past 72 hours derived from the NAM-NEST and HIRES WRF-ARW NWP 
-  forcing for the operational National Water Model (NWM) analysis and assimilation for Puerto Rico and the U.S. Virgin Islands. 
-  Updated hourly.'
-tags: nam-nest, nwp, accumulated, precipitation, national, water, model, nwm, puertorico, prvi, precip
+summary: MRMS Past 72-Hour Accumulated Precipitation Analysis for Puerto Rico and Virgin Islands
+description: 'Depicts accumulated precipitation totals over the past 72 hours derived from the MRMS forcing for the operational National Water Model (NWM) analysis and assimilation for Puerto Rico and the U.S. Virgin Islands.  If MRMS forcing data is not available, forcing data from the NAM-Nest is used as a backup.  Updated hourly.'
+tags: mrms, accumulated, precipitation, national, water, model, nwm, puertorico, prvi, precip
 credits: National Water Model, NOAA/NWS National Water Center
 egis_server: image
 egis_folder: nwm

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/forcing_short_range_hawaii/srf_48hr_accum_precip_hi_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/forcing_short_range_hawaii/srf_48hr_accum_precip_hi_noaa.yml
@@ -1,9 +1,7 @@
 service: srf_48hr_accum_precip_hi_noaa
-summary: NAM-NEST NWP Short-Range Accumulated Precipitation for Hawaii
-description: 'Depicts expected accumulated precipitation totals over the next 48 hours derived from the NAM-Nest with 
-  HIRESW WRF-ARW forcing for the operational National Water Model (NWM) short-range forecast for the state of Hawaii. 
-  Updated every 12 hours.'
-tags: nam-nest, nwp, accumulated, precipitation, national, water, model, nwm, hawaii, hi, precip
+summary: WRF-ARW 48-Hour Accumulated Precipitation Forecast for Hawaii
+description: 'Depicts expected accumulated precipitation totals over the next 48 hours derived from the WRF-ARW forcing for the operational National Water Model (NWM) short-range forecast for the state of Hawaii.  Updated every 12 hours.'
+tags: wrf-arw, accumulated, precipitation, national, water, model, nwm, hawaii, hi, precip
 credits: National Water Model, NOAA/NWS National Water Center
 egis_server: image
 egis_folder: nwm

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/forcing_short_range_puertorico/srf_48hr_accum_precip_prvi_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/forcing_short_range_puertorico/srf_48hr_accum_precip_prvi_noaa.yml
@@ -1,9 +1,7 @@
 service: srf_48hr_accum_precip_prvi_noaa
-summary: NAM-NEST NWP Short-Range Accumulated Precipitationn for Puerto Rico and Virgin Islands
-description: 'Depicts expected accumulated precipitation totals over the next 48 hours derived from the NAM-Nest with 
-  HIRESW WRF-ARW forcing for the operational National Water Model (NWM) short-range forecast for Puerto Rico and the 
-  U.S. Virgin Islands. Updated every 12 hours.'
-tags: nam-nest, nwp, accumulated, precipitation, national, water, model, nwm, puertorico, prvi, precip
+summary: WRF-ARW 48-Hour Accumulated Precipitation Forecast for Puerto Rico and Virgin Islands
+description: 'Depicts expected accumulated precipitation totals over the next 48 hours derived from the WRF-ARW forcing for the operational National Water Model (NWM) short-range forecast for Puerto Rico and the U.S. Virgin Islands.  Updated every 12 hours.'
+tags: wrf-arw, accumulated, precipitation, national, water, model, nwm, puertorico, prvi, precip
 credits: National Water Model, NOAA/NWS National Water Center
 egis_server: image
 egis_folder: nwm


### PR DESCRIPTION
It was recently brought to WPOD's attention that the descriptions for Hawaii and Puerto Rico QPE are incorrect. These QPE services use MRMS forcing not NAM-NEST. This was confirmed with Brian Cosgrove of APD. If you can please incorporate these updated service descriptions in our next update. Thanks!