### PR TITLE
Ensures test s3 files copied last on deploy

### DIFF
--- a/Core/Testing/main.tf
+++ b/Core/Testing/main.tf
@@ -14,6 +14,18 @@ variable "lambda_role" {
   type = string
 }
 
+variable "s3_module" {
+  type = any
+}
+
+variable "lambda_module" {
+  type = any
+}
+
+variable "step_function_module" {
+  type = any
+}
+
 resource "aws_cloudwatch_event_rule" "detect_test_files" {
   name                = "hv-vpp-${var.environment}-detect-test-files"
   description         = "Detects when a new test file has been created"
@@ -59,7 +71,9 @@ resource "aws_cloudwatch_event_target" "trigger_pipeline_test_run" {
   }
 }
 
-# Kick off tests in TI
+##################################
+###### KICK OFF TESTS IN TI ######
+##################################
 data "aws_s3_objects" "test_nwm_outputs" {
   bucket        = var.test_data_bucket
   prefix        = "test_nwm_outputs/"
@@ -67,6 +81,7 @@ data "aws_s3_objects" "test_nwm_outputs" {
 }
 
 resource "aws_s3_object_copy" "test" {
+  depends_on  = [var.s3_module, var.lambda_module, var.step_function_module]
   count       = length(data.aws_s3_objects.test_nwm_outputs.keys)
   bucket      = var.test_data_bucket
   source      = join("/", [var.test_data_bucket, element(data.aws_s3_objects.test_nwm_outputs.keys, count.index)])

--- a/Core/Testing/main.tf
+++ b/Core/Testing/main.tf
@@ -81,7 +81,7 @@ data "aws_s3_objects" "test_nwm_outputs" {
 }
 
 resource "aws_s3_object_copy" "test" {
-  depends_on  = [var.s3_module, var.lambda_module, var.step_function_module]
+  depends_on  = [var.s3_module, var.lambda_module, var.step_function_module, aws_cloudwatch_event_target.trigger_pipeline_test_run]
   count       = length(data.aws_s3_objects.test_nwm_outputs.keys)
   bucket      = var.test_data_bucket
   source      = join("/", [var.test_data_bucket, element(data.aws_s3_objects.test_nwm_outputs.keys, count.index)])

--- a/Core/main.tf
+++ b/Core/main.tf
@@ -710,14 +710,12 @@ module "sync-wrds-location-db" {
 module "testing" {
   count = local.env.environment == "ti" ? 1 : 0
   source = "./Testing"
-  depends_on = [
-    module.s3.buckets,
-    module.step-functions.viz_pipeline_step_function,
-    module.viz-lambda-functions
-  ]
 
   environment                 = local.env.environment
   test_data_bucket            = module.s3.buckets["deployment"].bucket
   viz_initialize_pipeline_arn = module.viz-lambda-functions.initialize_pipeline.arn
   lambda_role                 = module.iam-roles.role_viz_pipeline.arn
+  s3_module                   = module.s3
+  lambda_module               = module.viz-lambda-functions
+  step_function_module        = module.step-functions
 }


### PR DESCRIPTION
The apocalyptic tests should not kick off until essentially everything else has been deployed. This PR configures the "depends_on" parameter on the "aws_s3_object_copy" resource to ensure they are not copied over until the s3, lambda, and step_function modules are deployed and the eventbridge target is configured.