### PR TITLE
Implements apocalyptic-test step func in terraform

### DIFF
--- a/Core/Testing/trigger_apocalyptic_tests.json.tftpl
+++ b/Core/Testing/trigger_apocalyptic_tests.json.tftpl
@@ -1,0 +1,77 @@
+{
+  "QueryLanguage": "JSONata",
+  "Comment": "A description of my state machine",
+  "StartAt": "S3 object keys",
+  "States": {
+    "Remove Stale Run": {
+      "Type": "Map",
+      "ItemProcessor": {
+        "ProcessorConfig": {
+          "Mode": "DISTRIBUTED",
+          "ExecutionType": "EXPRESS"
+        },
+        "StartAt": "DeleteObject",
+        "States": {
+          "DeleteObject": {
+            "Type": "Task",
+            "Arguments": {
+              "Bucket": "${deployment_bucket}",
+              "Key": "{% $states.input.Key %}"
+            },
+            "Resource": "arn:aws:states:::aws-sdk:s3:deleteObject",
+            "End": true
+          }
+        }
+      },
+      "ItemReader": {
+        "Resource": "arn:aws:states:::s3:listObjectsV2",
+        "Arguments": {
+          "Bucket": "${deployment_bucket}",
+          "Prefix": "common/data/model/com/nwm/prod/"
+        },
+        "ReaderConfig": {}
+      },
+      "Label": "S3objectkeys",
+      "Output": {
+        "success": true
+      },
+      "Next": "Move Apocalyptic Files"
+    },
+    "Move Apocalyptic Files": {
+      "Type": "Map",
+      "ItemProcessor": {
+        "ProcessorConfig": {
+          "Mode": "DISTRIBUTED",
+          "ExecutionType": "EXPRESS"
+        },
+        "StartAt": "CopyObject",
+        "States": {
+          "CopyObject": {
+            "Type": "Task",
+            "Arguments": {
+              "Bucket": "${deployment_bucket}",
+              "CopySource": "{% $join(['${deployment_bucket}', $states.input.Key], '/') %}",
+              "Key": "{% $replace($states.input.Key, 'test_nwm_outputs', $now('common/data/model/com/nwm/prod/nwm.[Y0001][M01][D01]')) %}"
+            },
+            "Resource": "arn:aws:states:::aws-sdk:s3:copyObject",
+            "End": true,
+            "Output": {}
+          }
+        }
+      },
+      "ItemReader": {
+        "Resource": "arn:aws:states:::s3:listObjectsV2",
+        "Arguments": {
+          "Bucket": "${deployment_bucket}",
+          "Prefix": "test_nwm_outputs/"
+        },
+        "ReaderConfig": {}
+      },
+      "Label": "S3objectkeys",
+      "End": true,
+      "Output": {
+        "success": true
+      }
+    }
+  }
+}

--- a/Core/main.tf
+++ b/Core/main.tf
@@ -751,5 +751,6 @@ module "testing" {
   environment                 = local.env.environment
   s3_module                   = module.s3
   lambda_module               = module.viz-lambda-functions
-  step_function_module        = module.viz-step-functions
+  role                        = module.iam-roles.role_viz_pipeline.arn
+  deployment_bucket           = module.s3.buckets["deployment"].bucket
 }


### PR DESCRIPTION
Refs #938

Rather than have terraform essentially kick off the tests via the `aws_s3_objects` and `aws_s3_object_copy` terraform resources, which was an abuse of terraform and annoying to work with, I developed a step function that does the same thing. It can now be triggered on demand. It would be nice to eventually include some automation to kick it off automatically following a deployment, but not a big deal for now.