### PR TITLE
Allow db dumps at table level

### DIFF
--- a/Core/EC2/RDSBastion/scripts/utils/restore_db_dumps_from_s3.sh.tftpl
+++ b/Core/EC2/RDSBastion/scripts/utils/restore_db_dumps_from_s3.sh.tftpl
@@ -14,13 +14,13 @@ export PGPASSWORD=${db_password}
 %{ for s3_key in s3_key_list ~}
 
 # Get DB and Schema name from s3_key
-# (filepath)/((DB Name)DB_(Schema Name)_vX_X_X.dump)
-RE='^(.+)\/(([a-z].+)DB_(.+)_v[0-9]+_.+\.dump)$'
+# (filepath)/(dump date in YYYYmmddTHHMM)_(DB Name)DB_("table" or "schema")_(Schema Name).(optional table name)_vX_X_X.dump)
+RE='^(.+)\/[0-9]{8}T[0-9]{4}_(([a-z].+)DB_(schema|table)_(.+)_v[0-9]+_.+\.dump)$'
 [[ ${s3_key} =~ $RE ]]
 
 # Drop old schema and restore from S3 object
-echo "Setting up $${BASH_REMATCH[4]} schema in the $${BASH_REMATCH[3]} DB..."
-psql -h "${db_host}" -U "${db_username}" -p ${db_port} -d "${db_name}" -qtAc "DROP SCHEMA IF EXISTS $${BASH_REMATCH[4]} CASCADE;"
+echo "Setting up $${BASH_REMATCH[5]} $${BASH_REMATCH[4]} in the $${BASH_REMATCH[3]} DB..."
+psql -h "${db_host}" -U "${db_username}" -p ${db_port} -d "${db_name}" -qtAc "DROP $${BASH_REMATCH[4]} IF EXISTS $${BASH_REMATCH[5]} CASCADE;"
 aws s3 cp "s3://${s3_bucket}/${s3_key}" "$${postgres_data_folder}/db.dump" --only-show-errors
 pg_restore -h "${db_host}" -p ${db_port} -d "${db_name}" -U ${db_username} --clean --if-exists -j 4 "$${postgres_data_folder}/db.dump"
 

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/forcing_analysis_assim_hawaii/ana_past_72hr_accum_precip_hi_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/forcing_analysis_assim_hawaii/ana_past_72hr_accum_precip_hi_noaa.yml
@@ -1,8 +1,7 @@
 service: ana_past_72hr_accum_precip_hi_noaa
-summary: NAM-NEST NWP Past 72-Hour Accumulated Precipitation for Hawaii
-description: 'Depicts accumulated precipitation totals over the past 72 hours derived from the NAM-NEST NWP forcing for 
-  the operational National Water Model (NWM) analysis and assimilation for the state of Hawaii. Updated hourly.'
-tags: nam-nest, nwp, accumulated, precipitation, national, water, model, nwm, hawaii, hi, precip
+summary: MRMS Past 72-Hour Accumulated Precipitation Analysis for Hawaii
+description: 'Depicts accumulated precipitation totals over the past 72 hours derived from the MRMS forcing for the operational National Water Model (NWM) analysis and assimilation for the state of Hawaii.  If MRMS forcing data is not available, forcing data from the NAM-Nest is used as a backup.  Updated hourly.'
+tags: mrms, accumulated, precipitation, national, water, model, nwm, hawaii, hi, precip
 credits: National Water Model, NOAA/NWS National Water Center
 egis_server: image
 egis_folder: nwm

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/forcing_analysis_assim_puertorico/ana_past_72hr_accum_precip_prvi_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/forcing_analysis_assim_puertorico/ana_past_72hr_accum_precip_prvi_noaa.yml
@@ -1,9 +1,7 @@
 service: ana_past_72hr_accum_precip_prvi_noaa
