### PR TITLE
Created new SRF 18HR FIMPact to Critical Infrastructure Service

### DIFF
--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range/srf_18hr_max_inundation_extent_noaa.mapx
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range/srf_18hr_max_inundation_extent_noaa.mapx
@@ -15,8 +15,8 @@
     "illumination" : {
       "type" : "CIMIlluminationProperties",
       "ambientLight" : 75,
-      "sunPositionX" : -0.61237243569579,
-      "sunPositionY" : 0.61237243569579,
+      "sunPositionX" : -0.61237243569579003,
+      "sunPositionY" : 0.61237243569579003,
       "sunPositionZ" : 0.5,
       "illuminationSource" : "AbsoluteSunPosition",
       "sunAzimuth" : 315,
@@ -36,23 +36,23 @@
         [
           [
             -15224159.214216806,
-            2159597.880736096
+            2159597.88073609583
           ],
           [
             -15224159.214216806,
             7211496.010788572
           ],
           [
-            -6228307.888008264,
+            -6228307.88800826389,
             7211496.010788572
           ],
           [
-            -6228307.888008264,
-            2159597.880736096
+            -6228307.88800826389,
+            2159597.88073609583
           ],
           [
             -15224159.214216806,
-            2159597.880736096
+            2159597.88073609583
           ]
         ]
       ],
@@ -92,10 +92,10 @@
       }
     ],
     "defaultExtent" : {
-      "xmin" : -19368717.27557146,
-      "ymin" : -3442849.0279824976,
-      "xmax" : 390432.8362943493,
-      "ymax" : 13691546.818226324,
+      "xmin" : -21558155.2736334167,
+      "ymin" : -3442849.02798249759,
+      "xmax" : 2579870.83435630426,
+      "ymax" : 13691546.8182263244,
       "spatialReference" : {
         "wkid" : 102100,
         "latestWkid" : 3857
@@ -430,10 +430,10 @@
           "oIDFields" : "usgs_site_code",
           "geometryType" : "esriGeometryPoint",
           "extent" : {
-            "xmin" : -124.28338099999996,
-            "ymin" : 27.220882450000033,
-            "xmax" : -67.93527777999998,
-            "ymax" : 48.99916667000008,
+            "xmin" : -124.283380999999963,
+            "ymin" : 27.2208824500000333,
+            "xmax" : -67.9352777799999785,
+            "ymax" : 48.9991666700000792,
             "spatialReference" : {
               "wkid" : 4326,
               "latestWkid" : 4326
@@ -770,7 +770,7 @@
                                     2
                                   ],
                                   [
-                                    4.227406790097774e-15,
+                                    4.2274067900977742e-15,
                                     0
                                   ],
                                   0,
@@ -807,9 +807,9 @@
                               "color" : {
                                 "type" : "CIMHSVColor",
                                 "values" : [
-                                  32.77,
-                                  92.86,
-                                  54.9,
+                                  32.770000000000003,
+                                  92.859999999999999,
+                                  54.899999999999999,
                                   100
                                 ]
                               }
@@ -867,7 +867,7 @@
                                     2
                                   ],
                                   [
-                                    4.227406790097774e-15,
+                                    4.2274067900977742e-15,
                                     0
                                   ],
                                   0,
@@ -904,9 +904,9 @@
                               "color" : {
                                 "type" : "CIMHSVColor",
                                 "values" : [
-                                  40.7,
-                                  53.24,
-                                  84.71,
+                                  40.700000000000003,
+                                  53.240000000000002,
+                                  84.709999999999994,
                                   100
                                 ]
                               }
@@ -964,7 +964,7 @@
                                     2
                                   ],
                                   [
-                                    4.213081331715514e-15,
+                                    4.2130813317155137e-15,
                                     0
                                   ],
                                   0,
@@ -1001,9 +1001,9 @@
                               "color" : {
                                 "type" : "CIMHSVColor",
                                 "values" : [
-                                  43.53,
+                                  43.530000000000001,
                                   20.73,
-                                  96.47,
+                                  96.469999999999999,
                                   100
                                 ]
                               }
@@ -1061,7 +1061,7 @@
                                     2
                                   ],
                                   [
-                                    4.213081331715514e-15,
+                                    4.2130813317155137e-15,
                                     0
                                   ],
                                   0,
@@ -1100,7 +1100,7 @@
                                 "values" : [
                                   0,
                                   0,
-                                  96.08,
+                                  96.079999999999998,
                                   100
                                 ]
                               }
@@ -1158,7 +1158,7 @@
                                     2
                                   ],
                                   [
-                                    4.213081331715514e-15,
+                                    4.2130813317155137e-15,
                                     0
                                   ],
                                   0,
@@ -1195,9 +1195,9 @@
                               "color" : {
                                 "type" : "CIMHSVColor",
                                 "values" : [
-                                  171.43,
-                                  14.96,
-                                  91.76,
+                                  171.43000000000001,
+                                  14.960000000000001,
+                                  91.760000000000005,
                                   100
                                 ]
                               }
@@ -1255,7 +1255,7 @@
                                     2
                                   ],
                                   [
-                                    4.127128581421953e-15,
+                                    4.1271285814219533e-15,
                                     0
                                   ],
                                   0,
@@ -1292,9 +1292,9 @@
                               "color" : {
                                 "type" : "CIMHSVColor",
                                 "values" : [
-                                  174.67,
+                                  174.66999999999999,
                                   50,
-                                  70.59,
+                                  70.590000000000003,
                                   100
                                 ]
                               }
@@ -1352,7 +1352,7 @@
                                     2
                                   ],
                                   [
-                                    4.127128581421953e-15,
+                                    4.1271285814219533e-15,
                                     0
                                   ],
                                   0,
@@ -1390,7 +1390,7 @@
                                 "type" : "CIMHSVColor",
                                 "values" : [
                                   175.25,
-                                  99.02,
+                                  99.019999999999996,
                                   40,
                                   100
                                 ]
@@ -1509,7 +1509,7 @@
                           "joinStyle" : "Round",
                           "lineStyle3D" : "Strip",
                           "miterLimit" : 10,
