### PR TITLE
Update utcnow() calls deprecated in Python 3.12

### DIFF
--- a/Core/LAMBDA/viz_functions/viz_initialize_pipeline/lambda_function.py
+++ b/Core/LAMBDA/viz_functions/viz_initialize_pipeline/lambda_function.py
@@ -197,7 +197,7 @@ class viz_lambda_pipeline:
                 self.reference_time = datetime.datetime.strptime(self.start_event.get('reference_time'), '%Y-%m-%d %H:%M:%S')
                 self.configuration = configuration(start_event.get('configuration'), reference_time=self.reference_time, input_bucket=start_event.get('bucket'))
             elif self.start_event.get('configuration') and self.start_event.get('configuration') == 'rfc':
-                self.configuration = configuration('rfc', reference_time=datetime.datetime.utcnow().replace(second=0, microsecond=0))
+                self.configuration = configuration('rfc', reference_time=datetime.datetime.now(datetime.UTC).replace(second=0, microsecond=0))
             # If no reference time was specified, we get the most recent file available on S3 for the specified configruation, and use that.
             else:
                 most_recent_file = s3_file.get_most_recent_from_configuration(configuration_name=start_event.get('configuration'), bucket=start_event.get('bucket'))

--- a/Core/LAMBDA/viz_functions/viz_wrds_api_handler/lambda_function.py
+++ b/Core/LAMBDA/viz_functions/viz_wrds_api_handler/lambda_function.py
@@ -1,7 +1,7 @@
 import requests
 import os
 import pandas as pd
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 import boto3
 import botocore
 import json
@@ -67,7 +67,7 @@ def get_recent_rfc_forecasts(hour_range=48):
     df = pd.DataFrame(res['forecasts'])
     df['issuedTime'] = pd.to_datetime(df['issuedTime'], format='%Y-%m-%dT%H:%M:%SZ')
     
-    date_range = datetime.utcnow() - timedelta(hours=48)
+    date_range = datetime.now(UTC) - timedelta(hours=48)
     df = df[pd.to_datetime(df['issuedTime']) > date_range]
 
     df = pd.concat([df.drop(['location'], axis=1), df['location'].apply(pd.Series)], axis=1)

--- a/Source/Visualizations/aws_loosa/deploy/kick_off_lambdas.py
+++ b/Source/Visualizations/aws_loosa/deploy/kick_off_lambdas.py
@@ -1,5 +1,5 @@
 import boto3
-from datetime import datetime
+from datetime import datetime, UTC
 import json
 from aws_loosa import consts
 import os
@@ -11,7 +11,7 @@ def kickoff_viz_lambdas():
     postprocess_lambda = f"viz_db_postprocess_{consts.hydrovis_env_map[os.environ['VIZ_ENVIRONMENT']]}"
 
     print("Invoking max flows function for AnA 14 day")
-    current_datetime = datetime.utcnow()
+    current_datetime = datetime.now(UTC)
     current_date = current_datetime.strftime("%Y%m%d")
     latest_0Z_ana_file = f"common/data/model/com/nwm/prod/nwm.{current_date}/analysis_assim/nwm.t00z.analysis_assim.channel_rt.tm00.conus.nc"  # noqa: E501
     max_values_payload = {"data_key": latest_0Z_ana_file, "data_bucket": os.environ['NWM_DATA_BUCKET']}

--- a/Source/Visualizations/aws_loosa/processing_pipeline/cli/validation.py
+++ b/Source/Visualizations/aws_loosa/processing_pipeline/cli/validation.py
@@ -228,7 +228,7 @@ class PipelineConfigValidator(object):
                 raise ValueError()
 
             duration = isodate.parse_duration(raw_duration)
-            new_val = operation(datetime.datetime.utcnow(), duration)
+            new_val = operation(datetime.datetime.now(datetime.UTC), duration)
         except Exception:
             cls._raise('When using relative times, follow the format: [now]+|-<iso 8601 duration>')
 
@@ -245,7 +245,7 @@ class PipelineConfigValidator(object):
                 if mod_val.lower() == consts.LATEST or mod_val.lower() == consts.NONE:
                     new_val = None
                 elif mod_val.lower().strip() == consts.NOW:
