### PR TITLE
rm noaa:monitoring allowing granular env setting

### DIFF
--- a/Core/RDS/ingest/main.tf
+++ b/Core/RDS/ingest/main.tf
@@ -65,7 +65,6 @@ resource "aws_db_instance" "hydrovis" {
 
   tags = {
     "hv-vpp-${var.environment}-data-ingest-rdsdbtag" : "hv-vpp-${var.environment}-data-ingest-rdsdbtag"
-    "noaa:monitoring"                                : "true"
   }
 }
 

--- a/Core/RDS/viz/main.tf
+++ b/Core/RDS/viz/main.tf
@@ -122,7 +122,6 @@ resource "aws_db_instance" "hydrovis" {
 
   tags = {
     "hv-vpp-${var.environment}-viz-processing-rdsdbtag" : "hv-vpp-${var.environment}-viz-processing-rdsdbtag"
-    "noaa:monitoring"                                   : "true"
   }
 }
 

--- a/Core/StepFunctions/rnr/main.tf
+++ b/Core/StepFunctions/rnr/main.tf
@@ -37,9 +37,6 @@ resource "aws_sfn_state_machine" "replace_route_step_function" {
         rnr_domain_generator_arn = var.rnr_domain_generator_arn
         rnr_ec2_instance = var.rnr_ec2_instance
     })
-
-    tags = {
-    }
 }
 
 resource "aws_cloudwatch_event_target" "check_lambda_every_five_minutes" {

--- a/Core/StepFunctions/rnr/main.tf
+++ b/Core/StepFunctions/rnr/main.tf
@@ -39,7 +39,6 @@ resource "aws_sfn_state_machine" "replace_route_step_function" {
     })
 
     tags = {
-      "noaa:monitoring" : "true"
     }
 }
 

--- a/Core/StepFunctions/viz/main.tf
+++ b/Core/StepFunctions/viz/main.tf
@@ -106,9 +106,6 @@ resource "aws_sfn_state_machine" "viz_pipeline_step_function" {
         hand_fim_processing_step_function_arn = aws_sfn_state_machine.hand_fim_processing_step_function.arn
         viz_processing_pipeline_log_group = var.viz_processing_pipeline_log_group
     })
-
-    tags = {
-    }
 }
 
 ###############################################

--- a/Core/StepFunctions/viz/main.tf
+++ b/Core/StepFunctions/viz/main.tf
@@ -108,7 +108,6 @@ resource "aws_sfn_state_machine" "viz_pipeline_step_function" {
     })
 
     tags = {
-      "noaa:monitoring" : "true"
     }
 }
 


### PR DESCRIPTION
* This removes setting the `"noaa:monitoring": "true"` from four terraform files.
* The monitoring setting should only be on for prod.
* This tag is applied individually for prod in both regions in the env yaml files on the vlab repo instead of here
* If monitoring stops working, this change could be why