### PR TITLE
Schism AWS Batch Optimizations 

### DIFF
--- a/Core/LAMBDA/viz_functions/image_based/viz_schism_fim_processing/main.tf
+++ b/Core/LAMBDA/viz_functions/image_based/viz_schism_fim_processing/main.tf
@@ -262,11 +262,11 @@ resource "aws_batch_compute_environment" "schism_fim_compute_env" {
     instance_role = aws_iam_instance_profile.schism_execution.arn
 
     instance_type = [
-      "c7g",
+      "r7g.4xlarge",
     ]
 
     min_vcpus = 0
-    max_vcpus = 108
+    max_vcpus = 112
 
     security_group_ids = var.security_groups
 
@@ -300,11 +300,11 @@ resource "aws_batch_job_definition" "schism_fim_job_definition" {
     resourceRequirements = [
       {
         type  = "VCPU"
-        value = "4"
+        value = "1"
       },
       {
         type  = "MEMORY"
-        value = "8000"
+        value = "7000"
       }
     ]
 


### PR DESCRIPTION
- Updated the AWS Batch Compute environment to use a more memory-optimized EC2 Instance Type.
- Updated Job definition for Schism AWS Batch Jobs to have the proper CPU and memory requirements.