### PR TITLE
Separates cache logic and configures separate step

### DIFF
--- a/Core/LAMBDA/viz_functions/viz_update_egis_data/lambda_function.py
+++ b/Core/LAMBDA/viz_functions/viz_update_egis_data/lambda_function.py
@@ -131,8 +131,8 @@ def lambda_handler(event, context):
         connection.close()
 
         columns = ', '.join(column_names)
-        
-        if step == 'cache_data':
+
+        if 'cache' in step:
             cache_data_on_s3(viz_db, viz_schema, table, reference_time, cache_bucket, columns)
         else:
             # Copy data to EGIS

--- a/Core/LAMBDA/viz_functions/viz_update_egis_data/lambda_function.py
+++ b/Core/LAMBDA/viz_functions/viz_update_egis_data/lambda_function.py
@@ -1,8 +1,8 @@
 import boto3
 import os
-from viz_classes import database, s3_file
+from viz_classes import database
 from viz_lambda_shared_funcs import gen_dict_extract
-from datetime import datetime, timedelta
+from datetime import datetime
 
 ###################################
 def lambda_handler(event, context):
@@ -17,11 +17,12 @@ def lambda_handler(event, context):
     if event['args']['product']['configuration'] == "reference":
         return
     
+    if job_type == 'past_event' and 'cache' not in step:
+        return
+
     ################### Unstage EGIS Tables ###################
     if "unstage" in step:
-        if job_type == "past_event":
-            return
-        elif step == "unstage_db_tables":
+        if step == "unstage_db_tables":
             print(f"Unstaging tables for {event['args']['product']['product']}")
             target_tables = list(gen_dict_extract("target_table", event['args']))
             all_single_tables = [table for table in target_tables if type(table) is not list]
@@ -96,9 +97,9 @@ def lambda_handler(event, context):
         return True
     
     ################### Stage EGIS Tables ###################
-    elif step == "update_summary_data":
+    elif "summary_data" in step:
         tables =  event['args']['postprocess_summary']['target_table']
-    elif step == "update_fim_config_data":
+    elif "fim_config_data" in step:
         if not event['args']['fim_config'].get('postprocess'):
             return
         
@@ -130,19 +131,16 @@ def lambda_handler(event, context):
         connection.close()
 
         columns = ', '.join(column_names)
-            
-        if job_type == 'auto':
-            # Copy data to EGIS - THIS CURRENTLY DOES NOT WORK IN DEV DUE TO REVERSE PEERING NOT FUNCTIONING - it will copy the viz TI table.
+        
+        if step == 'cache_data':
+            cache_data_on_s3(viz_db, viz_schema, table, reference_time, cache_bucket, columns)
+        else:
+            # Copy data to EGIS
             try: # Try copying the data
                 stage_db_table(egis_db, origin_table=f"vizprc_publish.{table}", dest_table=f"services.{staged_table}", columns=columns, add_oid=True, add_geom_index=True, update_srid=3857) #Copy the publish table from the vizprc db to the egis db, using fdw
             except Exception as e: # If it doesn't work initially, try refreshing the foreign schema and try again.
                 refresh_fdw_schema(egis_db, local_schema="vizprc_publish", remote_server="vizprc_db", remote_schema=viz_schema) #Update the foreign data schema - we really don't need to run this all the time, but it's fast, so I'm trying it.
                 stage_db_table(egis_db, origin_table=f"vizprc_publish.{table}", dest_table=f"services.{staged_table}", columns=columns, add_oid=True, add_geom_index=True, update_srid=3857) #Copy the publish table from the vizprc db to the egis db, using fdw
-            cache_data_on_s3(viz_db, viz_schema, table, reference_time, cache_bucket, columns)
-
-        elif job_type == 'past_event':
-            viz_schema = 'archive'
-            cache_data_on_s3(viz_db, viz_schema, table, reference_time, cache_bucket, columns)
     
     return True
 

--- a/Core/StepFunctions/viz_processing_pipeline.json.tftpl
+++ b/Core/StepFunctions/viz_processing_pipeline.json.tftpl
@@ -658,6 +658,32 @@
                     }
                   ],
                   "ResultPath": null,
+                  "Next": "Cache Data - Product"
+                },
+                "Cache Data - Product": {
+                  "Type": "Task",
+                  "Resource": "arn:aws:states:::lambda:invoke",
+                  "Parameters": {
+                    "FunctionName": "${update_egis_data_arn}",
+                    "Payload": {
+                      "args.$": "$",
+                      "step": "cache_product_data"
+                    }
+                  },
+                  "Retry": [
+                    {
+                      "ErrorEquals": [
+                        "Lambda.ServiceException",
+                        "Lambda.AWSLambdaException",
+                        "Lambda.SdkClientException"
+                      ],
+                      "IntervalSeconds": 2,
+                      "MaxAttempts": 6,
+                      "BackoffRate": 2,
+                      "Comment": "Lambda Service Errors"
+                    }
+                  ],
+                  "ResultPath": null,
                   "End": true
                 }
               }
@@ -1154,6 +1180,32 @@
                     }
                   ],
                   "ResultPath": null,
+                  "Next": "Cache Data - FIM Config"
+                },
+                "Cache Data - FIM Config": {
+                  "Type": "Task",
+                  "Resource": "arn:aws:states:::lambda:invoke",
+                  "Parameters": {
+                    "FunctionName": "${update_egis_data_arn}",
+                    "Payload": {
+                      "args.$": "$",
+                      "step": "cache_fim_config_data"
+                    }
+                  },
+                  "Retry": [
+                    {
+                      "ErrorEquals": [
+                        "Lambda.ServiceException",
+                        "Lambda.AWSLambdaException",
+                        "Lambda.SdkClientException"
+                      ],
+                      "IntervalSeconds": 2,
+                      "MaxAttempts": 6,
+                      "BackoffRate": 2,
+                      "Comment": "Lambda Service Errors"
+                    }
+                  ],
+                  "ResultPath": null,
                   "End": true
                 }
               }
@@ -1246,6 +1298,32 @@
                     "Payload": {
                       "args.$": "$",
                       "step": "update_summary_data"
+                    }
+                  },
+                  "Retry": [
+                    {
+                      "ErrorEquals": [
+                        "Lambda.ServiceException",
+                        "Lambda.AWSLambdaException",
+                        "Lambda.SdkClientException"
+                      ],
+                      "IntervalSeconds": 2,
+                      "MaxAttempts": 6,
+                      "BackoffRate": 2,
+                      "Comment": "Lambda Service Errors"
+                    }
+                  ],
+                  "ResultPath": null,
+                  "Next": "Cache Data - Summary"
+                },
+                "Cache Data - Summary": {
+                  "Type": "Task",
+                  "Resource": "arn:aws:states:::lambda:invoke",
+                  "Parameters": {
+                    "FunctionName": "${update_egis_data_arn}",
+                    "Payload": {
+                      "args.$": "$",
+                      "step": "cache_summary_data"
                     }
                   },
                   "Retry": [


### PR DESCRIPTION
Refs #970 

The logic in `Core/LAMBDA/viz_functions/viz_update_egis_data/lambda_function.py` was tweaked to separate the code that updates the data behind the services from the code that caches the data in S3.

The configuration of the viz-pipline in `Core/StepFunctions/viz_processing_pipeline.json.tftpl` was updated to add a new "Cache EGIS Data - *" step after each "Update EGIS Data - *" step.