### PR TITLE
Refactors SQL usage of `channels_alaska` to `channels_ak`

### DIFF
--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/analysis_assim_alaska/ana_high_flow_magnitude_ak.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/analysis_assim_alaska/ana_high_flow_magnitude_ak.sql
@@ -43,5 +43,5 @@ SELECT channels.feature_id,
        to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS update_time,
        channels.geom
 INTO publish.ana_high_flow_magnitude_ak
-FROM derived.channels_alaska channels
+FROM derived.channels_ak channels
 JOIN high_flow_mag ON channels.feature_id = high_flow_mag.feature_id;

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/analysis_assim_alaska/ana_streamflow_ak.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/analysis_assim_alaska/ana_streamflow_ak.sql
@@ -16,4 +16,4 @@ SELECT
     channels.geom
 INTO publish.ana_streamflow_ak
 FROM cache.max_flows_ana_ak as ana
-left join derived.channels_alaska as channels ON channels.feature_id = ana.feature_id::bigint;
+left join derived.channels_ak as channels ON channels.feature_id = ana.feature_id::bigint;

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/medium_range_alaska_mem1/mrf_gfs_10day_high_water_arrival_time_ak.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/medium_range_alaska_mem1/mrf_gfs_10day_high_water_arrival_time_ak.sql
@@ -41,5 +41,5 @@ SELECT channels.feature_id,
     arrival_time.update_time,
     channels.geom
 INTO publish.mrf_gfs_10day_high_water_arrival_time_ak
-FROM derived.channels_alaska channels
+FROM derived.channels_ak channels
 JOIN arrival_time ON channels.feature_id = arrival_time.feature_id;

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/medium_range_alaska_mem1/mrf_gfs_10day_max_high_flow_magnitude_ak.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/medium_range_alaska_mem1/mrf_gfs_10day_max_high_flow_magnitude_ak.sql
@@ -69,5 +69,5 @@ SELECT channels.feature_id,
     to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS update_time,
     channels.geom
 INTO publish.mrf_gfs_10day_max_high_flow_magnitude_ak
