### PR TITLE
Increases max memory for TI version only of fim-data-prep Lambda

### DIFF
--- a/Core/LAMBDA/viz_functions/main.tf
+++ b/Core/LAMBDA/viz_functions/main.tf
@@ -655,7 +655,7 @@ resource "aws_s3_object" "fim_data_prep_zip_upload" {
 resource "aws_lambda_function" "viz_fim_data_prep" {
   function_name = "hv-vpp-${var.environment}-viz-fim-data-prep"
   description   = "Lambda function to setup a fim run by retriving max flows from the database, prepare an ingest database table, and creating a dictionary for huc-based worker lambdas to use."
-  memory_size   = 2048
+  memory_size   = var.environment == "ti" ? 4096 : 2048 # Larger for apocalyptic testing
   timeout       = 900
   vpc_config {
     security_group_ids = var.db_lambda_security_groups


### PR DESCRIPTION
Refs #938

The apocalyptic testing uses a lot more resources, as expected. In this case, the fim-data-prep Lambda was failing when running the srf_max_inundation. Rather than increase the memory for this Lambda across the board, this PR adds code to only increase it for the TI environment, since we'll assume that apocalyptic conditions should not ever be reached in real life. We want to continue to ensure everything can possibly be run within the allowable, configurable limits within the TI environment.