### PR TITLE
tag = {} for all aws_s3_objects

### DIFF
--- a/Core/EC2/Ingest/main.tf
+++ b/Core/EC2/Ingest/main.tf
@@ -84,6 +84,7 @@ locals {
 ###############
 
 resource "aws_s3_object" "hml_ingester" {
+  tags = {}
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/owp-hml-ingester.tar.gz"
   source      = "${path.module}/../../../Source/Ingest/owp-hml-ingester.tar.gz"

--- a/Core/EC2/Ingest/main.tf
+++ b/Core/EC2/Ingest/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      configuration_aliases = [ aws.sns, aws.no_tags]
+    }
+  }
+}
+
 ###############
 ## VARIABLES ##
 ###############
@@ -84,8 +93,7 @@ locals {
 ###############
 
 resource "aws_s3_object" "hml_ingester" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/owp-hml-ingester.tar.gz"
   source      = "${path.module}/../../../Source/Ingest/owp-hml-ingester.tar.gz"

--- a/Core/EC2/Ingest/main.tf
+++ b/Core/EC2/Ingest/main.tf
@@ -84,7 +84,8 @@ locals {
 ###############
 
 resource "aws_s3_object" "hml_ingester" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/owp-hml-ingester.tar.gz"
   source      = "${path.module}/../../../Source/Ingest/owp-hml-ingester.tar.gz"

--- a/Core/EC2/RDSBastion/main.tf
+++ b/Core/EC2/RDSBastion/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      configuration_aliases = [ aws.sns, aws.no_tags]
+    }
+  }
+}
+
 ###############
 ## VARIABLES ##
 ###############