-                    new_val = datetime.datetime.utcnow()
+                    new_val = datetime.datetime.now(datetime.UTC)
                 elif any(x in mod_val for x in ['+', '-']):
                     new_val = self.get_datetime_from_relative_time(mod_val)
                 else:

--- a/Source/Visualizations/aws_loosa/processing_pipeline/dataset.py
+++ b/Source/Visualizations/aws_loosa/processing_pipeline/dataset.py
@@ -383,7 +383,7 @@ class DataSet(FileHandlerMixin):
     @classmethod
     def _parse_datetime_token_value(cls, token_val, datetime=None):
         if not datetime:
-            datetime = dt.datetime.utcnow()
+            datetime = UTCNOW()
 
         try:
             if "reftime" in token_val:

--- a/Source/Visualizations/aws_loosa/processing_pipeline/fetchers/web_fetcher.py
+++ b/Source/Visualizations/aws_loosa/processing_pipeline/fetchers/web_fetcher.py
@@ -118,7 +118,7 @@ class WebFetcher(DataFetcher):
                 if last_modified:
                     try:
                         last_modified_obj = date_parser.parse(last_modified)
-                        utcnow = dt.datetime.utcnow().replace(tzinfo=tz.tz.tzutc())
+                        utcnow = dt.datetime.now(dt.UTC).replace(tzinfo=tz.tz.tzutc())
                         time_since_modified = utcnow - last_modified_obj
                         if time_since_modified < dt.timedelta(seconds=10):
                             self._log.warning(

--- a/Source/Visualizations/aws_loosa/processing_pipeline/fetchers/web_fetcher.py
+++ b/Source/Visualizations/aws_loosa/processing_pipeline/fetchers/web_fetcher.py
@@ -1,5 +1,5 @@
 import datetime as dt
-from dateutil import parser as date_parser, tz
+from dateutil import parser as date_parser
 import os
 import requests
 import time
@@ -118,7 +118,7 @@ class WebFetcher(DataFetcher):
                 if last_modified:
                     try:
                         last_modified_obj = date_parser.parse(last_modified)
-                        utcnow = dt.datetime.now(dt.UTC).replace(tzinfo=tz.tz.tzutc())
+                        utcnow = dt.datetime.now(dt.UTC)
                         time_since_modified = utcnow - last_modified_obj
                         if time_since_modified < dt.timedelta(seconds=10):
                             self._log.warning(

--- a/Source/Visualizations/aws_loosa/processing_pipeline/manager.py
+++ b/Source/Visualizations/aws_loosa/processing_pipeline/manager.py
@@ -64,10 +64,10 @@ class Manager(object):
             self._stop_events.append(stop_event)
 
         try:
-            last_heartbeat_minute = dt.datetime.utcnow().minute
+            last_heartbeat_minute = dt.datetime.now(dt.UTC).minute
             while True:
                 time.sleep(self.SLEEP_BETWEEN_HEARTBEAT_CHECK)
-                current_minute = dt.datetime.utcnow().minute
+                current_minute = dt.datetime.now(dt.UTC).minute
                 if last_heartbeat_minute != current_minute:
                     self._log.info("Heartbeat.")
                     last_heartbeat_minute = current_minute

--- a/Source/Visualizations/aws_loosa/processing_pipeline/utils/__init__.py
+++ b/Source/Visualizations/aws_loosa/processing_pipeline/utils/__init__.py
@@ -2,4 +2,4 @@ import datetime as dt
 
 
 def UTCNOW():
-    return dt.datetime.utcnow()
+    return dt.datetime.now(dt.UTC)

--- a/Source/Visualizations/aws_loosa/utils/shared_funcs.py
+++ b/Source/Visualizations/aws_loosa/utils/shared_funcs.py
@@ -22,7 +22,7 @@ def add_update_time(data, method='extend_table'):
     if method not in ['extend_table', 'calculate_field', 'array']:
         raise Exception("method must be extend_table, calculate_field,  or array")
 
-    update_time = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")
+    update_time = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d %H:%M UTC")
 
     if method == 'extend_table':
         print("--> Updating table by extending existing attributes")


### PR DESCRIPTION
`utcnow()` was deprecated in Python 3.12. This PR preemptively updates those calls to the preferred `.now(datetime.UTC)` method.

https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow