### PR TITLE
Use shapely objects to store geometries.

### DIFF
--- a/Core/LAMBDA/viz_functions/image_based/viz_schism_fim_processing/process_schism_fim.py
+++ b/Core/LAMBDA/viz_functions/image_based/viz_schism_fim_processing/process_schism_fim.py
@@ -9,7 +9,6 @@
 #
 ################################
 import boto3
-import gc
 import geopandas as gpd
 import fiona
 import numpy as np

--- a/Core/LAMBDA/viz_functions/image_based/viz_schism_fim_processing/process_schism_fim.py
+++ b/Core/LAMBDA/viz_functions/image_based/viz_schism_fim_processing/process_schism_fim.py
@@ -489,11 +489,10 @@ def raster_to_polygon_dataframe(input_raster_memfile, attributes):
     gpd_polygonized_raster = gpd.GeoDataFrame()
     with input_raster_memfile.open() as src:
         image = src.read(1).astype('float32')
-        results = (
-            {'properties': attributes, 'geometry': s} for i, (s, v) 
-            in enumerate(rasterio.features.shapes(image, mask=image > 0, transform=src.transform))
+        geoms = list(
+            {'properties': attributes, 'geometry': s} for s, v 
+            in rasterio.features.shapes(image, mask=image > 0, transform=src.transform)
         )
-        geoms = list(results)
         if geoms:
             gpd_polygonized_raster  = gpd.GeoDataFrame.from_features(geoms, crs='4326')
 

--- a/Core/LAMBDA/viz_functions/image_based/viz_schism_fim_processing/process_schism_fim.py
+++ b/Core/LAMBDA/viz_functions/image_based/viz_schism_fim_processing/process_schism_fim.py
@@ -68,7 +68,6 @@ def main(event):
     print(f'Top-level processing (i.e. data from network to memory) time: {main_end - main_start} seconds')
     
     for tile_key in tile_keys:
-        gc.collect()
         start = time()
         final_grid_memfile, polygon_df = create_fim_by_tile(tile_key, fcst_points, mask_geoms_by_group)
         end = time()
@@ -431,7 +430,6 @@ def mask_fim(input_fim, mask_geoms_by_group):
     out_meta = {}
 
     for group, geoms in mask_geoms_by_group.items():
-        gc.collect()
         if not geoms: continue
         print(f'... Applying {group} masks...')
         


### PR DESCRIPTION
process_schism_fim uses a lot of memory. I tested with the pacific domain and discovered that loading the shapefile into memory takes almost 3GB of RAM.

Fiona represents geometries as dictionaries of objects. When storing large geometries such as those in the pacific domain, it becomes very inefficient. Fortunately, we can store geometries as shapely objects, which only use a fraction of the memory.

Before/after memory usage of `get_mask_geoms_by_group`
```
atlgulf:
increment: 2849.89 MiB   # old
increment: 604.03 MiB   # new

pacific:
increment: 2882.93 MiB   # old
increment: 515.28 MiB    # new

hi:
increment: 0.00 MiB
increment: 0.00 MiB

prvi:
increment: 0.00 MiB
increment: 0.01 MiB
```

Other misc fixes are removing two ineffective gc calls and an unnecessary enumeration.