@@ -220,8 +229,7 @@ resource "aws_instance" "rds-bastion" {
 ###############
 
 resource "aws_s3_object" "postgis_setup" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket = var.data_deployment_bucket
   key    = "terraform_artifacts/${path.module}/postgis_setup.sql"
   source = "${path.module}/data/postgis_setup.sql"
@@ -229,8 +237,7 @@ resource "aws_s3_object" "postgis_setup" {
 }
 
 resource "aws_s3_object" "ingest_rfcfcst_base" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket = var.data_deployment_bucket
   key    = "terraform_artifacts/${path.module}/ingest/rfcfcst_base.sql.gz"
   source = "${path.module}/data/ingest/rfcfcst_base.sql.gz"
@@ -238,8 +245,7 @@ resource "aws_s3_object" "ingest_rfcfcst_base" {
 }
 
 resource "aws_s3_object" "ingest_ingest_users" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket  = var.data_deployment_bucket
   key     = "terraform_artifacts/${path.module}/ingest/ingest_users.sql"
   content = templatefile("${path.module}/data/ingest/ingest_users.sql.tftpl", {

--- a/Core/EC2/RDSBastion/main.tf
+++ b/Core/EC2/RDSBastion/main.tf
@@ -220,7 +220,8 @@ resource "aws_instance" "rds-bastion" {
 ###############
 
 resource "aws_s3_object" "postgis_setup" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket = var.data_deployment_bucket
   key    = "terraform_artifacts/${path.module}/postgis_setup.sql"
   source = "${path.module}/data/postgis_setup.sql"
@@ -228,7 +229,8 @@ resource "aws_s3_object" "postgis_setup" {
 }
 
 resource "aws_s3_object" "ingest_rfcfcst_base" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket = var.data_deployment_bucket
   key    = "terraform_artifacts/${path.module}/ingest/rfcfcst_base.sql.gz"
   source = "${path.module}/data/ingest/rfcfcst_base.sql.gz"
@@ -236,7 +238,8 @@ resource "aws_s3_object" "ingest_rfcfcst_base" {
 }
 
 resource "aws_s3_object" "ingest_ingest_users" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket  = var.data_deployment_bucket
   key     = "terraform_artifacts/${path.module}/ingest/ingest_users.sql"
   content = templatefile("${path.module}/data/ingest/ingest_users.sql.tftpl", {

--- a/Core/EC2/RDSBastion/main.tf
+++ b/Core/EC2/RDSBastion/main.tf
@@ -220,6 +220,7 @@ resource "aws_instance" "rds-bastion" {
 ###############
 
 resource "aws_s3_object" "postgis_setup" {
+  tags = {}
   bucket = var.data_deployment_bucket
   key    = "terraform_artifacts/${path.module}/postgis_setup.sql"
   source = "${path.module}/data/postgis_setup.sql"
@@ -227,6 +228,7 @@ resource "aws_s3_object" "postgis_setup" {
 }
 
 resource "aws_s3_object" "ingest_rfcfcst_base" {
+  tags = {}
   bucket = var.data_deployment_bucket
   key    = "terraform_artifacts/${path.module}/ingest/rfcfcst_base.sql.gz"
   source = "${path.module}/data/ingest/rfcfcst_base.sql.gz"
@@ -234,6 +236,7 @@ resource "aws_s3_object" "ingest_rfcfcst_base" {
 }
 
 resource "aws_s3_object" "ingest_ingest_users" {
+  tags = {}
   bucket  = var.data_deployment_bucket
   key     = "terraform_artifacts/${path.module}/ingest/ingest_users.sql"
   content = templatefile("${path.module}/data/ingest/ingest_users.sql.tftpl", {

--- a/Core/EC2/rnr/main.tf
+++ b/Core/EC2/rnr/main.tf
@@ -95,7 +95,8 @@ locals {
 ###############
 
 resource "aws_s3_object" "replace_route" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/owp-viz-replace-route.tgz"
   source = "${path.module}/../../../Source/RnR/owp-viz-replace-route.tgz"

--- a/Core/EC2/rnr/main.tf
+++ b/Core/EC2/rnr/main.tf
@@ -95,6 +95,7 @@ locals {
 ###############
 
 resource "aws_s3_object" "replace_route" {
+  tags = {}
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/owp-viz-replace-route.tgz"
   source = "${path.module}/../../../Source/RnR/owp-viz-replace-route.tgz"

--- a/Core/EC2/rnr/main.tf
+++ b/Core/EC2/rnr/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      configuration_aliases = [ aws.sns, aws.no_tags]
+    }
+  }
+}
+
 ###############
 ## VARIABLES ##
 ###############
@@ -95,8 +104,7 @@ locals {
 ###############
 
 resource "aws_s3_object" "replace_route" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/owp-viz-replace-route.tgz"
   source = "${path.module}/../../../Source/RnR/owp-viz-replace-route.tgz"

--- a/Core/EC2/viz/main.tf
+++ b/Core/EC2/viz/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      configuration_aliases = [ aws.sns, aws.no_tags]
+    }
+  }
+}
+
 #######################
 ## DYNAMIC VARIABLES ##
 #######################
@@ -171,8 +180,7 @@ data "aws_ami" "windows" {
 ################
 
 resource "aws_s3_object" "setup_upload" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket      = var.deployment_data_bucket
   key         = "terraform_artifacts/${path.module}/scripts/viz_ec2_setup.ps1"
   source      = "${path.module}/scripts/viz_ec2_setup.ps1"

--- a/Core/EC2/viz/main.tf
+++ b/Core/EC2/viz/main.tf
@@ -171,7 +171,8 @@ data "aws_ami" "windows" {
 ################
 
 resource "aws_s3_object" "setup_upload" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket      = var.deployment_data_bucket
   key         = "terraform_artifacts/${path.module}/scripts/viz_ec2_setup.ps1"
   source      = "${path.module}/scripts/viz_ec2_setup.ps1"

--- a/Core/EC2/viz/main.tf
+++ b/Core/EC2/viz/main.tf
@@ -171,6 +171,7 @@ data "aws_ami" "windows" {
 ################
 
 resource "aws_s3_object" "setup_upload" {
+  tags = {}
   bucket      = var.deployment_data_bucket
   key         = "terraform_artifacts/${path.module}/scripts/viz_ec2_setup.ps1"
   source      = "${path.module}/scripts/viz_ec2_setup.ps1"

--- a/Core/LAMBDA/ingest_functions/main.tf
+++ b/Core/LAMBDA/ingest_functions/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      configuration_aliases = [ aws.sns ]
+      configuration_aliases = [ aws.sns, aws.no_tags]
     }
   }
 }

--- a/Core/LAMBDA/layers/main.tf
+++ b/Core/LAMBDA/layers/main.tf
@@ -23,6 +23,7 @@ variable "deployment_bucket" {
 ######################
 
 resource "aws_s3_object" "es_logging" {
+  tags = {}
   bucket = var.deployment_bucket
   key    = "terraform_artifacts/${path.module}/es_logging.zip"
   source = "${path.module}/es_logging.zip"
@@ -52,6 +53,7 @@ data "archive_file" "viz_lambda_shared_funcs_zip" {
 }
 
 resource "aws_s3_object" "viz_lambda_shared_funcs_zip_upload" {
+  tags = {}
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_lambda_shared_funcs.zip"
   source      = data.archive_file.viz_lambda_shared_funcs_zip.output_path
@@ -75,6 +77,7 @@ resource "aws_lambda_layer_version" "viz_lambda_shared_funcs" {
 #############################
 
 resource "aws_s3_object" "arcgis_python_api" {
+  tags = {}
   bucket = var.deployment_bucket
   key    = "terraform_artifacts/${path.module}/arcgis_python_api.zip"
   source = "${path.module}/arcgis_python_api.zip"
@@ -98,6 +101,7 @@ resource "aws_lambda_layer_version" "arcgis_python_api" {
 ##################
 
 resource "aws_s3_object" "pandas" {
+  tags = {}
   bucket = var.deployment_bucket
   key    = "terraform_artifacts/${path.module}/pandas.zip"
   source = "${path.module}/pandas.zip"
@@ -122,6 +126,7 @@ resource "aws_lambda_layer_version" "pandas" {
 
 
 resource "aws_s3_object" "geopandas" {
+  tags = {}
   bucket = var.deployment_bucket
   key    = "terraform_artifacts/${path.module}/geopandas.zip"
   source = "${path.module}/geopandas.zip"
@@ -145,6 +150,7 @@ resource "aws_lambda_layer_version" "geopandas" {
 ##################################
 
 resource "aws_s3_object" "psycopg2_sqlalchemy" {
+  tags = {}
   bucket = var.deployment_bucket
   key    = "terraform_artifacts/${path.module}/psycopg2_sqlalchemy.zip"
   source = "${path.module}/psycopg2_sqlalchemy.zip"
@@ -168,6 +174,7 @@ resource "aws_lambda_layer_version" "psycopg2_sqlalchemy" {
 ##########################
 
 resource "aws_s3_object" "huc_proc_combo" {
+  tags = {}
   bucket = var.deployment_bucket
   key    = "terraform_artifacts/${path.module}/huc_proc_combo.zip"
   source = "${path.module}/huc_proc_combo.zip"
@@ -191,6 +198,7 @@ resource "aws_lambda_layer_version" "huc_proc_combo" {
 ##################
 
 resource "aws_s3_object" "xarray" {
+  tags = {}
   bucket = var.deployment_bucket
   key    = "terraform_artifacts/${path.module}/xarray.zip"
   source = "${path.module}/xarray.zip"
@@ -214,6 +222,7 @@ resource "aws_lambda_layer_version" "xarray" {
 ################
 
 resource "aws_s3_object" "pika" {
+  tags = {}
   bucket = var.deployment_bucket
   key    = "terraform_artifacts/${path.module}/pika.zip"
   source = "${path.module}/pika.zip"
@@ -237,6 +246,7 @@ resource "aws_lambda_layer_version" "pika" {
 ####################
 
 resource "aws_s3_object" "requests" {
+  tags = {}
   bucket = var.deployment_bucket
   key    = "terraform_artifacts/${path.module}/requests.zip"
   source = "${path.module}/requests.zip"

--- a/Core/LAMBDA/layers/main.tf
+++ b/Core/LAMBDA/layers/main.tf
@@ -23,7 +23,8 @@ variable "deployment_bucket" {
 ######################
 
 resource "aws_s3_object" "es_logging" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket = var.deployment_bucket
   key    = "terraform_artifacts/${path.module}/es_logging.zip"
   source = "${path.module}/es_logging.zip"
@@ -53,7 +54,8 @@ data "archive_file" "viz_lambda_shared_funcs_zip" {
 }
 
 resource "aws_s3_object" "viz_lambda_shared_funcs_zip_upload" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_lambda_shared_funcs.zip"
   source      = data.archive_file.viz_lambda_shared_funcs_zip.output_path
@@ -77,7 +79,8 @@ resource "aws_lambda_layer_version" "viz_lambda_shared_funcs" {
 #############################
 
 resource "aws_s3_object" "arcgis_python_api" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket = var.deployment_bucket
   key    = "terraform_artifacts/${path.module}/arcgis_python_api.zip"
   source = "${path.module}/arcgis_python_api.zip"
@@ -101,7 +104,8 @@ resource "aws_lambda_layer_version" "arcgis_python_api" {
 ##################
 
 resource "aws_s3_object" "pandas" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket = var.deployment_bucket
   key    = "terraform_artifacts/${path.module}/pandas.zip"
   source = "${path.module}/pandas.zip"
@@ -126,7 +130,8 @@ resource "aws_lambda_layer_version" "pandas" {
 
 
 resource "aws_s3_object" "geopandas" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket = var.deployment_bucket
   key    = "terraform_artifacts/${path.module}/geopandas.zip"
   source = "${path.module}/geopandas.zip"
@@ -150,7 +155,8 @@ resource "aws_lambda_layer_version" "geopandas" {
 ##################################
 
 resource "aws_s3_object" "psycopg2_sqlalchemy" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket = var.deployment_bucket
   key    = "terraform_artifacts/${path.module}/psycopg2_sqlalchemy.zip"
   source = "${path.module}/psycopg2_sqlalchemy.zip"
@@ -174,7 +180,8 @@ resource "aws_lambda_layer_version" "psycopg2_sqlalchemy" {
 ##########################
 
 resource "aws_s3_object" "huc_proc_combo" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket = var.deployment_bucket
   key    = "terraform_artifacts/${path.module}/huc_proc_combo.zip"
   source = "${path.module}/huc_proc_combo.zip"
@@ -198,7 +205,8 @@ resource "aws_lambda_layer_version" "huc_proc_combo" {
 ##################
 
 resource "aws_s3_object" "xarray" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket = var.deployment_bucket
   key    = "terraform_artifacts/${path.module}/xarray.zip"
   source = "${path.module}/xarray.zip"
@@ -222,7 +230,8 @@ resource "aws_lambda_layer_version" "xarray" {
 ################
 
 resource "aws_s3_object" "pika" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket = var.deployment_bucket
   key    = "terraform_artifacts/${path.module}/pika.zip"
   source = "${path.module}/pika.zip"
@@ -246,7 +255,8 @@ resource "aws_lambda_layer_version" "pika" {
 ####################
 
 resource "aws_s3_object" "requests" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket = var.deployment_bucket
   key    = "terraform_artifacts/${path.module}/requests.zip"
   source = "${path.module}/requests.zip"

--- a/Core/LAMBDA/layers/main.tf
+++ b/Core/LAMBDA/layers/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      configuration_aliases = [ aws.sns, aws.no_tags]
+    }
+  }
+}
+
 variable "environment" {
   description = "Hydrovis environment"
   type        = string
@@ -23,8 +32,7 @@ variable "deployment_bucket" {
 ######################
 
 resource "aws_s3_object" "es_logging" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket = var.deployment_bucket
   key    = "terraform_artifacts/${path.module}/es_logging.zip"
   source = "${path.module}/es_logging.zip"
@@ -54,8 +62,7 @@ data "archive_file" "viz_lambda_shared_funcs_zip" {
 }
 
 resource "aws_s3_object" "viz_lambda_shared_funcs_zip_upload" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_lambda_shared_funcs.zip"
   source      = data.archive_file.viz_lambda_shared_funcs_zip.output_path
@@ -79,8 +86,7 @@ resource "aws_lambda_layer_version" "viz_lambda_shared_funcs" {
 #############################
 
 resource "aws_s3_object" "arcgis_python_api" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket = var.deployment_bucket
   key    = "terraform_artifacts/${path.module}/arcgis_python_api.zip"
   source = "${path.module}/arcgis_python_api.zip"
@@ -104,8 +110,7 @@ resource "aws_lambda_layer_version" "arcgis_python_api" {
 ##################
 
 resource "aws_s3_object" "pandas" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket = var.deployment_bucket
   key    = "terraform_artifacts/${path.module}/pandas.zip"
   source = "${path.module}/pandas.zip"
@@ -130,8 +135,7 @@ resource "aws_lambda_layer_version" "pandas" {
 
 
 resource "aws_s3_object" "geopandas" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket = var.deployment_bucket
   key    = "terraform_artifacts/${path.module}/geopandas.zip"
   source = "${path.module}/geopandas.zip"
@@ -155,8 +159,7 @@ resource "aws_lambda_layer_version" "geopandas" {
 ##################################
 
 resource "aws_s3_object" "psycopg2_sqlalchemy" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket = var.deployment_bucket
   key    = "terraform_artifacts/${path.module}/psycopg2_sqlalchemy.zip"
   source = "${path.module}/psycopg2_sqlalchemy.zip"
@@ -180,8 +183,7 @@ resource "aws_lambda_layer_version" "psycopg2_sqlalchemy" {
 ##########################
 
 resource "aws_s3_object" "huc_proc_combo" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket = var.deployment_bucket
   key    = "terraform_artifacts/${path.module}/huc_proc_combo.zip"
   source = "${path.module}/huc_proc_combo.zip"
@@ -205,8 +207,7 @@ resource "aws_lambda_layer_version" "huc_proc_combo" {
 ##################
 
 resource "aws_s3_object" "xarray" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket = var.deployment_bucket
   key    = "terraform_artifacts/${path.module}/xarray.zip"
   source = "${path.module}/xarray.zip"
@@ -230,8 +231,7 @@ resource "aws_lambda_layer_version" "xarray" {
 ################
 
 resource "aws_s3_object" "pika" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket = var.deployment_bucket
   key    = "terraform_artifacts/${path.module}/pika.zip"
   source = "${path.module}/pika.zip"
@@ -255,8 +255,7 @@ resource "aws_lambda_layer_version" "pika" {
 ####################
 
 resource "aws_s3_object" "requests" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket = var.deployment_bucket
   key    = "terraform_artifacts/${path.module}/requests.zip"
   source = "${path.module}/requests.zip"

--- a/Core/LAMBDA/rnr_functions/main.tf
+++ b/Core/LAMBDA/rnr_functions/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      configuration_aliases = [ aws.sns ]
+      configuration_aliases = [ aws.sns, aws.no_tags]
     }
   }
 }
@@ -80,8 +80,7 @@ data "archive_file" "rnr_domain_generator_zip" {
 }
 
 resource "aws_s3_object" "rnr_domain_generator_zip_upload" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/rnr_domain_generator.zip"
   source      = data.archive_file.rnr_domain_generator_zip.output_path

--- a/Core/LAMBDA/rnr_functions/main.tf
+++ b/Core/LAMBDA/rnr_functions/main.tf
@@ -80,6 +80,7 @@ data "archive_file" "rnr_domain_generator_zip" {
 }
 
 resource "aws_s3_object" "rnr_domain_generator_zip_upload" {
+  tags = {}
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/rnr_domain_generator.zip"
   source      = data.archive_file.rnr_domain_generator_zip.output_path

--- a/Core/LAMBDA/rnr_functions/main.tf
+++ b/Core/LAMBDA/rnr_functions/main.tf
@@ -80,7 +80,8 @@ data "archive_file" "rnr_domain_generator_zip" {
 }
 
 resource "aws_s3_object" "rnr_domain_generator_zip_upload" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/rnr_domain_generator.zip"
   source      = data.archive_file.rnr_domain_generator_zip.output_path

--- a/Core/LAMBDA/viz_functions/image_based/main.tf
+++ b/Core/LAMBDA/viz_functions/image_based/main.tf
@@ -508,7 +508,11 @@ data "aws_lambda_function" "viz_hand_fim_processing" {
 
 module "schism-fim" {
   source = "./viz_schism_fim_processing"
-  
+  providers = {
+    aws     = aws
+    aws.sns = aws.sns
+    aws.no_tags = aws.no_tags
+  }
   environment                 = var.environment
   account_id                  = var.account_id
   region                      = var.region

--- a/Core/LAMBDA/viz_functions/image_based/main.tf
+++ b/Core/LAMBDA/viz_functions/image_based/main.tf
@@ -129,7 +129,8 @@ data "archive_file" "raster_processing_zip" {
 }
 
 resource "aws_s3_object" "raster_processing_zip_upload" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_raster_processing.zip"
   source      = data.archive_file.raster_processing_zip.output_path
@@ -254,7 +255,8 @@ data "archive_file" "optimize_rasters_zip" {
 }
 
 resource "aws_s3_object" "optimize_rasters_zip_upload" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_optimize_rasters.zip"
   source      = data.archive_file.optimize_rasters_zip.output_path
@@ -398,7 +400,8 @@ data "archive_file" "hand_fim_processing_zip" {
 }
 
 resource "aws_s3_object" "hand_fim_processing_zip_upload" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_hand_fim_processing.zip"
   source      = data.archive_file.hand_fim_processing_zip.output_path

--- a/Core/LAMBDA/viz_functions/image_based/main.tf
+++ b/Core/LAMBDA/viz_functions/image_based/main.tf
@@ -129,6 +129,7 @@ data "archive_file" "raster_processing_zip" {
 }
 
 resource "aws_s3_object" "raster_processing_zip_upload" {
+  tags = {}
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_raster_processing.zip"
   source      = data.archive_file.raster_processing_zip.output_path
@@ -253,6 +254,7 @@ data "archive_file" "optimize_rasters_zip" {
 }
 
 resource "aws_s3_object" "optimize_rasters_zip_upload" {
+  tags = {}
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_optimize_rasters.zip"
   source      = data.archive_file.optimize_rasters_zip.output_path
@@ -396,6 +398,7 @@ data "archive_file" "hand_fim_processing_zip" {
 }
 
 resource "aws_s3_object" "hand_fim_processing_zip_upload" {
+  tags = {}
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_hand_fim_processing.zip"
   source      = data.archive_file.hand_fim_processing_zip.output_path

--- a/Core/LAMBDA/viz_functions/image_based/main.tf
+++ b/Core/LAMBDA/viz_functions/image_based/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      configuration_aliases = [ aws.sns, aws.no_tags]
+    }
+  }
+}
+
 variable "environment" {
   type = string
 }
@@ -129,8 +138,7 @@ data "archive_file" "raster_processing_zip" {
 }
 
 resource "aws_s3_object" "raster_processing_zip_upload" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_raster_processing.zip"
   source      = data.archive_file.raster_processing_zip.output_path
@@ -255,8 +263,7 @@ data "archive_file" "optimize_rasters_zip" {
 }
 
 resource "aws_s3_object" "optimize_rasters_zip_upload" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_optimize_rasters.zip"
   source      = data.archive_file.optimize_rasters_zip.output_path
@@ -400,8 +407,7 @@ data "archive_file" "hand_fim_processing_zip" {
 }
 
 resource "aws_s3_object" "hand_fim_processing_zip_upload" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_hand_fim_processing.zip"
   source      = data.archive_file.hand_fim_processing_zip.output_path

--- a/Core/LAMBDA/viz_functions/image_based/viz_schism_fim_processing/main.tf
+++ b/Core/LAMBDA/viz_functions/image_based/viz_schism_fim_processing/main.tf
@@ -87,7 +87,8 @@ data "archive_file" "schism_processing_zip" {
 }
 
 resource "aws_s3_object" "schism_processing_zip_upload" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_schism_fim_processing.zip"
   source      = data.archive_file.schism_processing_zip.output_path

--- a/Core/LAMBDA/viz_functions/image_based/viz_schism_fim_processing/main.tf
+++ b/Core/LAMBDA/viz_functions/image_based/viz_schism_fim_processing/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      configuration_aliases = [ aws.sns, aws.no_tags]
+    }
+  }
+}
+
 variable "environment" {
   type = string
 }
@@ -87,8 +96,7 @@ data "archive_file" "schism_processing_zip" {
 }
 
 resource "aws_s3_object" "schism_processing_zip_upload" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_schism_fim_processing.zip"
   source      = data.archive_file.schism_processing_zip.output_path

--- a/Core/LAMBDA/viz_functions/image_based/viz_schism_fim_processing/main.tf
+++ b/Core/LAMBDA/viz_functions/image_based/viz_schism_fim_processing/main.tf
@@ -87,6 +87,7 @@ data "archive_file" "schism_processing_zip" {
 }
 
 resource "aws_s3_object" "schism_processing_zip_upload" {
+  tags = {}
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_schism_fim_processing.zip"
   source      = data.archive_file.schism_processing_zip.output_path

--- a/Core/LAMBDA/viz_functions/main.tf
+++ b/Core/LAMBDA/viz_functions/main.tf
@@ -239,6 +239,7 @@ data "archive_file" "egis_health_checker_zip" {
 }
 
 resource "aws_s3_object" "egis_health_checker_zip_upload" {
+  tags = {}
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/egis_health_checker.zip"
   source      = data.archive_file.egis_health_checker_zip.output_path
@@ -329,6 +330,7 @@ data "archive_file" "python_preprocessing_zip" {
 }
 
 resource "aws_s3_object" "python_preprocessing_zip_upload" {
+  tags = {}
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_python_preprocessing.zip"
   source      = data.archive_file.python_preprocessing_zip.output_path
@@ -449,6 +451,7 @@ data "archive_file" "initialize_pipeline_zip" {
 }
 
 resource "aws_s3_object" "initialize_pipeline_zip_upload" {
+  tags = {}
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_initialize_pipeline.zip"
   source      = data.archive_file.initialize_pipeline_zip.output_path
@@ -550,6 +553,7 @@ data "archive_file" "db_postprocess_sql_zip" {
 }
 
 resource "aws_s3_object" "db_postprocess_sql_zip_upload" {
+  tags = {}
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_db_postprocess_sql.zip"
   source      = data.archive_file.db_postprocess_sql_zip.output_path
@@ -612,6 +616,7 @@ data "archive_file" "db_ingest_zip" {
 }
 
 resource "aws_s3_object" "db_ingest_zip_upload" {
+  tags = {}
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_db_ingest.zip"
   source      = data.archive_file.db_ingest_zip.output_path
@@ -674,6 +679,7 @@ data "archive_file" "fim_data_prep_zip" {
 }
 
 resource "aws_s3_object" "fim_data_prep_zip_upload" {
+  tags = {}
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_fim_data_prep.zip"
   source      = data.archive_file.fim_data_prep_zip.output_path
@@ -743,6 +749,7 @@ data "archive_file" "update_egis_data_zip" {
 }
 
 resource "aws_s3_object" "update_egis_data_zip_upload" {
+  tags = {}
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_update_egis_data.zip"
   source      = data.archive_file.update_egis_data_zip.output_path
@@ -809,6 +816,7 @@ data "archive_file" "publish_service_zip" {
 }
 
 resource "aws_s3_object" "publish_service_zip_upload" {
+  tags = {}
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_publish_service.zip"
   source      = data.archive_file.publish_service_zip.output_path
@@ -816,6 +824,7 @@ resource "aws_s3_object" "publish_service_zip_upload" {
 }
 
 resource "aws_s3_object" "viz_publish_mapx_files" {
+  tags = {}
   for_each    = fileset("${path.module}/viz_publish_service/services", "**/*.mapx")
   bucket      = var.deployment_bucket
   key         = "viz_mapx/${reverse(split("/",each.key))[0]}"
@@ -897,6 +906,7 @@ data "archive_file" "viz_test_wrds_db_zip" {
 }
 
 resource "aws_s3_object" "viz_test_wrds_db_upload" {
+  tags = {}
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_update_egis_data.zip"
   source      = data.archive_file.viz_test_wrds_db_zip.output_path

--- a/Core/LAMBDA/viz_functions/main.tf
+++ b/Core/LAMBDA/viz_functions/main.tf
@@ -239,7 +239,8 @@ data "archive_file" "egis_health_checker_zip" {
 }
 
 resource "aws_s3_object" "egis_health_checker_zip_upload" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/egis_health_checker.zip"
   source      = data.archive_file.egis_health_checker_zip.output_path
@@ -330,7 +331,8 @@ data "archive_file" "python_preprocessing_zip" {
 }
 
 resource "aws_s3_object" "python_preprocessing_zip_upload" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_python_preprocessing.zip"
   source      = data.archive_file.python_preprocessing_zip.output_path
@@ -451,7 +453,8 @@ data "archive_file" "initialize_pipeline_zip" {
 }
 
 resource "aws_s3_object" "initialize_pipeline_zip_upload" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_initialize_pipeline.zip"
   source      = data.archive_file.initialize_pipeline_zip.output_path
@@ -553,7 +556,8 @@ data "archive_file" "db_postprocess_sql_zip" {
 }
 
 resource "aws_s3_object" "db_postprocess_sql_zip_upload" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_db_postprocess_sql.zip"
   source      = data.archive_file.db_postprocess_sql_zip.output_path
@@ -616,7 +620,8 @@ data "archive_file" "db_ingest_zip" {
 }
 
 resource "aws_s3_object" "db_ingest_zip_upload" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_db_ingest.zip"
   source      = data.archive_file.db_ingest_zip.output_path
@@ -679,7 +684,8 @@ data "archive_file" "fim_data_prep_zip" {
 }
 
 resource "aws_s3_object" "fim_data_prep_zip_upload" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_fim_data_prep.zip"
   source      = data.archive_file.fim_data_prep_zip.output_path
@@ -749,7 +755,8 @@ data "archive_file" "update_egis_data_zip" {
 }
 
 resource "aws_s3_object" "update_egis_data_zip_upload" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_update_egis_data.zip"
   source      = data.archive_file.update_egis_data_zip.output_path
@@ -816,7 +823,8 @@ data "archive_file" "publish_service_zip" {
 }
 
 resource "aws_s3_object" "publish_service_zip_upload" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_publish_service.zip"
   source      = data.archive_file.publish_service_zip.output_path
@@ -824,7 +832,8 @@ resource "aws_s3_object" "publish_service_zip_upload" {
 }
 
 resource "aws_s3_object" "viz_publish_mapx_files" {
-  tags = {}
+  provider = aws.no_tags
+  
   for_each    = fileset("${path.module}/viz_publish_service/services", "**/*.mapx")
   bucket      = var.deployment_bucket
   key         = "viz_mapx/${reverse(split("/",each.key))[0]}"
@@ -906,7 +915,8 @@ data "archive_file" "viz_test_wrds_db_zip" {
 }
 
 resource "aws_s3_object" "viz_test_wrds_db_upload" {
-  tags = {}
+  provider = aws.no_tags
+  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_update_egis_data.zip"
   source      = data.archive_file.viz_test_wrds_db_zip.output_path

--- a/Core/LAMBDA/viz_functions/main.tf
+++ b/Core/LAMBDA/viz_functions/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      configuration_aliases = [ aws.sns ]
+      configuration_aliases = [ aws.sns, aws.no_tags]
     }
   }
 }
@@ -239,8 +239,7 @@ data "archive_file" "egis_health_checker_zip" {
 }
 
 resource "aws_s3_object" "egis_health_checker_zip_upload" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/egis_health_checker.zip"
   source      = data.archive_file.egis_health_checker_zip.output_path
@@ -331,8 +330,7 @@ data "archive_file" "python_preprocessing_zip" {
 }
 
 resource "aws_s3_object" "python_preprocessing_zip_upload" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_python_preprocessing.zip"
   source      = data.archive_file.python_preprocessing_zip.output_path
@@ -453,8 +451,7 @@ data "archive_file" "initialize_pipeline_zip" {
 }
 
 resource "aws_s3_object" "initialize_pipeline_zip_upload" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_initialize_pipeline.zip"
   source      = data.archive_file.initialize_pipeline_zip.output_path
@@ -556,8 +553,7 @@ data "archive_file" "db_postprocess_sql_zip" {
 }
 
 resource "aws_s3_object" "db_postprocess_sql_zip_upload" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_db_postprocess_sql.zip"
   source      = data.archive_file.db_postprocess_sql_zip.output_path
@@ -620,8 +616,7 @@ data "archive_file" "db_ingest_zip" {
 }
 
 resource "aws_s3_object" "db_ingest_zip_upload" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_db_ingest.zip"
   source      = data.archive_file.db_ingest_zip.output_path
@@ -684,8 +679,7 @@ data "archive_file" "fim_data_prep_zip" {
 }
 
 resource "aws_s3_object" "fim_data_prep_zip_upload" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_fim_data_prep.zip"
   source      = data.archive_file.fim_data_prep_zip.output_path
@@ -755,8 +749,7 @@ data "archive_file" "update_egis_data_zip" {
 }
 
 resource "aws_s3_object" "update_egis_data_zip_upload" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_update_egis_data.zip"
   source      = data.archive_file.update_egis_data_zip.output_path
@@ -823,8 +816,7 @@ data "archive_file" "publish_service_zip" {
 }
 
 resource "aws_s3_object" "publish_service_zip_upload" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_publish_service.zip"
   source      = data.archive_file.publish_service_zip.output_path
@@ -832,8 +824,7 @@ resource "aws_s3_object" "publish_service_zip_upload" {
 }
 
 resource "aws_s3_object" "viz_publish_mapx_files" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   for_each    = fileset("${path.module}/viz_publish_service/services", "**/*.mapx")
   bucket      = var.deployment_bucket
   key         = "viz_mapx/${reverse(split("/",each.key))[0]}"
@@ -915,8 +906,7 @@ data "archive_file" "viz_test_wrds_db_zip" {
 }
 
 resource "aws_s3_object" "viz_test_wrds_db_upload" {
-  provider = aws.no_tags
-  
+  provider = aws.no_tags  
   bucket      = var.deployment_bucket
   key         = "terraform_artifacts/${path.module}/viz_update_egis_data.zip"
   source      = data.archive_file.viz_test_wrds_db_zip.output_path

--- a/Core/LAMBDA/viz_functions/main.tf
+++ b/Core/LAMBDA/viz_functions/main.tf
@@ -956,7 +956,11 @@ resource "aws_lambda_function" "viz_test_wrds_db" {
 
 module "image-based-lambdas" {
   source = "./image_based"
-
+  providers = {
+    aws     = aws
+    aws.sns = aws.sns
+    aws.no_tags = aws.no_tags
+  }
   environment                 = var.environment
   account_id                  = var.account_id
   region                      = var.region

--- a/Core/Testing/main.tf
+++ b/Core/Testing/main.tf
@@ -91,7 +91,8 @@ data "aws_s3_objects" "test_nwm_outputs" {
 }
 
 resource "aws_s3_object_copy" "test" {
-  provider = aws.no_tags  depends_on  = [var.s3_module, var.lambda_module, var.step_function_module, aws_cloudwatch_event_target.trigger_pipeline_test_run]
+  provider = aws.no_tags
+  depends_on  = [var.s3_module, var.lambda_module, var.step_function_module, aws_cloudwatch_event_target.trigger_pipeline_test_run]
   count       = length(data.aws_s3_objects.test_nwm_outputs.keys)
   bucket      = local.test_bucket
   source      = join("/", [local.test_bucket, element(data.aws_s3_objects.test_nwm_outputs.keys, count.index)])

--- a/Core/Testing/main.tf
+++ b/Core/Testing/main.tf
@@ -82,6 +82,7 @@ data "aws_s3_objects" "test_nwm_outputs" {
 }
 
 resource "aws_s3_object_copy" "test" {
+  tags = {}
   depends_on  = [var.s3_module, var.lambda_module, var.step_function_module, aws_cloudwatch_event_target.trigger_pipeline_test_run]
   count       = length(data.aws_s3_objects.test_nwm_outputs.keys)
   bucket      = local.test_bucket

--- a/Core/Testing/main.tf
+++ b/Core/Testing/main.tf
@@ -82,7 +82,7 @@ data "aws_s3_objects" "test_nwm_outputs" {
 }
 
 resource "aws_s3_object_copy" "test" {
-  tags = {}
+  provider = aws.no_tags
   depends_on  = [var.s3_module, var.lambda_module, var.step_function_module, aws_cloudwatch_event_target.trigger_pipeline_test_run]
   count       = length(data.aws_s3_objects.test_nwm_outputs.keys)
   bucket      = local.test_bucket

--- a/Core/Testing/main.tf
+++ b/Core/Testing/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      configuration_aliases = [ aws.sns, aws.no_tags]
+    }
+  }
+}
+
 variable "environment" {
   type = string
 }
@@ -82,8 +91,7 @@ data "aws_s3_objects" "test_nwm_outputs" {
 }
 
 resource "aws_s3_object_copy" "test" {
-  provider = aws.no_tags
-  depends_on  = [var.s3_module, var.lambda_module, var.step_function_module, aws_cloudwatch_event_target.trigger_pipeline_test_run]
+  provider = aws.no_tags  depends_on  = [var.s3_module, var.lambda_module, var.step_function_module, aws_cloudwatch_event_target.trigger_pipeline_test_run]
   count       = length(data.aws_s3_objects.test_nwm_outputs.keys)
   bucket      = local.test_bucket
   source      = join("/", [local.test_bucket, element(data.aws_s3_objects.test_nwm_outputs.keys, count.index)])

--- a/Core/main.tf
+++ b/Core/main.tf
@@ -44,6 +44,13 @@ provider "aws" {
   }
 }
 
+provider "aws" {
+  alias = "no_tags"
+  region = local.env.region
+  profile = local.env.environment
+  shared_credentials_files = ["/cloud/aws/credentials"]
+}
+
 ###################### STAGE 1 ######################
 
 # IAM Roles

--- a/Core/main.tf
+++ b/Core/main.tf
@@ -301,7 +301,11 @@ module "sagemaker" {
 # Lambda Layers
 module "lambda-layers" {
   source = "./LAMBDA/layers"
-
+  providers = {
+    aws     = aws
+    aws.sns = aws.sns
+    aws.no_tags = aws.no_tags
+  }
   environment       = local.env.environment
   region            = local.env.region
   viz_environment   = local.env.environment == "prod" ? "production" : local.env.environment == "uat" ? "staging" : local.env.environment == "ti" ? "staging" : "development"
@@ -369,7 +373,11 @@ module "rds-egis" {
 
 module "rds-bastion" {
   source = "./EC2/RDSBastion"
-
+  providers = {
+    aws     = aws
+    aws.sns = aws.sns
+    aws.no_tags = aws.no_tags
+  }
   environment                    = local.env.environment
   region                         = local.env.region
   account_id                     = local.env.account_id
@@ -444,8 +452,8 @@ module "ingest-lambda-functions" {
   providers = {
     aws     = aws
     aws.sns = aws.sns
+    aws.no_tags = aws.no_tags
   }
-
   environment                 = local.env.environment
   region                      = local.env.region
   deployment_bucket           = module.s3.buckets["deployment"].bucket
@@ -470,7 +478,11 @@ module "ingest-lambda-functions" {
 # Data Ingest
 module "data-ingest-ec2" {
   source = "./EC2/Ingest"
-
+  providers = {
+    aws     = aws
+    aws.sns = aws.sns
+    aws.no_tags = aws.no_tags
+  }
   environment            = local.env.environment
   region                 = local.env.region
   account_id             = local.env.account_id
@@ -495,7 +507,11 @@ module "data-ingest-ec2" {
 
 module "rnr" {
   source = "./EC2/rnr"
-
+  providers = {
+    aws     = aws
+    aws.sns = aws.sns
+    aws.no_tags = aws.no_tags
+  }
   environment                    = local.env.environment
   region                         = local.env.region
   account_id                     = local.env.account_id
@@ -518,8 +534,8 @@ module "rnr-lambda-functions" {
   providers = {
     aws     = aws
     aws.sns = aws.sns
+    aws.no_tags = aws.no_tags
   }
-
   environment                   = local.env.environment
   region                        = local.env.region
   rnr_data_bucket               = module.s3.buckets["rnr"].bucket
@@ -585,8 +601,8 @@ module "viz-lambda-functions" {
   providers = {
     aws     = aws
     aws.sns = aws.sns
+    aws.no_tags = aws.no_tags
   }
-
   environment                    = local.env.environment
   account_id                     = local.env.account_id
   region                         = local.env.region
@@ -685,7 +701,11 @@ module "eventbridge" {
 
 module "viz-ec2" {
   source = "./EC2/viz"
-
+  providers = {
+    aws     = aws
+    aws.sns = aws.sns
+    aws.no_tags = aws.no_tags
+  }
   environment                    = local.env.environment
   account_id                     = local.env.account_id
   region                         = local.env.region
@@ -723,7 +743,11 @@ module "viz-ec2" {
 module "testing" {
   count = local.env.environment == "ti" ? 1 : 0
   source = "./Testing"
-
+  providers = {
+    aws     = aws
+    aws.sns = aws.sns
+    aws.no_tags = aws.no_tags
+  }
   environment                 = local.env.environment
   s3_module                   = module.s3
   lambda_module               = module.viz-lambda-functions


### PR DESCRIPTION
## Why
This is to fix deployment errors with s3 objects having >10 tags which is [not allowed.](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html)

## Additions

- `tags = {}`

## Screenshots
I did a really cool regex find and replace:
![amazing-regex](https://github.com/user-attachments/assets/1c566abf-94f3-4183-b1d2-393894357828)


## Notes

Drix encountered this error:
```

│ Error: error updating tags: error setting resource tags (hydrovis-ti-deployment-us-east-1/terraform_artifacts/EC2/Ingest/owp-hml-ingester.tar.gz): BadRequest: Object tags cannot be greater than 10
│       status code: 400, request id: PA30P15KR8DPBNXN, host id: HI7YPFc9BOOKetco+P8fLEvb1p/0WS+vXX8U8+w9qBZgyKPFZrSxSnPYNRnsrWwC4amexhSkdQk=
│ 
│   with module.data-ingest-ec2.aws_s3_object.hml_ingester,
│   on EC2/Ingest/[main.tf](http://main.tf/) line 86, in resource "aws_s3_object" "hml_ingester":
│   86: resource "aws_s3_object" "hml_ingester" {
│ 
```