### PR TITLE
Alaska FIM product config yaml files AnA, GFS 10 day, NBM 10/5 day, SRF

### DIFF
--- a/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/analysis_assim_alaska/ana_inundation_ak.yml
+++ b/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/analysis_assim_alaska/ana_inundation_ak.yml
@@ -1,0 +1,31 @@
+product: ana_inundation_ak
+configuration: analysis_assim_alaska
+product_type: "fim"
+domain: alaska
+run: true
+
+ingest_files:
+    - file_format: common/data/model/com/nwm/{{variable:NWM_DATAFLOW_VERSION}}/nwm.{{datetime:%Y%m%d}}/analysis_assim_alaska/nwm.t{{datetime:%H}}z.analysis_assim.channel_rt.tm00.alaska.nc
+      file_step: None
+      file_window: None
+      target_table: ingest.nwm_channel_rt_ana_ak
+      target_keys: (feature_id, streamflow)
+
+db_max_flows:
+  - name: ana_max_flows_ak
+    target_table: cache.max_flows_ana_ak
+    target_keys: (feature_id, streamflow)
+    method: database
+    max_flows_sql_file: ana_max_flows_ak
+
+fim_configs:
+  - name: ana_inundation_ak
+    flows_table: cache.max_flows_ana_ak
+    target_table: fim_ingest.ana_inundation_ak
+    fim_type: hand
+    postprocess:
+      sql_file: ana_inundation_ak
+      target_table: publish.ana_inundation_ak
+ 
+services:
+  - ana_inundation_extent_ak_noaa

--- a/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/medium_range_alaska_mem1/mrf_gfs_10day_max_inundation_ak.yml
+++ b/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/medium_range_alaska_mem1/mrf_gfs_10day_max_inundation_ak.yml
@@ -1,0 +1,55 @@
+product: mrf_gfs_10day_max_inundation_ak
+configuration: medium_range_alaska_mem1
+product_type: "fim"
+domain: alaska
+run: true
+
+ingest_files:
+    - file_format: common/data/model/com/nwm/{{variable:NWM_DATAFLOW_VERSION}}/nwm.{{datetime:%Y%m%d}}/medium_range_alaska_mem1/nwm.t{{datetime:%H}}z.medium_range.channel_rt_1.f{{range:3,243,3,%03d}}.alaska.nc
+      file_step: None
+      file_window: None
+      target_table: ingest.nwm_channel_rt_mrf_gfs_ak_mem1
+      target_keys: (feature_id, streamflow)
+
+db_max_flows:
+  - name: mrf_gfs_3day_max_flows_ak
+    target_table: cache.max_flows_mrf_gfs_3day_ak
+    target_keys: (feature_id, streamflow)
+    method: database
+    max_flows_sql_file: mrf_gfs_3day_max_flows_ak
+  - name: mrf_gfs_5day_max_flows_ak
+    target_table: cache.max_flows_mrf_gfs_5day_ak
+    target_keys: (feature_id, streamflow)
+    method: database
+    max_flows_sql_file: mrf_gfs_5day_max_flows_ak
+  - name: mrf_gfs_10day_max_flows_ak
+    target_table: cache.max_flows_mrf_gfs_10day_ak
+    target_keys: (feature_id, streamflow)
+    method: database
+    max_flows_sql_file: mrf_gfs_10day_max_flows_ak
+
+fim_configs:
+  - name: mrf_gfs_max_inundation_3day_ak
+    flows_table: cache.max_flows_mrf_gfs_3day_ak
+    target_table: fim_ingest.mrf_gfs_max_inundation_3day_ak
+    fim_type: hand
+    postprocess:
+      sql_file: mrf_gfs_max_inundation_3day_ak
+      target_table: publish.mrf_gfs_max_inundation_3day_ak
+  - name: mrf_gfs_max_inundation_5day_ak
+    flows_table: cache.max_flows_mrf_gfs_5day_ak
+    target_table: fim_ingest.mrf_gfs_max_inundation_5day_ak
+    fim_type: hand
+    postprocess:
+      sql_file: mrf_gfs_max_inundation_5day_ak
+      target_table: publish.mrf_gfs_max_inundation_5day_ak
+  - name: mrf_gfs_max_inundation_10day_ak
+    flows_table: cache.max_flows_mrf_gfs_10day_ak
+    target_table: fim_ingest.mrf_gfs_max_inundation_10day_ak
+    fim_type: hand
+    postprocess:
+      sql_file: mrf_gfs_max_inundation_10day_ak
+      target_table: publish.mrf_gfs_max_inundation_10day_ak
+  
+services:
+  - mrf_gfs_10day_max_inundation_extent_ak_noaa