-summary: NAM-NEST NWP Past 72-Hour Accumulated Precipitationn for Puerto Rico and Virgin Islands
-description: 'Depicts accumulated precipitation totals over the past 72 hours derived from the NAM-NEST and HIRES WRF-ARW NWP 
-  forcing for the operational National Water Model (NWM) analysis and assimilation for Puerto Rico and the U.S. Virgin Islands. 
-  Updated hourly.'
-tags: nam-nest, nwp, accumulated, precipitation, national, water, model, nwm, puertorico, prvi, precip
+summary: MRMS Past 72-Hour Accumulated Precipitation Analysis for Puerto Rico and Virgin Islands
+description: 'Depicts accumulated precipitation totals over the past 72 hours derived from the MRMS forcing for the operational National Water Model (NWM) analysis and assimilation for Puerto Rico and the U.S. Virgin Islands.  If MRMS forcing data is not available, forcing data from the NAM-Nest is used as a backup.  Updated hourly.'
+tags: mrms, accumulated, precipitation, national, water, model, nwm, puertorico, prvi, precip
 credits: National Water Model, NOAA/NWS National Water Center
 egis_server: image
 egis_folder: nwm

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/forcing_short_range_hawaii/srf_48hr_accum_precip_hi_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/forcing_short_range_hawaii/srf_48hr_accum_precip_hi_noaa.yml
@@ -1,9 +1,7 @@
 service: srf_48hr_accum_precip_hi_noaa
-summary: NAM-NEST NWP Short-Range Accumulated Precipitation for Hawaii
-description: 'Depicts expected accumulated precipitation totals over the next 48 hours derived from the NAM-Nest with 
-  HIRESW WRF-ARW forcing for the operational National Water Model (NWM) short-range forecast for the state of Hawaii. 
-  Updated every 12 hours.'
-tags: nam-nest, nwp, accumulated, precipitation, national, water, model, nwm, hawaii, hi, precip
+summary: WRF-ARW 48-Hour Accumulated Precipitation Forecast for Hawaii
+description: 'Depicts expected accumulated precipitation totals over the next 48 hours derived from the WRF-ARW forcing for the operational National Water Model (NWM) short-range forecast for the state of Hawaii.  Updated every 12 hours.'
+tags: wrf-arw, accumulated, precipitation, national, water, model, nwm, hawaii, hi, precip
 credits: National Water Model, NOAA/NWS National Water Center
 egis_server: image
 egis_folder: nwm

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/forcing_short_range_puertorico/srf_48hr_accum_precip_prvi_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/forcing_short_range_puertorico/srf_48hr_accum_precip_prvi_noaa.yml
@@ -1,9 +1,7 @@
 service: srf_48hr_accum_precip_prvi_noaa
-summary: NAM-NEST NWP Short-Range Accumulated Precipitationn for Puerto Rico and Virgin Islands
-description: 'Depicts expected accumulated precipitation totals over the next 48 hours derived from the NAM-Nest with 
-  HIRESW WRF-ARW forcing for the operational National Water Model (NWM) short-range forecast for Puerto Rico and the 
-  U.S. Virgin Islands. Updated every 12 hours.'
-tags: nam-nest, nwp, accumulated, precipitation, national, water, model, nwm, puertorico, prvi, precip
+summary: WRF-ARW 48-Hour Accumulated Precipitation Forecast for Puerto Rico and Virgin Islands
+description: 'Depicts expected accumulated precipitation totals over the next 48 hours derived from the WRF-ARW forcing for the operational National Water Model (NWM) short-range forecast for Puerto Rico and the U.S. Virgin Islands.  Updated every 12 hours.'
+tags: wrf-arw, accumulated, precipitation, national, water, model, nwm, puertorico, prvi, precip
 credits: National Water Model, NOAA/NWS National Water Center
 egis_server: image
 egis_folder: nwm


### PR DESCRIPTION
The context can be found in issue #817. I have updated the code that restores db dumps from s3, and modified the S3 Key regex pattern matching to look for "table" or "schema" in the appropriate place and then substitute whichever string is found into the `DROP` statement (e.g. `DROP table IF EXISTS...` or `DROP schema IF EXISTS...`). The proposed new format for the db dump files that would be required with this code change is: 

`YYYYmmddTHHMM_<db_name>DB_<"table" or "schema">_<schema[.table]>_vX_Y_Z.dump`

I added the `YYYYmmddTHHMM` portion as well, because this solves the question of what would happen if someone dumped an entire schema after making many updates to it, but then sometime (days, weeks) afterward, another person updates a single table and then dumps just that table. The order that the dumps are applied on restore would be essential - since these act essentially like db migrations. The default already in place is that the dumps are executed in alphanumeric sorting order. Thus, with the date in the dump name, the tables would be restored in the same order they were dumped - maintaining the integrity of the database.

Though it's annoying to have to remember these dump filename formats when creating the dumps, I hope to automate this via the proposed HydroVIS Developer Tethys App - in which case it wouldn't be a big deal. But that's just a side note since the annoyance is present regardless of this update or not.