-                          "width" : 0.7,
+                          "width" : 0.69999999999999996,
                           "color" : {
                             "type" : "CIMRGBColor",
                             "values" : [
@@ -1604,7 +1604,7 @@
                           "joinStyle" : "Round",
                           "lineStyle3D" : "Strip",
                           "miterLimit" : 10,
-                          "width" : 0.7,
+                          "width" : 0.69999999999999996,
                           "color" : {
                             "type" : "CIMRGBColor",
                             "values" : [
@@ -1819,9 +1819,9 @@
           "geometryType" : "esriGeometryPoint",
           "extent" : {
             "xmin" : -13667986.8586,
-            "ymin" : 2976131.9767000005,
-            "xmax" : -7545985.205399999,
-            "ymax" : 6264345.286700003,
+            "ymin" : 2976131.97670000046,
+            "xmax" : -7545985.2053999994,
+            "ymax" : 6264345.28670000285,
             "spatialReference" : {
               "wkid" : 102100,
               "latestWkid" : 3857
@@ -2575,26 +2575,26 @@
             }
           ],
           "weights" : [
-            0.07692307692307694,
-            0.07692307692307694,
-            0.07692307692307694,
-            0.07692307692307694,
-            0.07692307692307694,
-            0.07692307692307694,
-            0.07692307692307694,
-            0.07692307692307694,
-            0.07692307692307694,
-            0.07692307692307694,
-            0.07692307692307694,
-            0.07692307692307694,
-            0.07692307692307694
+            0.076923076923076941,
+            0.076923076923076941,
+            0.076923076923076941,
+            0.076923076923076941,
+            0.076923076923076941,
+            0.076923076923076941,
+            0.076923076923076941,
+            0.076923076923076941,
+            0.076923076923076941,
+            0.076923076923076941,
+            0.076923076923076941,
+            0.076923076923076941,
+            0.076923076923076941
           ]
         },
         "radius" : 30,
         "rendererQuality" : 2,
         "minLabel" : "Sparse",
         "maxLabel" : "Dense",
-        "maxPixelIntensity" : 3.127700489026043e-07,
+        "maxPixelIntensity" : 3.1277004890260432e-07,
         "pixelIntensityStops" : [
           0.0011764705882353343,
           1
@@ -2610,13 +2610,938 @@
     },
     {
       "type" : "CIMFeatureLayer",
+      "name" : "18 Hours - Estimated Impacted Critical Infrastructure - Heatmap",
+      "uRI" : "CIMPATH=nwm_short_range_max_fim_extent_forecast/s___estimated_impacted_critical_infrastructure___heatmap.xml",
+      "sourceModifiedTime" : {
+        "type" : "TimeInstant"
+      },
+      "useSourceMetadata" : true,
+      "description" : "vizprocessing.postgres.18 Hours - Estimated Impacted Critical Infrastructure - Heatmap",
+      "layerElevation" : {
+        "type" : "CIMLayerElevationSurface",
+        "mapElevationID" : "{84F61CAA-CD53-4C26-BBF2-C7F7CA71C354}"
+      },
+      "expanded" : true,
+      "layerType" : "Operational",
+      "showLegends" : true,
+      "visibility" : false,
+      "displayCacheType" : "Permanent",
+      "maxDisplayCacheAge" : 5,
+      "showPopups" : true,
+      "serviceLayerID" : -1,
+      "refreshRate" : -1,
+      "refreshRateUnit" : "esriTimeUnitsSeconds",
+      "blendingMode" : "Alpha",
+      "autoGenerateFeatureTemplates" : true,
+      "featureElevationExpression" : "0",
+      "featureTable" : {
+        "type" : "CIMFeatureTable",
+        "displayField" : "name",
+        "editable" : true,
+        "dataConnection" : {
+          "type" : "CIMSqlQueryDataConnection",
+          "workspaceConnectionString" : "ENCRYPTED_PASSWORD=00022e68364562702b334f417050534f366337412f344166364656484246785735746f2f30754948375139454e45775761526f5034665946356d4366776e4d75703152622a00;SERVER=hv-vpp-ti-viz-processing.c4vzypepnkx3.us-east-1.rds.amazonaws.com;INSTANCE=sde:postgresql:hv-vpp-ti-viz-processing.c4vzypepnkx3.us-east-1.rds.amazonaws.com;DBCLIENT=postgresql;DB_CONNECTION_PROPERTIES=hv-vpp-ti-viz-processing.c4vzypepnkx3.us-east-1.rds.amazonaws.com;DATABASE=vizprocessing;USER=postgres;AUTHENTICATION_MODE=DBMS",
+          "workspaceFactory" : "SDE",
+          "dataset" : "vizprocessing.postgres.%18 Hours - Estimated Impacted Critical Infrastructure - Heatmap",
+          "datasetType" : "esriDTFeatureClass",
+          "sqlQuery" : "select oid, build_type, name, geometry, city, country, state, population, beds, naics_code, specialty, sourcedate, zipcode, status, trauma, alias, county, naics_desc, alt_name, naicsdescr, helipad, level_, source, type, hydro_id, hydro_id_str, feature_id, feature_id_str, streamflow_cfs, fim_stage_ft from vizprocessing.publish.srf_18hr_max_inundation_critical_infrastructure",
+          "srid" : "3857",
+          "spatialReference" : {
+            "wkid" : 102100,
+            "latestWkid" : 3857
+          },
+          "oIDFields" : "oid",
+          "geometryType" : "esriGeometryPoint",
+          "extent" : {
+            "xmin" : -11233061.5255999994,
+            "ymin" : 3166721.97920000181,
+            "xmax" : -8066621.58500000089,
+            "ymax" : 5422752.96230000257,
+            "spatialReference" : {
+              "wkid" : 102100,
+              "latestWkid" : 3857
+            }
+          },
+          "queryFields" : [
+            {
+              "name" : "oid",
+              "type" : "esriFieldTypeInteger",
+              "alias" : "oid"
+            },
+            {
+              "name" : "build_type",
+              "type" : "esriFieldTypeString",
+              "alias" : "build_type",
+              "length" : 1073741822
+            },
+            {
+              "name" : "name",
+              "type" : "esriFieldTypeString",
+              "alias" : "name",
+              "length" : 1073741822
+            },
+            {
+              "name" : "geometry",
+              "type" : "esriFieldTypeGeometry",
+              "alias" : "geometry",
+              "geometryDef" : {
+                "avgNumPoints" : 0,
+                "geometryType" : "esriGeometryPoint",
+                "hasM" : false,
+                "hasZ" : false,
+                "spatialReference" : {
+                  "wkid" : 102100,
+                  "latestWkid" : 3857
+                }
+              }
+            },
+            {
+              "name" : "city",
+              "type" : "esriFieldTypeString",
+              "alias" : "city",
+              "length" : 1073741822
+            },
+            {
+              "name" : "country",
+              "type" : "esriFieldTypeString",
+              "alias" : "country",
+              "length" : 1073741822
+            },
+            {
+              "name" : "state",
+              "type" : "esriFieldTypeString",
+              "alias" : "state",
+              "length" : 1073741822
+            },
+            {
+              "name" : "population",
+              "type" : "esriFieldTypeDouble",
+              "alias" : "population"
+            },
+            {
+              "name" : "beds",
+              "type" : "esriFieldTypeDouble",
+              "alias" : "beds"
+            },
+            {
+              "name" : "naics_code",
+              "type" : "esriFieldTypeString",
+              "alias" : "naics_code",
+              "length" : 1073741822
+            },
+            {
+              "name" : "specialty",
+              "type" : "esriFieldTypeString",
+              "alias" : "specialty",
+              "length" : 1073741822
+            },
+            {
+              "name" : "sourcedate",
+              "type" : "esriFieldTypeDouble",
+              "alias" : "sourcedate"
+            },
+            {
+              "name" : "zipcode",
+              "type" : "esriFieldTypeString",
+              "alias" : "zipcode",
+              "length" : 1073741822
+            },
+            {
+              "name" : "status",
+              "type" : "esriFieldTypeString",
+              "alias" : "status",
+              "length" : 1073741822
+            },
+            {
+              "name" : "trauma",
+              "type" : "esriFieldTypeString",
+              "alias" : "trauma",
+              "length" : 1073741822
+            },
+            {
+              "name" : "alias",
+              "type" : "esriFieldTypeString",
+              "alias" : "alias",
+              "length" : 1073741822
+            },
+            {
+              "name" : "county",
+              "type" : "esriFieldTypeString",
+              "alias" : "county",
+              "length" : 1073741822
+            },
+            {
+              "name" : "naics_desc",
+              "type" : "esriFieldTypeString",
+              "alias" : "naics_desc",
+              "length" : 1073741822
+            },
+            {
+              "name" : "alt_name",
+              "type" : "esriFieldTypeString",
+              "alias" : "alt_name",
+              "length" : 1073741822
+            },
+            {
+              "name" : "naicsdescr",
+              "type" : "esriFieldTypeString",
+              "alias" : "naicsdescr",
+              "length" : 1073741822
+            },
+            {
+              "name" : "helipad",
+              "type" : "esriFieldTypeString",
+              "alias" : "helipad",
+              "length" : 1073741822
+            },
+            {
+              "name" : "level_",
+              "type" : "esriFieldTypeString",
+              "alias" : "level_",
+              "length" : 1073741822
+            },
+            {
+              "name" : "source",
+              "type" : "esriFieldTypeString",
+              "alias" : "source",
+              "length" : 1073741822
+            },
+            {
+              "name" : "type",
+              "type" : "esriFieldTypeString",
+              "alias" : "type",
+              "length" : 1073741822
+            },
+            {
+              "name" : "hydro_id",
+              "type" : "esriFieldTypeInteger",
+              "alias" : "hydro_id"
+            },
+            {
+              "name" : "hydro_id_str",
+              "type" : "esriFieldTypeString",
+              "alias" : "hydro_id_str",
+              "length" : 1073741822
+            },
+            {
+              "name" : "feature_id",
+              "type" : "esriFieldTypeDouble",
+              "alias" : "feature_id"
+            },
+            {
+              "name" : "feature_id_str",
+              "type" : "esriFieldTypeString",
+              "alias" : "feature_id_str",
+              "length" : 1073741822
+            },
+            {
+              "name" : "streamflow_cfs",
+              "type" : "esriFieldTypeDouble",
+              "alias" : "streamflow_cfs"
+            },
+            {
+              "name" : "fim_stage_ft",
+              "type" : "esriFieldTypeDouble",
+              "alias" : "fim_stage_ft"
+            }
+          ],
+          "spatialStorageType" : 8
+        },
+        "studyAreaSpatialRel" : "esriSpatialRelUndefined",
+        "searchOrder" : "esriSearchOrderSpatial"
+      },
+      "htmlPopupEnabled" : true,
+      "selectable" : true,
+      "featureCacheType" : "Session",
+      "displayFiltersType" : "ByScale",
+      "featureBlendingMode" : "Alpha",
+      "labelClasses" : [
+        {
+          "type" : "CIMLabelClass",
+          "expressionTitle" : "Custom",
+          "expression" : "$feature.name",
+          "expressionEngine" : "Arcade",
+          "featuresToLabel" : "AllVisibleFeatures",
+          "maplexLabelPlacementProperties" : {
+            "type" : "CIMMaplexLabelPlacementProperties",
+            "featureType" : "Point",
+            "avoidPolygonHoles" : true,
+            "canOverrunFeature" : true,
+            "canPlaceLabelOutsidePolygon" : true,
+            "canRemoveOverlappingLabel" : true,
+            "canStackLabel" : true,
+            "connectionType" : "Unambiguous",
+            "constrainOffset" : "NoConstraint",
+            "contourAlignmentType" : "Page",
+            "contourLadderType" : "Straight",
+            "contourMaximumAngle" : 90,
+            "enableConnection" : true,
+            "enablePointPlacementPriorities" : true,
+            "featureWeight" : 0,
+            "fontHeightReductionLimit" : 4,
+            "fontHeightReductionStep" : 0.5,
+            "fontWidthReductionLimit" : 90,
+            "fontWidthReductionStep" : 5,
+            "graticuleAlignmentType" : "Straight",
+            "keyNumberGroupName" : "Default",
+            "labelBuffer" : 15,
+            "labelLargestPolygon" : true,
+            "labelPriority" : -1,
+            "labelStackingProperties" : {
+              "type" : "CIMMaplexLabelStackingProperties",
+              "stackAlignment" : "ChooseBest",
+              "maximumNumberOfLines" : 3,
+              "minimumNumberOfCharsPerLine" : 3,
+              "maximumNumberOfCharsPerLine" : 24,
+              "separators" : [
+                {
+                  "type" : "CIMMaplexStackingSeparator",
+                  "separator" : " ",
+                  "splitAfter" : true
+                },
+                {
+                  "type" : "CIMMaplexStackingSeparator",
+                  "separator" : ",",
+                  "visible" : true,
+                  "splitAfter" : true
+                }
+              ]
+            },
+            "lineFeatureType" : "General",
+            "linePlacementMethod" : "OffsetCurvedFromLine",
+            "maximumLabelOverrun" : 36,
+            "maximumLabelOverrunUnit" : "Point",
+            "minimumFeatureSizeUnit" : "Map",
+            "multiPartOption" : "OneLabelPerPart",
+            "offsetAlongLineProperties" : {
+              "type" : "CIMMaplexOffsetAlongLineProperties",
+              "placementMethod" : "BestPositionAlongLine",
+              "labelAnchorPoint" : "CenterOfLabel",
+              "distanceUnit" : "Percentage",
+              "useLineDirection" : true
+            },
+            "pointExternalZonePriorities" : {
+              "type" : "CIMMaplexExternalZonePriorities",
+              "aboveLeft" : 4,
+              "aboveCenter" : 2,
+              "aboveRight" : 1,
+              "centerRight" : 3,
+              "belowRight" : 5,
+              "belowCenter" : 7,
+              "belowLeft" : 8,
+              "centerLeft" : 6
+            },
+            "pointPlacementMethod" : "AroundPoint",
+            "polygonAnchorPointType" : "GeometricCenter",
+            "polygonBoundaryWeight" : 0,
+            "polygonExternalZones" : {
+              "type" : "CIMMaplexExternalZonePriorities",
+              "aboveLeft" : 4,
+              "aboveCenter" : 2,
+              "aboveRight" : 1,
+              "centerRight" : 3,
+              "belowRight" : 5,
+              "belowCenter" : 7,
+              "belowLeft" : 8,
+              "centerLeft" : 6
+            },
+            "polygonFeatureType" : "General",
+            "polygonInternalZones" : {
+              "type" : "CIMMaplexInternalZonePriorities",
+              "center" : 1
+            },
+            "polygonPlacementMethod" : "CurvedInPolygon",
+            "primaryOffset" : 1,
+            "primaryOffsetUnit" : "Point",
+            "removeExtraWhiteSpace" : true,
+            "repetitionIntervalUnit" : "Point",
+            "rotationProperties" : {
+              "type" : "CIMMaplexRotationProperties",
+              "rotationType" : "Arithmetic",
+              "alignmentType" : "Straight"
+            },
+            "secondaryOffset" : 100,
+            "strategyPriorities" : {
+              "type" : "CIMMaplexStrategyPriorities",
+              "stacking" : 1,
+              "overrun" : 2,
+              "fontCompression" : 3,
+              "fontReduction" : 4,
+              "abbreviation" : 5
+            },
+            "thinningDistanceUnit" : "Point",
+            "truncationMarkerCharacter" : ".",
+            "truncationMinimumLength" : 1,
+            "truncationPreferredCharacters" : "aeiou",
+            "truncationExcludedCharacters" : "0123456789",
+            "polygonAnchorPointPerimeterInsetUnit" : "Point"
+          },
+          "name" : "Class 1",
+          "priority" : -1,
+          "standardLabelPlacementProperties" : {
+            "type" : "CIMStandardLabelPlacementProperties",
+            "featureType" : "Line",
+            "featureWeight" : "None",
+            "labelWeight" : "High",
+            "numLabelsOption" : "OneLabelPerName",
+            "lineLabelPosition" : {
+              "type" : "CIMStandardLineLabelPosition",
+              "above" : true,
+              "inLine" : true,
+              "parallel" : true
+            },
+            "lineLabelPriorities" : {
+              "type" : "CIMStandardLineLabelPriorities",
+              "aboveStart" : 3,
+              "aboveAlong" : 3,
+              "aboveEnd" : 3,
+              "centerStart" : 3,
+              "centerAlong" : 3,
+              "centerEnd" : 3,
+              "belowStart" : 3,
+              "belowAlong" : 3,
+              "belowEnd" : 3
+            },
+            "pointPlacementMethod" : "AroundPoint",
+            "pointPlacementPriorities" : {
+              "type" : "CIMStandardPointPlacementPriorities",
+              "aboveLeft" : 2,
+              "aboveCenter" : 2,
+              "aboveRight" : 1,
+              "centerLeft" : 3,
+              "centerRight" : 2,
+              "belowLeft" : 3,
+              "belowCenter" : 3,
+              "belowRight" : 2
+            },
+            "rotationType" : "Arithmetic",
+            "polygonPlacementMethod" : "AlwaysHorizontal"
+          },
+          "textSymbol" : {
+            "type" : "CIMSymbolReference",
+            "symbol" : {
+              "type" : "CIMTextSymbol",
+              "blockProgression" : "TTB",
+              "depth3D" : 1,
+              "extrapolateBaselines" : true,
+              "fontEffects" : "Normal",
+              "fontEncoding" : "Unicode",
+              "fontFamilyName" : "Tahoma",
+              "fontStyleName" : "Regular",
+              "fontType" : "Unspecified",
+              "haloSize" : 1,
+              "height" : 10,
+              "hinting" : "Default",
+              "horizontalAlignment" : "Left",
+              "kerning" : true,
+              "letterWidth" : 100,
+              "ligatures" : true,
+              "lineGapType" : "ExtraLeading",
+              "symbol" : {
+                "type" : "CIMPolygonSymbol",
+                "symbolLayers" : [
+                  {
+                    "type" : "CIMSolidFill",
+                    "enable" : true,
+                    "color" : {
+                      "type" : "CIMRGBColor",
+                      "values" : [
+                        0,
+                        0,
+                        0,
+                        100
+                      ]
+                    }
+                  }
+                ]
+              },
+              "textCase" : "Normal",
+              "textDirection" : "LTR",
+              "verticalAlignment" : "Bottom",
+              "verticalGlyphOrientation" : "Right",
+              "wordSpacing" : 100,
+              "billboardMode3D" : "FaceNearPlane"
+            }
+          },
+          "useCodedValue" : true,
+          "visibility" : true,
+          "iD" : -1
+        }
+      ],
+      "renderer" : {
+        "type" : "CIMHeatMapRenderer",
+        "colorScheme" : {
+          "type" : "CIMMultipartColorRamp",
+          "colorSpace" : {
+            "type" : "CIMICCColorSpace",
+            "url" : "Default RGB"
+          },
+          "colorRamps" : [
+            {
+              "type" : "CIMLinearContinuousColorRamp",
+              "colorSpace" : {
+                "type" : "CIMICCColorSpace",
+                "url" : "Default RGB"
+              },
+              "fromColor" : {
+                "type" : "CIMRGBColor",
+                "colorSpace" : {
+                  "type" : "CIMICCColorSpace",
+                  "url" : "Default RGB"
+                },
+                "values" : [
+                  133,
+                  193,
+                  200,
+                  0
+                ]
+              },
+              "toColor" : {
+                "type" : "CIMRGBColor",
+                "values" : [
+                  133,
+                  193,
+                  200,
+                  100
+                ]
+              }
+            },
+            {
+              "type" : "CIMLinearContinuousColorRamp",
+              "colorSpace" : {
+                "type" : "CIMICCColorSpace",
+                "url" : "Default RGB"
+              },
+              "fromColor" : {
+                "type" : "CIMRGBColor",
+                "values" : [
+                  133,
+                  193,
+                  200,
+                  100
+                ]
+              },
+              "toColor" : {
+                "type" : "CIMRGBColor",
+                "colorSpace" : {
+                  "type" : "CIMICCColorSpace",
+                  "url" : "Default RGB"
+                },
+                "values" : [
+                  144,
+                  161,
+                  190,
+                  100
+                ]
+              }
+            },
+            {
+              "type" : "CIMLinearContinuousColorRamp",
+              "colorSpace" : {
+                "type" : "CIMICCColorSpace",
+                "url" : "Default RGB"
+              },
+              "fromColor" : {
+                "type" : "CIMRGBColor",
+                "colorSpace" : {
+                  "type" : "CIMICCColorSpace",
+                  "url" : "Default RGB"
+                },
+                "values" : [
+                  144,
+                  161,
+                  190,
+                  100
+                ]
+              },
+              "toColor" : {
+                "type" : "CIMRGBColor",
+                "colorSpace" : {
+                  "type" : "CIMICCColorSpace",
+                  "url" : "Default RGB"
+                },
+                "values" : [
+                  156,
+                  129,
+                  132,
+                  100
+                ]
+              }
+            },
+            {
+              "type" : "CIMLinearContinuousColorRamp",
+              "colorSpace" : {
+                "type" : "CIMICCColorSpace",
+                "url" : "Default RGB"
+              },
+              "fromColor" : {
+                "type" : "CIMRGBColor",
+                "colorSpace" : {
+                  "type" : "CIMICCColorSpace",
+                  "url" : "Default RGB"
+                },
+                "values" : [
+                  156,
+                  129,
+                  132,
+                  100
+                ]
+              },
+              "toColor" : {
+                "type" : "CIMRGBColor",
+                "colorSpace" : {
+                  "type" : "CIMICCColorSpace",
+                  "url" : "Default RGB"
+                },
+                "values" : [
+                  167,
+                  97,
+                  170,
+                  100
+                ]
+              }
+            },
+            {
+              "type" : "CIMLinearContinuousColorRamp",
+              "colorSpace" : {
+                "type" : "CIMICCColorSpace",
+                "url" : "Default RGB"
+              },
+              "fromColor" : {
+                "type" : "CIMRGBColor",
+                "colorSpace" : {
+                  "type" : "CIMICCColorSpace",
+                  "url" : "Default RGB"
+                },
+                "values" : [
+                  167,
+                  97,
+                  170,
+                  100
+                ]
+              },
+              "toColor" : {
+                "type" : "CIMRGBColor",
+                "colorSpace" : {
+                  "type" : "CIMICCColorSpace",
+                  "url" : "Default RGB"
+                },
+                "values" : [
+                  175,
+                  73,
+                  128,
+                  100
+                ]
+              }
+            },
+            {
+              "type" : "CIMLinearContinuousColorRamp",
+              "colorSpace" : {
+                "type" : "CIMICCColorSpace",
+                "url" : "Default RGB"
+              },
+              "fromColor" : {
+                "type" : "CIMRGBColor",
+                "colorSpace" : {
+                  "type" : "CIMICCColorSpace",
+                  "url" : "Default RGB"
+                },
+                "values" : [
+                  175,
+                  73,
+                  128,
+                  100
+                ]
+              },
+              "toColor" : {
+                "type" : "CIMRGBColor",
+                "colorSpace" : {
+                  "type" : "CIMICCColorSpace",
+                  "url" : "Default RGB"
+                },
+                "values" : [
+                  184,
+                  48,
+                  85,
+                  100
+                ]
+              }
+            },
+            {
+              "type" : "CIMLinearContinuousColorRamp",
+              "colorSpace" : {
+                "type" : "CIMICCColorSpace",
+                "url" : "Default RGB"
+              },
+              "fromColor" : {
+                "type" : "CIMRGBColor",
+                "colorSpace" : {
+                  "type" : "CIMICCColorSpace",
+                  "url" : "Default RGB"
+                },
+                "values" : [
+                  184,
+                  48,
+                  85,
+                  100
+                ]
+              },
+              "toColor" : {
+                "type" : "CIMRGBColor",
+                "colorSpace" : {
+                  "type" : "CIMICCColorSpace",
+                  "url" : "Default RGB"
+                },
+                "values" : [
+                  192,
+                  24,
+                  42,
+                  100
+                ]
+              }
+            },
+            {
+              "type" : "CIMLinearContinuousColorRamp",
+              "colorSpace" : {
+                "type" : "CIMICCColorSpace",
+                "url" : "Default RGB"
+              },
+              "fromColor" : {
+                "type" : "CIMRGBColor",
+                "colorSpace" : {
+                  "type" : "CIMICCColorSpace",
+                  "url" : "Default RGB"
+                },
+                "values" : [
+                  192,
+                  24,
+                  42,
+                  100
+                ]
+              },
+              "toColor" : {
+                "type" : "CIMRGBColor",
+                "colorSpace" : {
+                  "type" : "CIMICCColorSpace",
+                  "url" : "Default RGB"
+                },
+                "values" : [
+                  200,
+                  0,
+                  0,
+                  100
+                ]
+              }
+            },
+            {
+              "type" : "CIMLinearContinuousColorRamp",
+              "colorSpace" : {
+                "type" : "CIMICCColorSpace",
+                "url" : "Default RGB"
+              },
+              "fromColor" : {
+                "type" : "CIMRGBColor",
+                "colorSpace" : {
+                  "type" : "CIMICCColorSpace",
+                  "url" : "Default RGB"
+                },
+                "values" : [
+                  200,
+                  0,
+                  0,
+                  100
+                ]
+              },
+              "toColor" : {
+                "type" : "CIMRGBColor",
+                "colorSpace" : {
+                  "type" : "CIMICCColorSpace",
+                  "url" : "Default RGB"
+                },
+                "values" : [
+                  211,
+                  51,
+                  0,
+                  100
+                ]
+              }
+            },
+            {
+              "type" : "CIMLinearContinuousColorRamp",
+              "colorSpace" : {
+                "type" : "CIMICCColorSpace",
+                "url" : "Default RGB"
+              },
+              "fromColor" : {
+                "type" : "CIMRGBColor",
+                "colorSpace" : {
+                  "type" : "CIMICCColorSpace",
+                  "url" : "Default RGB"
+                },
+                "values" : [
+                  211,
+                  51,
+                  0,
+                  100
+                ]
+              },
+              "toColor" : {
+                "type" : "CIMRGBColor",
+                "colorSpace" : {
+                  "type" : "CIMICCColorSpace",
+                  "url" : "Default RGB"
+                },
+                "values" : [
+                  222,
+                  102,
+                  0,
+                  100
+                ]
+              }
+            },
+            {
+              "type" : "CIMLinearContinuousColorRamp",
+              "colorSpace" : {
+                "type" : "CIMICCColorSpace",
+                "url" : "Default RGB"
+              },
+              "fromColor" : {
+                "type" : "CIMRGBColor",
+                "colorSpace" : {
+                  "type" : "CIMICCColorSpace",
+                  "url" : "Default RGB"
+                },
+                "values" : [
+                  222,
+                  102,
+                  0,
+                  100
+                ]
+              },
+              "toColor" : {
+                "type" : "CIMRGBColor",
+                "colorSpace" : {
+                  "type" : "CIMICCColorSpace",
+                  "url" : "Default RGB"
+                },
+                "values" : [
+                  233,
+                  153,
+                  0,
+                  100
+                ]
+              }
+            },
+            {
+              "type" : "CIMLinearContinuousColorRamp",
+              "colorSpace" : {
+                "type" : "CIMICCColorSpace",
+                "url" : "Default RGB"
+              },
+              "fromColor" : {
+                "type" : "CIMRGBColor",
+                "colorSpace" : {
+                  "type" : "CIMICCColorSpace",
+                  "url" : "Default RGB"
+                },
+                "values" : [
+                  233,
+                  153,
+                  0,
+                  100
+                ]
+              },
+              "toColor" : {
+                "type" : "CIMRGBColor",
+                "colorSpace" : {
+                  "type" : "CIMICCColorSpace",
+                  "url" : "Default RGB"
+                },
+                "values" : [
+                  244,
+                  204,
+                  0,
+                  100
+                ]
+              }
+            },
+            {
+              "type" : "CIMLinearContinuousColorRamp",
+              "colorSpace" : {
+                "type" : "CIMICCColorSpace",
+                "url" : "Default RGB"
+              },
+              "fromColor" : {
+                "type" : "CIMRGBColor",
+                "colorSpace" : {
+                  "type" : "CIMICCColorSpace",
+                  "url" : "Default RGB"
+                },
+                "values" : [
+                  244,
+                  204,
+                  0,
+                  100
+                ]
+              },
+              "toColor" : {
+                "type" : "CIMRGBColor",
+                "colorSpace" : {
+                  "type" : "CIMICCColorSpace",
+                  "url" : "Default RGB"
+                },
+                "values" : [
+                  255,
+                  255,
+                  0,
+                  100
+                ]
+              }
+            }
+          ],
+          "weights" : [
+            0.076923076923076927,
+            0.076923076923076927,
+            0.076923076923076927,
+            0.076923076923076927,
+            0.076923076923076927,
+            0.076923076923076927,
+            0.076923076923076927,
+            0.076923076923076927,
+            0.076923076923076927,
+            0.076923076923076927,
+            0.076923076923076927,
+            0.076923076923076927,
+            0.076923076923076927
+          ]
+        },
+        "radius" : 30,
+        "rendererQuality" : 5,
+        "minLabel" : "Sparse",
+        "maxLabel" : "Dense",
+        "maxPixelIntensity" : 1.451244015104933e-08,
+        "pixelIntensityStops" : [
+          0,
+          1
+        ],
+        "autoAdjustPixelIntensity" : false,
+        "maxPixelIntensityReferenceScale" : 54465762.648160771
+      },
+      "scaleSymbols" : true,
+      "snappable" : true,
+      "symbolLayerDrawing" : {
+        "type" : "CIMSymbolLayerDrawing"
+      }
+    },
+    {
+      "type" : "CIMFeatureLayer",
       "name" : "18 Hours - Estimated Impacted Buildings - HUC10 Hotspots",
       "uRI" : "CIMPATH=nwm_short_range_max_fim_analysis/8_hour_max_estimated_impacted_buildings___huc10_hotspots2.xml",
       "sourceModifiedTime" : {
         "type" : "TimeInstant",
         "start" : 978307200000
       },
-      "metadataURI" : "CIMPATH=Metadata/e568d03a5c87608c77eb5a6a017a8692.xml",
+      "metadataURI" : "CIMPATH=Metadata/8783ad058ec3113f5c40ce369fff0ddf.xml",
       "useSourceMetadata" : true,
       "description" : "vizprocessing.dev.srf_18hr_max_inundation_hucs",
       "layerElevation" : {
@@ -2933,8 +3858,8 @@
           "extent" : {
             "xmin" : -13702752.5208,
             "ymin" : 2900684.3673,
-            "xmax" : -7456492.422700001,
-            "ymax" : 6265558.830300003,
+            "xmax" : -7456492.42270000093,
+            "ymax" : 6265558.83030000329,
             "spatialReference" : {
               "wkid" : 102100,
               "latestWkid" : 3857
@@ -3302,7 +4227,7 @@
                     "joinStyle" : "Round",
                     "lineStyle3D" : "Strip",
                     "miterLimit" : 10,
-                    "width" : 0.7,
+                    "width" : 0.69999999999999996,
                     "color" : {
                       "type" : "CIMRGBColor",
                       "values" : [
@@ -3347,7 +4272,7 @@
                     "joinStyle" : "Round",
                     "lineStyle3D" : "Strip",
                     "miterLimit" : 10,
-                    "width" : 0.7,
+                    "width" : 0.69999999999999996,
                     "color" : {
                       "type" : "CIMRGBColor",
                       "values" : [
@@ -3392,7 +4317,7 @@
                     "joinStyle" : "Round",
                     "lineStyle3D" : "Strip",
                     "miterLimit" : 10,
-                    "width" : 0.7,
+                    "width" : 0.69999999999999996,
                     "color" : {
                       "type" : "CIMRGBColor",
                       "values" : [
@@ -3437,7 +4362,7 @@
                     "joinStyle" : "Round",
                     "lineStyle3D" : "Strip",
                     "miterLimit" : 10,
-                    "width" : 0.7,
+                    "width" : 0.69999999999999996,
                     "color" : {
                       "type" : "CIMRGBColor",
                       "values" : [
@@ -3482,7 +4407,7 @@
                     "joinStyle" : "Round",
                     "lineStyle3D" : "Strip",
                     "miterLimit" : 10,
-                    "width" : 0.7,
+                    "width" : 0.69999999999999996,
                     "color" : {
                       "type" : "CIMRGBColor",
                       "values" : [
@@ -3603,7 +4528,7 @@
                 "joinStyle" : "Round",
                 "lineStyle3D" : "Strip",
                 "miterLimit" : 10,
-                "width" : 0.7,
+                "width" : 0.69999999999999996,
                 "color" : {
                   "type" : "CIMRGBColor",
                   "values" : [
@@ -3646,7 +4571,7 @@
                 "joinStyle" : "Round",
                 "lineStyle3D" : "Strip",
                 "miterLimit" : 10,
-                "width" : 0.7,
+                "width" : 0.69999999999999996,
                 "color" : {
                   "type" : "CIMRGBColor",
                   "values" : [
@@ -3690,7 +4615,7 @@
         "type" : "TimeInstant",
         "start" : 978307200000
       },
-      "metadataURI" : "CIMPATH=Metadata/665aec1a0ec457eb33cb24c21ca116eb.xml",
+      "metadataURI" : "CIMPATH=Metadata/891e62fcb6684cc68d9675b11d0f653b.xml",
       "useSourceMetadata" : true,
       "description" : "vizprocessing.dev.srf_18hr_max_inundation_counties",
       "layerElevation" : {
@@ -4006,10 +4931,10 @@
           "oIDFields" : "oid",
           "geometryType" : "esriGeometryPolygon",
           "extent" : {
-            "xmin" : -13714908.124699999,
-            "ymin" : 2892633.5918999985,
-            "xmax" : -7445653.492900001,
-            "ymax" : 6274987.502999999,
+            "xmin" : -13714908.1246999986,
+            "ymin" : 2892633.59189999849,
+            "xmax" : -7445653.49290000089,
+            "ymax" : 6274987.50299999863,
             "spatialReference" : {
               "wkid" : 102100,
               "latestWkid" : 3857
@@ -4384,7 +5309,7 @@
                     "joinStyle" : "Round",
                     "lineStyle3D" : "Strip",
                     "miterLimit" : 10,
-                    "width" : 0.7,
+                    "width" : 0.69999999999999996,
                     "color" : {
                       "type" : "CIMRGBColor",
                       "values" : [
@@ -4429,7 +5354,7 @@
                     "joinStyle" : "Round",
                     "lineStyle3D" : "Strip",
                     "miterLimit" : 10,
-                    "width" : 0.7,
+                    "width" : 0.69999999999999996,
                     "color" : {
                       "type" : "CIMRGBColor",
                       "values" : [
@@ -4474,7 +5399,7 @@
                     "joinStyle" : "Round",
                     "lineStyle3D" : "Strip",
                     "miterLimit" : 10,
-                    "width" : 0.7,
+                    "width" : 0.69999999999999996,
                     "color" : {
                       "type" : "CIMRGBColor",
                       "values" : [
@@ -4519,7 +5444,7 @@
                     "joinStyle" : "Round",
                     "lineStyle3D" : "Strip",
                     "miterLimit" : 10,
-                    "width" : 0.7,
+                    "width" : 0.69999999999999996,
                     "color" : {
                       "type" : "CIMRGBColor",
                       "values" : [
@@ -4564,7 +5489,7 @@
                     "joinStyle" : "Round",
                     "lineStyle3D" : "Strip",
                     "miterLimit" : 10,
-                    "width" : 0.7,
+                    "width" : 0.69999999999999996,
                     "color" : {
                       "type" : "CIMRGBColor",
                       "values" : [
@@ -4685,7 +5610,7 @@
                 "joinStyle" : "Round",
                 "lineStyle3D" : "Strip",
                 "miterLimit" : 10,
-                "width" : 0.7,
+                "width" : 0.69999999999999996,
                 "color" : {
                   "type" : "CIMRGBColor",
                   "values" : [
@@ -4728,7 +5653,7 @@
                 "joinStyle" : "Round",
                 "lineStyle3D" : "Strip",
                 "miterLimit" : 10,
-                "width" : 0.7,
+                "width" : 0.69999999999999996,
                 "color" : {
                   "type" : "CIMRGBColor",
                   "values" : [
@@ -4772,7 +5697,7 @@
         "type" : "TimeInstant",
         "start" : 978307200000
       },
-      "metadataURI" : "CIMPATH=Metadata/14c3b2188dff36dfaa5e73f05e9a7b00.xml",
+      "metadataURI" : "CIMPATH=Metadata/e94cdf7e58446d9fa2399495a1968fc0.xml",
       "useSourceMetadata" : true,
       "description" : "vizprocessing.publish.srf_18hr_max_inundation_building_footprints",
       "layerElevation" : {
@@ -4967,9 +5892,9 @@
           "geometryType" : "esriGeometryPolygon",
           "extent" : {
             "xmin" : -13578523.488499999,
-            "ymin" : 3096599.3299000002,
-            "xmax" : -7616764.763599999,
-            "ymax" : 6208676.231600001,
+            "ymin" : 3096599.32990000024,
+            "xmax" : -7616764.76359999925,
+            "ymax" : 6208676.23160000145,
             "spatialReference" : {
               "wkid" : 102100,
               "latestWkid" : 3857
@@ -5328,7 +6253,7 @@
                 "joinStyle" : "Round",
                 "lineStyle3D" : "Strip",
                 "miterLimit" : 10,
-                "width" : 0.7,
+                "width" : 0.69999999999999996,
                 "color" : {
                   "type" : "CIMRGBColor",
                   "values" : [
@@ -5379,7 +6304,7 @@
                         "joinStyle" : "Round",
                         "lineStyle3D" : "Strip",
                         "miterLimit" : 10,
-                        "width" : 0.7,
+                        "width" : 0.69999999999999996,
                         "color" : {
                           "type" : "CIMRGBColor",
                           "values" : [
@@ -5432,7 +6357,7 @@
                         "joinStyle" : "Round",
                         "lineStyle3D" : "Strip",
                         "miterLimit" : 10,
-                        "width" : 0.7,
+                        "width" : 0.69999999999999996,
                         "color" : {
                           "type" : "CIMRGBColor",
                           "values" : [
@@ -5485,7 +6410,7 @@
                         "joinStyle" : "Round",
                         "lineStyle3D" : "Strip",
                         "miterLimit" : 10,
-                        "width" : 0.7,
+                        "width" : 0.69999999999999996,
                         "color" : {
                           "type" : "CIMRGBColor",
                           "values" : [
@@ -5538,7 +6463,7 @@
                         "joinStyle" : "Round",
                         "lineStyle3D" : "Strip",
                         "miterLimit" : 10,
-                        "width" : 0.7,
+                        "width" : 0.69999999999999996,
                         "color" : {
                           "type" : "CIMRGBColor",
                           "values" : [
@@ -5591,7 +6516,7 @@
                         "joinStyle" : "Round",
                         "lineStyle3D" : "Strip",
                         "miterLimit" : 10,
-                        "width" : 0.7,
+                        "width" : 0.69999999999999996,
                         "color" : {
                           "type" : "CIMRGBColor",
                           "values" : [
@@ -5644,7 +6569,7 @@
                         "joinStyle" : "Round",
                         "lineStyle3D" : "Strip",
                         "miterLimit" : 10,
-                        "width" : 0.7,
+                        "width" : 0.69999999999999996,
                         "color" : {
                           "type" : "CIMRGBColor",
                           "values" : [
@@ -5697,7 +6622,7 @@
                         "joinStyle" : "Round",
                         "lineStyle3D" : "Strip",
                         "miterLimit" : 10,
-                        "width" : 0.7,
+                        "width" : 0.69999999999999996,
                         "color" : {
                           "type" : "CIMRGBColor",
                           "values" : [
@@ -5750,7 +6675,7 @@
                         "joinStyle" : "Round",
                         "lineStyle3D" : "Strip",
                         "miterLimit" : 10,
-                        "width" : 0.7,
+                        "width" : 0.69999999999999996,
                         "color" : {
                           "type" : "CIMRGBColor",
                           "values" : [
@@ -5827,6 +6752,7 @@
       "blendingMode" : "Alpha",
       "layers" : [
         "CIMPATH=nwm_short_range_max_fim_analysis/18_hour_max_estimated_impacted_buildings___heatmap.xml",
+        "CIMPATH=nwm_short_range_max_fim_extent_forecast/s___estimated_impacted_critical_infrastructure___heatmap.xml",
         "CIMPATH=nwm_short_range_max_fim_analysis/8_hour_max_estimated_impacted_buildings___huc10_hotspots2.xml",
         "CIMPATH=nwm_short_range_max_fim_analysis/vizprocessing_dev_srf_18hr_max_inundation_counties.xml",
         "CIMPATH=nwm_short_range_max_fim_analysis/r_max_estimated_impacted_buildings__fema_usa_structures_.xml"
@@ -6460,7 +7386,7 @@
                 "joinStyle" : "Round",
                 "lineStyle3D" : "Strip",
                 "miterLimit" : 10,
-                "width" : 0.7,
+                "width" : 0.69999999999999996,
                 "color" : {
                   "type" : "CIMRGBColor",
                   "values" : [
@@ -6505,23 +7431,23 @@
     },
     {
       "type" : "CIMBinaryReference",
-      "uRI" : "CIMPATH=Metadata/14c3b2188dff36dfaa5e73f05e9a7b00.xml",
-      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230106</CreaDate><CreaTime>16411800</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>18 Hours - Estimated Impacted Buildings (FEMA USA Structures)</resTitle></idCitation><idAbs>vizprocessing.publish.srf_18hr_max_inundation_building_footprints</idAbs><idCredit></idCredit><idPurp></idPurp><resConst><Consts><useLimit></useLimit></Consts></resConst></dataIdInfo></metadata>\r\n"
-    },
-    {
-      "type" : "CIMBinaryReference",
       "uRI" : "CIMPATH=Metadata/14fe75088d76b1922ea8443fd1723cc8.xml",
       "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20220127</CreaDate><CreaTime>19155000</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>Map</resTitle></idCitation></dataIdInfo><Binary><Thumbnail><Data EsriPropertyType=\"PictureX\">/9j/4AAQSkZJRgABAQEAAAAAAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0a\r\nHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIy\r\nMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCADIASwDAREA\r\nAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQA\r\nAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3\r\nODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWm\r\np6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEA\r\nAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSEx\r\nBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElK\r\nU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3\r\nuLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3+gAo\r\nAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAjliSaIxuuVbq\r\nKAWhjNqg0y8+y3BJjY/uix5I9vWo95X00NlCM0rPU1oLmK5XdE4b1HcVSaexnKLi7MnpkhQAUAFA\r\nBQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAc\r\n14n0m1vfImliHmqSFl7qe1Cr1KS916PfzNaNGFSVpb9DmtK12Sy1+LSb+TNxnesiDAZPQj14963l\r\nhOaj9bpK0dmv66A6/wC8eFq6y3TPRopUmjEkbblboawTuZtNOzJKBBQAUAFABQAUAFABQAUAFABQ\r\nAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQA10V1KuoZT2IzQBw3i3Q\r\nIbpXIRUfG6BwMFG9qvD4qWGqqX2XuujNpUI4mk4v4lsy94F1aTU9JlE4C3FvKYpFznLDqR9a1xeH\r\njQqWg/daTXozmp15Vo3ktVo/VHW1zlhQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAU\r\nAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAU76xjv7cxOSD1VgeVPrRZdUVGTjszzv7NqvhO+ln\r\n0+3N3JMSJlLdW6g49O35V3QrUsTaFeXJy7adO36/eZzozpR56Uebm39f60+429G+Iem3872t8DY3\r\nCDJEnQ9ePyFa1crrQgpw95PscsMZTc3CWj8zsIZo7iJZYnV42GVZTkEV5rTTszrTT1RLSGFABQAU\r\nAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFAEcsgiiaQ9F\r\nGaGNK7sR2lyl3brKnQ9vSkndXHKLi7MsUySpdWEV2dzZVwMbhUygpbmlOrKGxx2t+AI9Wu5pomEM\r\ngUCORuQT7iu7BY2phvc3h2OfFUYV1z/aNDwjpmqaNbLY3EyzW6FskjBVvb1FLGYmniJuajb9SaNB\r\n0YJc1zrK5DYKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKA\r\nCgAoAKAMvWL1bW0dMZd179APU1E5W0NaVNyd+iOb8ETNNcXpMu5RKxGGypHtXTXiouKWmiM0+ZSf\r\nmzuKxEFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUA\r\nFABQAUAFABQBxXjyeCG0jWWQxrJhZWHUKT2H51thoylWXIrtajnJRpPndkzS8PxWthp5n+SKNgAn\r\nGOB7Vz80m3Kb1NqqWkILRGld6vbWlukzF5A/QRrk/X2FUrPqZKEm7WJ7G8S/tVnjVgjdN3ej1FJW\r\nZaoEFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFA\r\nBQAUAcR41sI9Rjmjl/gUMjE4CnFXh8ROhXUoGssPCth2pGJ9unktre1huArsuNykHb64FLljzSnN\r\naLoacz5Yxg9X1IbjR9ULoYNQd5OQNx+Uj3reljMP8M6en4/IyqYWt8UKmv4fM9L0uHyNLtYu6RKD\r\n7nHWueUuZuXcz5eXQu0gCgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKA\r\nCgAoAKACgAoAKACgAoAKAKdxp1tduWlTcSMH0NLlV7lqpJLlWxhHwmkd150IjBPBI4wKUudx5b6G\r\nsasE+bl1OghsoIUiUICYxhWI5p2MOZlmmIKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoA\r\nKACgAoAKACgAoAKAMrVdTWyTYjYkPU4+6KicraLc2o0uZ3exFpWr/a5fKZg+RkMKUJNu0iq1KMVz\r\nRehtVoc4UAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAhIAyTgCgBiyx\r\nspZWUqOpBoCwkU0U67onDDpxSTT2G01oyWmIKACgAoAKACgCKaUQwvIQSEUsQPagaV3YwU18XN9C\r\nqIybH2OpPBzj/wDXWbnqvM6FRtGV90UPFk0aGbc2CAoGPpQouVVJFQko0W2T+FzGuwNjeU4PqamD\r\nXOx10/ZrsdXWxxhQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFAFTUP8A\r\nkHz8E4QnApS2KhpJHIWMss93OkDP5ICrtHIPHt9awtJRSXU724OTb6HY2dqlrAEXOTyxPc1tGKir\r\nI4Zzc3dlmqICgAoAKACgAoAq3zMtlKyMFIXqRnilLYqFuZXOHXNvq8sWGTciyZJ59M8/QVjJP2cZ\r\nP+up3RcXOUV2L+v3dnLa+bEreYVwSeMtjpj1qklOSsZRUoRfNsW/DejT2tnbSTMVI+faxyef5VpN\r\nc1RzMva2p+zR1FMxCgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgDPv8AU47E\r\nbQu+TGducYFRKaia06TnsQaZrSagxRk2tkgbeQcdaFO7sxzpOKutjVIDKQeh4NWYle0sLaxVlt4w\r\ngY5PvSSsNyb3LVMQUAFABQAUAFABQAhAIwRkUAcFqgPnyTS/M8ZYN83JPTArnu3LlueilFQUkg0l\r\nJDcLPMnnbPmEJGQp9frVxlytqKM6keZJzdjtrWc3EO9o2jOcYNaJ3RySjyu1yxTJCgAoAKACgAoA\r\nKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgDh9dnEzu6th2faAD26Vz7zPQiuWkkavh6zj2i\r\ndVVdgKgKe/rV01d8zMcRNWUEjo61OUKACgAoAKACgAoAKACgCvdz/ZrWSXG4qOB6ntSbsrlRi5NJ\r\nHA3EjXFwqEAEN5khPY81gtIuT6ne91BdDsdFtBBaeYUAeQ5P0rSnGyOSvPmloataGIUAFABQAUAF\r\nABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFAHMa7plusgm4RZMhvrWNRW95HZh5c3uyK/\r\nhmdvtAjLgIm5Tz94DoapK0xVXemjrQQwBByD3rQ5B1ABQAUAFABQAUAFABQBR1ZC+mTheoAb8AQf\r\n6VM/hZpSdpo4eNY1vZWLdVBOehIz/jWLu6aO9JKbO0tdTtWjjjL7HwAA1axnFnDOjOL1RoggjIqz\r\nIWgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAhuIVnhaNlDZHH1pNXQ4tx\r\nd0eeTO+j6sUu1K27MF8wkEKx9eeOo5pxoOtC0H7y6d15HV7ZQleXwvr5+Z22j3IuLPaE2+X8v1Hr\r\n/Oog7oxrQcZepp1ZkFABQAUAFABQAUAFADHRZEZGGVYYI9qAON1HTbm3kXasv7sH5gu4EVgk43TV\r\n0eh7SMkmnZmaVvF2ygl0UYYMMEe4oXJLRqxXvrVao39F1lQhRiWgB4Y9U9qak4PlkY1KSmueB0ys\r\nGUMpBBGQRWxxjqACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgAoAKACgDN1HR7TVI2\r\nW4TO9drEdx6UotxkpR0aKUvdcXszlrvw5qGkGP8AsbULpYFZXEJJbhSMgnrgiulYqLk5Thdu/l87\r\nbGSotx5VO1reZ1GlG9KN9pyU/hL/AHq5Y36nRVUE/dNOqMgoAKACgAoAKACgAoAKAKN9YR3aZAAl\r\nH3W/xqZxUkaUqjg79DjLsNZ3kkjKflP7yPOB/wDrrJK65JHbzL+JHYup4laztQrOqLnIP3sD0qqa\r\nnL3Y7mVWNPm5paI0tC18amIw3KyA7G4zx6/lWklKE3TlujGUIygqkNjoqZiFABQAUAFABQAUAFAB\r\nQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFAGRqmlyXkgkhKAl\r\ncNuHWs5wu7o3pVuRNM53T/Cym4yVkJzgu/OzHpmqdWpP3dkXalBcy1Z1VjpNnp0YW2hVcEnOOcnq\r\nf1NW227s5r6WL9IQUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFA\r\nBQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAF\r\nABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUA\r\nFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAU\r\nAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQA\r\nUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQ\r\nAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFAB\r\nQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFA\r\nBQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQAUAFABQB//9k=</Data></Thumbnail></Binary></metadata>\r\n"
     },
     {
       "type" : "CIMBinaryReference",
-      "uRI" : "CIMPATH=Metadata/665aec1a0ec457eb33cb24c21ca116eb.xml",
-      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230106</CreaDate><CreaTime>16411800</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>18 Hours - Estimated Impacted Buildings - County Hotspots</resTitle></idCitation><idAbs>vizprocessing.dev.srf_18hr_max_inundation_counties</idAbs><idCredit></idCredit><idPurp></idPurp><resConst><Consts><useLimit></useLimit></Consts></resConst></dataIdInfo></metadata>\r\n"
+      "uRI" : "CIMPATH=Metadata/85116301fe25154234c93a77620dcd4e.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230106</CreaDate><CreaTime>16411800</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>18 Hours - Max Estimated Impacted Buildings - Heatmap</resTitle></idCitation><idAbs>hydrovis.hydrovis.fimpact_centroids</idAbs><idCredit></idCredit><idPurp></idPurp><resConst><Consts><useLimit></useLimit></Consts></resConst></dataIdInfo></metadata>\r\n"
     },
     {
       "type" : "CIMBinaryReference",
-      "uRI" : "CIMPATH=Metadata/85116301fe25154234c93a77620dcd4e.xml",
-      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230106</CreaDate><CreaTime>16411800</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>18 Hours - Max Estimated Impacted Buildings - Heatmap</resTitle></idCitation><idAbs>hydrovis.hydrovis.fimpact_centroids</idAbs><idCredit></idCredit><idPurp></idPurp><resConst><Consts><useLimit></useLimit></Consts></resConst></dataIdInfo></metadata>\r\n"
+      "uRI" : "CIMPATH=Metadata/8783ad058ec3113f5c40ce369fff0ddf.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230106</CreaDate><CreaTime>16411800</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>18 Hours - Estimated Impacted Buildings - HUC10 Hotspots</resTitle></idCitation><idAbs>vizprocessing.dev.srf_18hr_max_inundation_hucs</idAbs><idCredit></idCredit><idPurp></idPurp><resConst><Consts><useLimit></useLimit></Consts></resConst></dataIdInfo></metadata>\r\n"
+    },
+    {
+      "type" : "CIMBinaryReference",
+      "uRI" : "CIMPATH=Metadata/891e62fcb6684cc68d9675b11d0f653b.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230106</CreaDate><CreaTime>16411800</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>18 Hours - Estimated Impacted Buildings - County Hotspots</resTitle></idCitation><idAbs>vizprocessing.dev.srf_18hr_max_inundation_counties</idAbs><idCredit></idCredit><idPurp></idPurp><resConst><Consts><useLimit></useLimit></Consts></resConst></dataIdInfo></metadata>\r\n"
     },
     {
       "type" : "CIMBinaryReference",
@@ -6535,8 +7461,8 @@
     },
     {
       "type" : "CIMBinaryReference",
-      "uRI" : "CIMPATH=Metadata/e568d03a5c87608c77eb5a6a017a8692.xml",
-      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230106</CreaDate><CreaTime>16411800</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>18 Hours - Estimated Impacted Buildings - HUC10 Hotspots</resTitle></idCitation><idAbs>vizprocessing.dev.srf_18hr_max_inundation_hucs</idAbs><idCredit></idCredit><idPurp></idPurp><resConst><Consts><useLimit></useLimit></Consts></resConst></dataIdInfo></metadata>\r\n"
+      "uRI" : "CIMPATH=Metadata/e94cdf7e58446d9fa2399495a1968fc0.xml",
+      "data" : "<?xml version=\"1.0\"?>\r\n<metadata xml:lang=\"en\"><Esri><CreaDate>20230106</CreaDate><CreaTime>16411800</CreaTime><ArcGISFormat>1.0</ArcGISFormat><SyncOnce>TRUE</SyncOnce></Esri><dataIdInfo><idCitation><resTitle>18 Hours - Estimated Impacted Buildings (FEMA USA Structures)</resTitle></idCitation><idAbs>vizprocessing.publish.srf_18hr_max_inundation_building_footprints</idAbs><idCredit></idCredit><idPurp></idPurp><resConst><Consts><useLimit></useLimit></Consts></resConst></dataIdInfo></metadata>\r\n"
     }
   ]
 }

--- a/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range/srf_18hr_max_inundation_extent_noaa.yml
+++ b/Core/LAMBDA/viz_functions/viz_publish_service/services/short_range/srf_18hr_max_inundation_extent_noaa.yml
@@ -14,9 +14,13 @@ description: "Depicts the inundation extent of the peak National Water Model (NW
   (as of August, 2022). Occupancy type data is only available for AL, CA, FL, GA,
   LA, MS, NC, SC, TX, and VA at this time. Also shown are a relative density heatmap
   of potentially impacted buildings (based on extent), county, and HUC level summary
-  layers.\n\nUpdated hourly.\n\nThis service is for internal use only for NOAA employees
-  and requires access to view.  Please do not share externally without prior approval
-  from OWP as this service is experimental and undergoing regular developmental changes.
+  layers. \n\nEstimated Impacted Critical Infrastructure: Depicts colleges, 
+  fire stations, hospitals, nursing homes, police stations, and schools
+  that intersect inundation extents. The critical infrastructure data is derived
+  from the static FEMA Infrastructure dataset.\n\nUpdated hourly.
+  \n\nThis service is for internal use only for NOAA employees and requires access to view.  
+  Please do not share externally without prior approval from OWP as this 
+  service is experimental and undergoing regular developmental changes.
   \n\nFor feedback or questions please reach out to GID directly via slack at national-water-center-gid
   or national-water-center-fim pages or reach out directly to derek.giardino@noaa.gov"
 tags: national water model, nwm, srf, short, range, conus, fim, inundation, extent


### PR DESCRIPTION
This is the first of what will be a series of FIMPact to Critical Infrastructure Points services. This service intersects critical infrastructure locations as points, derived from FEMA Infrastructure datasets found [here](https://noaa.maps.arcgis.com/home/item.html?id=6f93038c830c4fa9b3d183011ace5c4a) with the SRF 18 Max Inundation Extent geometry. 

## Additions
18 Hours - Estimated Impacted Critical Infrastructure sublayer added to the[ srf_18hr_max_inundation_extent](https://maps.water.noaa.gov/server/rest/services/nwm/srf_18hr_max_inundation_extent_noaa/MapServer) service. 


## Removals

-

## Changes
The SRF 18hr building_footprints_fimpact.sql file is updated to include a section on creating the FIMPact to Critical Infrastructure table in the publish schema of the viz db by performing an intersection of critical infrastructure points and the srf 18hr fim geometry. The srf_18hr_max_inundation_extent_noaa.mapx and yml files are updated with the symbolized FIMPact heatmap and a brief description of the new service.

Due to slow spatial querying, a spatial index was added to the srf 18 hr max inundation geometry table.

## Testing
Data was tested on copies of srf 18 hr max inundation tables in the dev schema of the viz db.

1.

## Screenshots
![image](https://github.com/user-attachments/assets/bbb69323-dbe0-4ca2-8caa-a4c21f1a25a8)


## Notes
Versions of this service will be created for MRF NBM, MRF GFS, RFC, and ANA FIMs. The source of the critical infrastructure data should be reviewed for updating. 

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [x] Windows
- [ ] Linux
- [x] Browser

### Accessibility

- [x] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