--- a/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/medium_range_blend_alaska/mrf_nbm_10day_max_inundation_ak.yml
+++ b/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/medium_range_blend_alaska/mrf_nbm_10day_max_inundation_ak.yml
@@ -1,0 +1,31 @@
+product: mrf_nbm_10day_max_inundation_ak
+configuration: medium_range_blend_alaska
+product_type: "fim"
+domain: alaska
+run: true
+
+ingest_files:
+    - file_format: common/data/model/com/nwm/{{variable:NWM_DATAFLOW_VERSION}}/nwm.{{datetime:%Y%m%d}}/medium_range_blend_alaska/nwm.t{{datetime:%H}}z.medium_range_blend.channel_rt.f{{range:3,243,3,%03d}}.alaska.nc
+      file_step: None
+      file_window: None
+      target_table: ingest.nwm_channel_rt_mrf_nbm_ak
+      target_keys: (feature_id, streamflow)
+
+db_max_flows:
+  - name: mrf_nbm_10day_max_flows_ak
+    target_table: cache.max_flows_mrf_nbm_10day_ak
+    target_keys: (feature_id, streamflow)
+    method: database
+    max_flows_sql_file: mrf_nbm_10day_max_flows_ak
+
+fim_configs:
+  - name: mrf_nbm_max_inundation_10day_ak
+    flows_table: cache.max_flows_mrf_nbm_10day_ak
+    target_table: fim_ingest.mrf_nbm_max_inundation_10day_ak
+    fim_type: hand
+    postprocess:
+      sql_file: mrf_nbm_max_inundation_10day_ak
+      target_table: publish.mrf_nbm_max_inundation_10day_ak
+  
+services:
+  - mrf_nbm_10day_max_inundation_extent_noaa_ak

--- a/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/medium_range_blend_alaska/mrf_nbm_5day_max_inundation_ak.yml
+++ b/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/medium_range_blend_alaska/mrf_nbm_5day_max_inundation_ak.yml
@@ -1,0 +1,31 @@
+product: mrf_nbm_5day_max_inundation_ak
+configuration: medium_range_blend_alaska
+product_type: "fim"
+domain: alaska
+run: true
+
+ingest_files:
+    - file_format: common/data/model/com/nwm/{{variable:NWM_DATAFLOW_VERSION}}/nwm.{{datetime:%Y%m%d}}/medium_range_blend_alaska/nwm.t{{datetime:%H}}z.medium_range_blend.channel_rt.f{{range:3,123,3,%03d}}.alaska.nc
+      file_step: None
+      file_window: None
+      target_table: ingest.nwm_channel_rt_mrf_nbm_ak
+      target_keys: (feature_id, streamflow)
+
+db_max_flows:
+  - name: mrf_nbm_5day_max_flows_ak
+    target_table: cache.max_flows_mrf_nbm_5day_ak
+    target_keys: (feature_id, streamflow)
+    method: database
+    max_flows_sql_file: mrf_nbm_5day_max_flows_ak
+
+fim_configs:
+  - name: mrf_nbm_max_inundation_5day_ak
+    flows_table: cache.max_flows_mrf_nbm_5day_ak
+    target_table: fim_ingest.mrf_nbm_max_inundation_5day_ak
+    fim_type: hand
+    postprocess:
+      sql_file: mrf_nbm_max_inundation_5day_ak
+      target_table: publish.mrf_nbm_max_inundation_5day_ak
+  
+services:
+  - mrf_nbm_5day_max_inundation_extent_noaa_ak

--- a/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/short_range_alaska/srf_15hr_max_inundation_ak.yml
+++ b/Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/short_range_alaska/srf_15hr_max_inundation_ak.yml
@@ -1,0 +1,31 @@
+product: srf_15hr_max_inundation_ak
+configuration: short_range_alaska
+product_type: "fim"
+domain: alaska
+run: true
+
+ingest_files:
+    - file_format: common/data/model/com/nwm/{{variable:NWM_DATAFLOW_VERSION}}/nwm.{{datetime:%Y%m%d}}/short_range_alaska/nwm.t{{datetime:%H}}z.short_range.channel_rt.f{{range:1,16,1,%03d}}.alaska.nc
+      file_step: None
+      file_window: None
+      target_table: ingest.nwm_channel_rt_srf_ak
+      target_keys: (feature_id, streamflow)
+
+db_max_flows:
+  - name: srf_max_flows_ak
+    target_table: cache.max_flows_srf_ak
+    target_keys: (feature_id, streamflow)
+    method: database
+    max_flows_sql_file: srf_max_flows_ak
+
+fim_configs:
+  - name: srf_15hr_max_inundation_ak
+    flows_table: cache.max_flows_srf_ak
+    target_table: fim_ingest.srf_15hr_max_inundation_ak
+    fim_type: hand
+    postprocess:
+      sql_file: srf_15hr_max_inundation_ak
+      target_table: publish.srf_15hr_max_inundation_ak
+  
+services:
+  - srf_15hr_max_inundation_extent_ak_noaa


### PR DESCRIPTION
Please use the 5 new Alaska FIM service product config yaml's to start the pipeline and generate output for these services. Once they have been started, we can complete the rest of the FIM service development (mapx, etc.)

Added files:

Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/analysis_assim_alaska/ana_inundation_ak.yml
Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/medium_range_alaska_mem1/mrf_gfs_10day_max_inundation_ak.yml
Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/medium_range_blend_alaska/mrf_nbm_10day_max_inundation_ak.yml
Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/medium_range_blend_alaska/mrf_nbm_5day_max_inundation_ak.yml
Core/LAMBDA/viz_functions/viz_initialize_pipeline/product_configs/short_range_alaska/srf_15hr_max_inundation_ak.yml