-FROM derived.channels_alaska channels
+FROM derived.channels_ak channels
 JOIN high_flow_mag ON channels.feature_id = high_flow_mag.feature_id;

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/medium_range_alaska_mem1/mrf_gfs_10day_rapid_onset_flooding_ak.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/medium_range_alaska_mem1/mrf_gfs_10day_rapid_onset_flooding_ak.sql
@@ -10,7 +10,7 @@ WITH rapid_onset AS (
 				(
 				WITH series AS -- Calculate a full 240 hour series for every feature_id, so that unadjacent hours aren't compared
 					(SELECT channels.feature_id, generate_series(3,240,3) AS forecast_hour
-					 FROM derived.channels_alaska channels JOIN cache.max_flows_mrf_gfs_10day_ak as mf on channels.feature_id = mf.feature_id
+					 FROM derived.channels_ak channels JOIN cache.max_flows_mrf_gfs_10day_ak as mf on channels.feature_id = mf.feature_id
 					 WHERE channels.strm_order <= 4
 					)
 				SELECT series.feature_id, series.forecast_hour, CASE WHEN streamflow is NOT NULL THEN (streamflow * 35.315) ELSE 0.001 END AS streamflow -- Set streamflow to 0.01 in cases where it is missing, so we don't get a divide by zero error
@@ -72,6 +72,6 @@ SELECT channels.feature_id,
 	ST_LENGTH(channels.geom)*0.000621371 AS reach_Length_miles, to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS update_time,
 	geom
 INTO publish.mrf_gfs_10day_rapid_onset_flooding_alaska
-FROM derived.channels_alaska channels
+FROM derived.channels_ak channels
 JOIN rapid_onset ON channels.feature_id = rapid_onset.feature_id
 where channels.strm_order <= 4;

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/medium_range_blend_alaska/mrf_nbm_10day_high_water_arrival_time_ak.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/medium_range_blend_alaska/mrf_nbm_10day_high_water_arrival_time_ak.sql
@@ -42,5 +42,5 @@ SELECT channels.feature_id,
     arrival_time.update_time,
     channels.geom
 INTO publish.mrf_nbm_10day_high_water_arrival_time_ak
-FROM derived.channels_alaska channels
+FROM derived.channels_ak channels
 JOIN arrival_time ON channels.feature_id = arrival_time.feature_id;

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/medium_range_blend_alaska/mrf_nbm_10day_max_high_flow_magnitude_ak.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/medium_range_blend_alaska/mrf_nbm_10day_max_high_flow_magnitude_ak.sql
@@ -43,5 +43,5 @@ SELECT channels.feature_id,
     to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS update_time,
     channels.geom
 INTO publish.mrf_nbm_10day_max_high_flow_magnitude_ak
-FROM derived.channels_alaska channels
+FROM derived.channels_ak channels
 JOIN high_flow_mag ON channels.feature_id = high_flow_mag.feature_id;

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/medium_range_blend_alaska/mrf_nbm_10day_peak_flow_arrival_time_ak.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/medium_range_blend_alaska/mrf_nbm_10day_peak_flow_arrival_time_ak.sql
@@ -26,7 +26,7 @@ JOIN cache.max_flows_mrf_nbm_10day_ak AS max_flows
     ON forecasts.feature_id = max_flows.feature_id AND round((forecasts.streamflow*35.315)::numeric, 2) = max_flows.discharge_cfs
 
 -- Join in channels data to get reach metadata and geometry
-JOIN derived.channels_alaska as channels ON forecasts.feature_id = channels.feature_id::bigint
+JOIN derived.channels_ak as channels ON forecasts.feature_id = channels.feature_id::bigint
 
 -- Join in high water arrival time for return time (the yaml config file ensures that arrival time finishes first for this, but we'll join on reference_time as well to ensure)
 JOIN publish.mrf_nbm_10day_high_water_arrival_time_ak AS arrival_time ON forecasts.feature_id = arrival_time.feature_id and forecasts.reference_time = arrival_time.reference_time

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/medium_range_blend_alaska/mrf_nbm_10day_rapid_onset_flooding_ak.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/medium_range_blend_alaska/mrf_nbm_10day_rapid_onset_flooding_ak.sql
@@ -10,7 +10,7 @@ WITH rapid_onset AS (
 				(
 				WITH series AS -- Calculate a full 240 hour series for every feature_id, so that unadjacent hours aren't compared
 					(SELECT channels.feature_id, generate_series(3,240,3) AS forecast_hour
-					 FROM derived.channels_alaska channels JOIN cache.max_flows_mrf_nbm_10day_ak as mf on channels.feature_id = mf.feature_id
+					 FROM derived.channels_ak channels JOIN cache.max_flows_mrf_nbm_10day_ak as mf on channels.feature_id = mf.feature_id
 					 WHERE channels.strm_order <= 4
 					)
 				SELECT series.feature_id, series.forecast_hour, CASE WHEN streamflow is NOT NULL THEN (streamflow * 35.315) ELSE 0.001 END AS streamflow -- Set streamflow to 0.01 in cases where it is missing, so we don't get a divide by zero error
@@ -72,6 +72,6 @@ SELECT channels.feature_id,
 	ST_LENGTH(channels.geom)*0.000621371 AS reach_Length_miles, to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS update_time,
 	geom
 INTO publish.mrf_nbm_10day_rapid_onset_flooding_alaska
-FROM derived.channels_alaska channels
+FROM derived.channels_ak channels
 JOIN rapid_onset ON channels.feature_id = rapid_onset.feature_id
 where channels.strm_order <= 4;

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_alaska/srf_15hr_high_water_arrival_time_ak.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_alaska/srf_15hr_high_water_arrival_time_ak.sql
@@ -41,5 +41,5 @@ SELECT channels.feature_id,
     arrival_time.update_time,
     channels.geom
 INTO publish.srf_15hr_high_water_arrival_time_alaska
-FROM derived.channels_alaska channels
+FROM derived.channels_ak channels
 JOIN arrival_time ON channels.feature_id = arrival_time.feature_id

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_alaska/srf_15hr_max_high_flow_magnitude_ak.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_alaska/srf_15hr_max_high_flow_magnitude_ak.sql
@@ -42,5 +42,5 @@ SELECT channels.feature_id,
     to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS update_time,
     channels.geom
 INTO publish.srf_15hr_max_high_flow_magnitude_ak
-FROM derived.channels_alaska channels
+FROM derived.channels_ak channels
 JOIN high_flow_mag ON channels.feature_id = high_flow_mag.feature_id

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_alaska/srf_15hr_peak_flow_arrival_time_ak.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_alaska/srf_15hr_peak_flow_arrival_time_ak.sql
@@ -26,7 +26,7 @@ JOIN cache.max_flows_srf_ak AS max_flows
     ON forecasts.feature_id = max_flows.feature_id AND forecasts.streamflow = max_flows.discharge_cms
 
 -- Join in channels data to get reach metadata and geometry
-JOIN derived.channels_alaska as channels ON forecasts.feature_id = channels.feature_id::bigint
+JOIN derived.channels_ak as channels ON forecasts.feature_id = channels.feature_id::bigint
 
 -- Join in recurrence flows to get high water threshold
 JOIN derived.recurrence_flows_ak AS rf ON forecasts.feature_id = rf.feature_id

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_alaska/srf_15hr_rapid_onset_flooding_ak.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_alaska/srf_15hr_rapid_onset_flooding_ak.sql
@@ -10,7 +10,7 @@ WITH rapid_onset AS (
 				(
 				WITH series AS -- Calculate a full 15 hour series for every feature_id, so that unadjacent hours aren't compared
 					(SELECT channels.feature_id, generate_series(1,15,1) AS forecast_hour
-					 FROM derived.channels_alaska channels JOIN cache.max_flows_srf_ak as mf on channels.feature_id = mf.feature_id
+					 FROM derived.channels_ak channels JOIN cache.max_flows_srf_ak as mf on channels.feature_id = mf.feature_id
 					 WHERE channels.strm_order <= 4
 					)
 				SELECT series.feature_id, series.forecast_hour, CASE WHEN streamflow is NOT NULL THEN (streamflow * 35.315) ELSE 0.001 END AS streamflow -- Set streamflow to 0.01 in cases where it is missing, so we don't get a divide by zero error
@@ -71,6 +71,6 @@ SELECT channels.feature_id,
 	ST_LENGTH(channels.geom)*0.000621371 AS reach_Length_miles, to_char(now()::timestamp without time zone, 'YYYY-MM-DD HH24:MI:SS UTC') AS update_time,
 	geom
 INTO publish.srf_15hr_rapid_onset_flooding_ak
-FROM derived.channels_alaska channels
+FROM derived.channels_ak channels
 JOIN rapid_onset ON channels.feature_id = rapid_onset.feature_id
 where channels.strm_order <= 4;

--- a/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_alaska/srf_15hr_rate_of_change_ak.sql
+++ b/Core/LAMBDA/viz_functions/viz_db_postprocess_sql/products/short_range_alaska/srf_15hr_rate_of_change_ak.sql
@@ -27,6 +27,6 @@ INTO publish.srf_15hr_rate_of_change_ak
 FROM ingest.nwm_channel_rt_srf_ak as srf
 JOIN roi ON roi.feature_id = srf.feature_id
 JOIN cache.max_flows_ana_past_hour_ak AS ana ON ana.feature_id = srf.feature_id
-JOIN derived.channels_alaska as channels ON channels.feature_id = srf.feature_id
+JOIN derived.channels_ak as channels ON channels.feature_id = srf.feature_id
 WHERE srf.forecast_hour IN (3,6,9,12,15)
 ORDER BY forecast_hour, srf.feature_id;

--- a/Core/Manual_Workflows/static_services/Flowline Reference Services.ipynb
+++ b/Core/Manual_Workflows/static_services/Flowline Reference Services.ipynb
@@ -133,7 +133,7 @@
     "\trow_number() over() as oid,\n",
     "\tchannels.feature_id::TEXT AS feature_id_str\n",
     "INTO dev.flowlines_ak\n",
-    "FROM derived.channels_alaska AS channels\n",
+    "FROM derived.channels_ak AS channels\n",
     "JOIN derived.recurrence_flows_ak AS thresholds ON channels.feature_id = thresholds.feature_id\n",
     "'''\n",
     "execute_sql(sql)"


### PR DESCRIPTION
Refs #1033 

See issue above for details, or TLDR: the `channels_alaska` table was renamed to `channels_ak` so the code must be refactored to not break.