### PR TITLE
Various tweaks to fix coastal fim services

### DIFF
--- a/Core/LAMBDA/viz_functions/image_based/viz_schism_fim_processing/main.tf
+++ b/Core/LAMBDA/viz_functions/image_based/viz_schism_fim_processing/main.tf
@@ -266,7 +266,7 @@ resource "aws_batch_compute_environment" "schism_fim_compute_env" {
     ]
 
     min_vcpus = 0
-    max_vcpus = 96
+    max_vcpus = 108
 
     security_group_ids = var.security_groups
 

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/admin/ingest_finish.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/admin/ingest_finish.sql
@@ -1,7 +1,7 @@
 CREATE INDEX IF NOT EXISTS {index_name} ON {target_table} {index_columns};
 
-ALTER TABLE {target_table}
-ADD COLUMN reference_time TEXT DEFAULT '1900-01-01 00:00:00 UTC';
+ALTER TABLE {target_table} ADD COLUMN IF NOT EXISTS reference_time TEXT DEFAULT '1900-01-01 00:00:00 UTC';
+UPDATE {target_table} SET reference_time = '1900-01-01 00:00:00 UTC' WHERE reference_time != '1900-01-01 00:00:00 UTC';
 
 -- Checks to see if feature_id is a column in the target table
 SELECT EXISTS (SELECT 1 

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal/ana_coastal_inundation_depth_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal/ana_coastal_inundation_depth_noaa.yml
@@ -5,7 +5,7 @@ description: Depicts the inundation depth of the National Water Model (NWM) tota
   Updated hourly.
 tags: national water model, nwm, ana, conus, schism, coastal, fim, inundation, depth
 credits: National Water Model, NOAA/NWS National Water Center
-egis_server: server
+egis_server: image
 egis_folder: nwm
 feature_service: false
 public_service: false

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal_hawaii/ana_coastal_inundation_depth_hi_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal_hawaii/ana_coastal_inundation_depth_hi_noaa.yml
@@ -5,7 +5,7 @@ description: Depicts the inundation depth of the National Water Model (NWM) tota
   Updated hourly.
 tags: national water model, nwm, ana, schism, coastal, fim, inundation, depth, hawaii, hi
 credits: National Water Model, NOAA/NWS National Water Center
-egis_server: server
+egis_server: image
 egis_folder: nwm
 feature_service: false
 public_service: false

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal_puertorico/ana_coastal_inundation_depth_prvi_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/analysis_assim_coastal_puertorico/ana_coastal_inundation_depth_prvi_noaa.yml
@@ -5,7 +5,7 @@ description: Depicts the inundation depth of the National Water Model (NWM) tota
   Updated hourly.
 tags: national water model, nwm, ana, schism, coastal, fim, inundation, depth, prvi, puertorico
 credits: National Water Model, NOAA/NWS National Water Center
-egis_server: server
+egis_server: image
 egis_folder: nwm
 feature_service: false
 public_service: false

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_blend_coastal/mrf_nbm_10day_max_coastal_inundation_depth_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_blend_coastal/mrf_nbm_10day_max_coastal_inundation_depth_noaa.yml
@@ -5,7 +5,7 @@ description: Depicts the inundation depth of the peak National Water Model (NWM)
   over the contiguous U.S. Updated every 6 hours.
 tags: national water model, nwm, mrf, medium, range, conus, schism, coastal, fim, inundation, depth
 credits: National Water Model, NOAA/NWS National Water Center
-egis_server: server
+egis_server: image
 egis_folder: nwm
 feature_service: false
 public_service: false

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_coastal_mem1/mrf_gfs_10day_max_coastal_inundation_depth_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/medium_range_coastal_mem1/mrf_gfs_10day_max_coastal_inundation_depth_noaa.yml
@@ -5,7 +5,7 @@ description: Depicts the inundation depth of the peak National Water Model (NWM)
   over the contiguous U.S. Updated every 6 hours.
 tags: national water model, nwm, mrf, medium, range, conus, schism, coastal, fim, inundation, depth
 credits: National Water Model, NOAA/NWS National Water Center
-egis_server: server
+egis_server: image
 egis_folder: nwm
 feature_service: false
 public_service: false

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal/srf_18hr_max_coastal_inundation_depth_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal/srf_18hr_max_coastal_inundation_depth_noaa.yml
@@ -5,7 +5,7 @@ description: Depicts the peak inundation depth of the National Water Model (NWM)
   NWM over the contiguous U.S. Updated hourly.
 tags: national water model, nwm, srf, short, range, conus, schism, coastal, fim, inundation, extent
 credits: National Water Model, NOAA/NWS National Water Center
-egis_server: server
+egis_server: image
 egis_folder: nwm
 feature_service: false
 public_service: false

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal_hawaii/srf_48hr_max_coastal_inundation_depth_hi_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal_hawaii/srf_48hr_max_coastal_inundation_depth_hi_noaa.yml
@@ -5,7 +5,7 @@ description: Depicts the peak inundation depth of the National Water Model (NWM)
   NWM over Hawaii. Updated every 12 hours.
 tags: national water model, nwm, srf, short, range, schism, coastal, fim, inundation, depth, hawaii, hi
 credits: National Water Model, NOAA/NWS National Water Center
-egis_server: server
+egis_server: image
 egis_folder: nwm
 feature_service: false
 public_service: false

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal_puertorico/srf_48hr_max_coastal_inundation_depth_prvi_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range_coastal_puertorico/srf_48hr_max_coastal_inundation_depth_prvi_noaa.yml
@@ -5,7 +5,7 @@ description: Depicts the peak inundation depth of the National Water Model (NWM)
   NWM over Puerto Rico and the U.S. Virgin Islands. Updated every 12 hours.
 tags: national water model, nwm, srf, short, range, schism, coastal, fim, inundation, depth, puertorico, prvi
 credits: National Water Model, NOAA/NWS National Water Center
-egis_server: server
+egis_server: image
 egis_folder: nwm
 feature_service: false
 public_service: false

--- a/Core/StepFunctions/viz_processing_pipeline.json.tftpl
+++ b/Core/StepFunctions/viz_processing_pipeline.json.tftpl
@@ -976,7 +976,7 @@
                   "Resource": "arn:aws:states:::states:startExecution.sync:2",
                   "Parameters": {
                     "StateMachineArn": "${schism_fim_processing_step_function_arn}",
-                    "Name.$": "States.Format('{}_{}T{}Z', $.fim_config.name, States.ArrayGetItem(States.StringSplit($.reference_time, ' '), 0), States.ArrayGetItem(States.StringSplit(States.ArrayGetItem(States.StringSplit($.reference_time, ' '), 1), ':'), 0))",
+                    "Name.$": "States.Format('{}_{}T{}Z_{}', $.fim_config.name, States.ArrayGetItem(States.StringSplit($.reference_time, ' '), 0), States.ArrayGetItem(States.StringSplit(States.ArrayGetItem(States.StringSplit($.reference_time, ' '), 1), ':'), 0), States.ArrayGetItem(States.StringSplit(States.UUID(), '-'), 0))",
                     "Input": {
                       "fim_config.$": "$.fim_config",
                       "reference_time.$": "$.reference_time",
@@ -1559,5 +1559,5 @@
       "Type": "Succeed"
     }
   },
-  "TimeoutSeconds": 4500
+  "TimeoutSeconds": 5400
 }


### PR DESCRIPTION
Includes the following tweaks:

* Increases max_vcpus in schism-fim-compute-env from 96 to 108
* Adds code to ingest_finish.sql to avoid "reference_time already exists" error
* Increases timeout to Viz Pipeline step function
* Adds random/unique id to coastal fim step function name
* Changes server of coastal depth services from "server" to "image"