### PR TITLE
Viz_classes code cleanup

### DIFF
--- a/Core/LAMBDA/layers/viz_lambda_shared_funcs/python/viz_classes.py
+++ b/Core/LAMBDA/layers/viz_lambda_shared_funcs/python/viz_classes.py
@@ -4,6 +4,7 @@ import json
 import re
 import urllib.parse
 import inspect
+import pathlib
 try:
     import fsspec
 except:
@@ -98,7 +99,7 @@ class database: #TODO: Should we be creating a connection/engine upon initializa
     ###################################
     def execute_sql(self, sql):
         if sql.endswith('.sql') and os.path.exists(sql):
-            sql = open(sql, 'r').read()
+            sql = pathlib.Path(sql).read_text()
         with self.connection:
             try:
                 with self.connection.cursor() as cur:
@@ -111,7 +112,7 @@ class database: #TODO: Should we be creating a connection/engine upon initializa
     ###################################                
     def sql_to_dataframe(self, sql, return_geodataframe=False):
         if sql.endswith(".sql"):
-            sql = open(sql, 'r').read()
+            sql = pathlib.Path(sql).read_text()
             
         db_engine = self.engine
         if not return_geodataframe:
@@ -223,7 +224,7 @@ class database: #TODO: Should we be creating a connection/engine upon initializa
         issues_encountered = []
         # Determine if arg is file or raw SQL string
         if os.path.exists(sql_path_or_str):
-            sql = open(sql_path_or_str, 'r').read()
+            sql = pathlib.Path(sql_path_or_str).read_text()
         else:
             sql = sql_path_or_str
         

--- a/Core/LAMBDA/layers/viz_lambda_shared_funcs/python/viz_classes.py
+++ b/Core/LAMBDA/layers/viz_lambda_shared_funcs/python/viz_classes.py
@@ -232,7 +232,7 @@ class database: #TODO: Should we be creating a connection/engine upon initializa
         
         output_tables = set(re.findall(r'(?<=INTO\s)\w+\.\w+', sql, flags=re.IGNORECASE)) 
         input_tables = set(re.findall(r'(?<=FROM\s|JOIN\s)\w+\.\w+', sql, flags=re.IGNORECASE))
-        check_tables = [t for t in input_tables if t not in output_tables]
+        check_tables = input_tables - output_tables
 
         if not check_tables:
             return True

--- a/Core/LAMBDA/layers/viz_lambda_shared_funcs/python/viz_classes.py
+++ b/Core/LAMBDA/layers/viz_lambda_shared_funcs/python/viz_classes.py
@@ -230,8 +230,8 @@ class database: #TODO: Should we be creating a connection/engine upon initializa
         for word, replacement in sql_replace.items():
             sql = re.sub(word, replacement, sql, flags=re.IGNORECASE).replace('utc', 'UTC')
         
-        output_tables = set(re.findall('(?<=INTO )\w+\.\w+', sql, flags=re.IGNORECASE)) 
-        input_tables = set(re.findall('(?<=FROM |JOIN )\w+\.\w+', sql, flags=re.IGNORECASE))
+        output_tables = set(re.findall(r'(?<=INTO\s)\w+\.\w+', sql, flags=re.IGNORECASE)) 
+        input_tables = set(re.findall(r'(?<=FROM\s|JOIN\s)\w+\.\w+', sql, flags=re.IGNORECASE))
         check_tables = [t for t in input_tables if t not in output_tables]
 
         if not check_tables:


### PR DESCRIPTION
Some very minor cleanup of some code in viz_classes. Changes include:

1. Using raw strings to properly escape regex tokens. This silences some warnings.
2. Properly close the sql files that are opened
3. Use native set difference instead of manually computing it with a list comprehension.

ping: @shawncrawley 