### PR TITLE
Remove GDAL env variables.

### DIFF
--- a/Core/LAMBDA/viz_functions/image_based/viz_optimize_rasters/serverless.yml.tmpl
+++ b/Core/LAMBDA/viz_functions/image_based/viz_optimize_rasters/serverless.yml.tmpl
@@ -14,7 +14,3 @@ functions:
     memorySize: 2048
     timeout: 900
     ephemeralStorageSize: 4096
-    environment:
-      GDAL_DATA: /var/task/share/gdal
-      PROJ_LIB: /var/task/share/proj
-


### PR DESCRIPTION
GDAL environment variable were set in serverless config. These paths are now set by the conda environment inside the container. Futhermore, in the new image, these paths don't exist.

ping: @shawncrawley 