### PR TITLE
Fim new model version field

### DIFF
--- a/Core/LAMBDA/viz_functions/image_based/viz_hand_fim_processing/lambda_function.py
+++ b/Core/LAMBDA/viz_functions/image_based/viz_hand_fim_processing/lambda_function.py
@@ -111,7 +111,7 @@ def lambda_handler(event, context):
                 print(f"catchment, hand, or rating curve are missing for huc {huc8} and branch {branch}:\nCatchment exists: {catch_exists} ({catchment_key})\nHand exists: {hand_exists} ({hand_key})\nRating curve exists: {rating_curve_exists} ({rating_curve_key})")
  
         # If not a reference/egis fim run, Upload zero_stage reaches for tracking / FIM cache
-        if fim_run_type != 'reference':
+        if fim_run_type != 'reference' and not stage_lookup.empty:
             print(f"Adding zero stage data to {db_table}_zero_stage")# Only process inundation configuration if available data
             df_zero_stage_records = df_zero_stage_records.reset_index()
             df_zero_stage_records.drop(columns=['hydro_id','feature_id'], inplace=True)

--- a/Core/LAMBDA/viz_functions/image_based/viz_hand_fim_processing/lambda_function.py
+++ b/Core/LAMBDA/viz_functions/image_based/viz_hand_fim_processing/lambda_function.py
@@ -111,7 +111,7 @@ def lambda_handler(event, context):
                 print(f"catchment, hand, or rating curve are missing for huc {huc8} and branch {branch}:\nCatchment exists: {catch_exists} ({catchment_key})\nHand exists: {hand_exists} ({hand_key})\nRating curve exists: {rating_curve_exists} ({rating_curve_key})")
  
         # If not a reference/egis fim run, Upload zero_stage reaches for tracking / FIM cache
-        if fim_run_type != 'reference' and not stage_lookup.empty:
+        if fim_run_type != 'reference' and not df_zero_stage_records.empty:
             print(f"Adding zero stage data to {db_table}_zero_stage")# Only process inundation configuration if available data
             df_zero_stage_records = df_zero_stage_records.reset_index()
             df_zero_stage_records.drop(columns=['hydro_id','feature_id'], inplace=True)

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_caching_templates/0_create_or_truncate_tables.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_caching_templates/0_create_or_truncate_tables.sql
@@ -1,5 +1,7 @@
 -- This creates the four tables on a RDS db needed for a cached fim pipeline run.
-CREATE TABLE IF NOT EXISTS {db_fim_table}_flows
+DROP TABLE IF EXISTS {db_fim_table}_flows;
+
+CREATE TABLE {db_fim_table}_flows
 (
     hand_id integer,
     hydro_id integer,
@@ -12,7 +14,9 @@ CREATE TABLE IF NOT EXISTS {db_fim_table}_flows
     prc_status text
 );
 
-CREATE TABLE IF NOT EXISTS {db_fim_table} 
+DROP TABLE IF EXISTS {db_fim_table};
+
+CREATE TABLE {db_fim_table} 
 (
     hand_id integer,
     forecast_discharge_cfs double precision,
@@ -29,20 +33,18 @@ CREATE TABLE IF NOT EXISTS {db_fim_table}
 	prc_method text
 );
 
-CREATE TABLE IF NOT EXISTS {db_fim_table}_geo (
+DROP TABLE IF EXISTS {db_fim_table}_geo;
+
+CREATE TABLE {db_fim_table}_geo (
     hand_id integer,
     rc_stage_ft integer,
     geom geometry(geometry, 3857)
 );
 
-CREATE TABLE IF NOT EXISTS {db_fim_table}_zero_stage (
+DROP TABLE IF EXISTS {db_fim_table}_zero_stage;
+
+CREATE TABLE {db_fim_table}_zero_stage (
     hand_id integer,
     rc_discharge_cms double precision,
 	note text
 );
-
--- Truncate the tables so they are ready for the FIM Config run
-TRUNCATE {db_fim_table}_flows;
-TRUNCATE {db_fim_table};
-TRUNCATE {db_fim_table}_geo;
-TRUNCATE {db_fim_table}_zero_stage;

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_caching_templates/2a_query_fim_cache-ras2fim.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_caching_templates/2a_query_fim_cache-ras2fim.sql
@@ -2,7 +2,7 @@
 INSERT INTO {db_fim_table} (
     hand_id, forecast_discharge_cfs,
     rc_discharge_cfs, rc_previous_discharge_cfs, rc_stage_ft, rc_previous_stage_ft,
-    max_rc_stage_ft, max_rc_discharge_cfs, fim_version, model_version, reference_time, prc_method
+    max_rc_stage_ft, max_rc_discharge_cfs, model_version, fim_version, reference_time, prc_method
 )
 
 SELECT

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_caching_templates/2b_query_fim_cache-hand.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/fim_caching_templates/2b_query_fim_cache-hand.sql
@@ -1,7 +1,7 @@
 -- Query the hand cache.
 INSERT INTO {db_fim_table} (
     hand_id, forecast_discharge_cfs, rc_discharge_cfs, rc_previous_discharge_cfs, rc_stage_ft, rc_previous_stage_ft,
-    max_rc_stage_ft, max_rc_discharge_cfs, fim_version, model_version, reference_time, prc_method
+    max_rc_stage_ft, max_rc_discharge_cfs, model_version, fim_version, reference_time, prc_method
 )
 SELECT
     fs.hand_id,


### PR DESCRIPTION
Refs #824

After merging PR #949 and manually deploying the code, a few issues were still found that needed to be cleaned up:

- When testing for apocalyptic flooding, it turns out that there may not be any "zero stage" records. So we now check if `df_zero_stage_records` is empty or not before operating on it rather than assuming it's not empty
- This enforces the dropping and recreating of the "{db_fim_table}*" tables. That shouldn't add much overhead at all and ensures that any tweaks to those schemas gets rolled out to the tables (as is the case here with the `model_version` column being added)
- Reorders the `fim_version` and `model_version` columns in a couple of places where they are inserted so they don't get mixed up